### PR TITLE
feat: pallet-file-system clear storage requests up to current block `on_idle`

### DIFF
--- a/pallets/file-system/src/benchmarking.rs
+++ b/pallets/file-system/src/benchmarking.rs
@@ -21,6 +21,8 @@ benchmarks! {
     verify {
         assert!(FileSystem::<T>::storage_requests(location).is_some());
     }
+
+    // TODO: add benchmarking for `on_idle`
 }
 
 impl_benchmark_test_suite!(FileSystem, crate::mock::new_test_ext(), crate::mock::Test);

--- a/pallets/file-system/src/lib.rs
+++ b/pallets/file-system/src/lib.rs
@@ -134,7 +134,7 @@ pub mod pallet {
     /// storage request expiration will be inserted in the block `StorageRequestTtl` ahead, and then
     /// this value will be reset to block number a `current_block` + `StorageRequestTtl`.
     #[pallet::storage]
-    #[pallet::getter(fn current_expiration_block)]
+    #[pallet::getter(fn next_available_expiration_insertion_block)]
     pub type NextAvailableExpirationInsertionBlock<T: Config> =
         StorageValue<_, BlockNumberFor<T>, ValueQuery>;
 
@@ -172,7 +172,7 @@ pub mod pallet {
         /// Notifies the expiration of a storage request.
         StorageRequestExpired { location: FileLocation<T> },
 
-        /// Notifies that a storage request has been deleted.
+        /// Notifies that a storage request has been revoked by the user who initiated it.
         StorageRequestRevoked { location: FileLocation<T> },
     }
 

--- a/pallets/file-system/src/tests.rs
+++ b/pallets/file-system/src/tests.rs
@@ -121,7 +121,7 @@ fn request_storage_expiration_current_block_increment_success() {
 
         // Assert that the `CurrentExpirationBlock` storage is incremented by 1
         assert_eq!(
-            FileSystem::current_expiration_block(),
+            FileSystem::next_available_expiration_insertion_block(),
             expected_expiration_block_number
         );
 
@@ -179,7 +179,7 @@ fn request_storage_expiration_current_block_increment_when_on_idle_skips_success
 
         // Assert that the `CurrentExpirationBlock` storage is incremented by 1
         assert_eq!(
-            FileSystem::current_expiration_block(),
+            FileSystem::next_available_expiration_insertion_block(),
             expected_expiration_block_number
         );
 

--- a/pallets/file-system/src/utils.rs
+++ b/pallets/file-system/src/utils.rs
@@ -158,6 +158,8 @@ where
         // Remove storage request.
         <StorageRequests<T>>::remove(&location);
 
+        // TODO: initiate deletion request for SPs.
+
         Ok(())
     }
 


### PR DESCRIPTION
Refactored `on_idle` to manage clearing storage requests from old blocks up to the current block if any based on `NextStartingBlockToCleanUp`. 

Iterating over every old block number until we reach the current block while clearing all expired storage requests from `StorageRequestExpirations`. 

This iteration maintains the `total_used_weight` to avoid exceeding the `remaining_weight` for the current block. 