### PR TITLE
refactor: ♻️ `storage-proofs` -> `proofs-dealer-trie`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6698,6 +6698,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-proofs-dealer-trie"
+version = "0.1.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-trie",
+]
+
+[[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-v1.5.0#a3dc2f15f23b3fd25ada62917bfab169a01f2b0d"
@@ -6922,22 +6938,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-v1.5.0)",
-]
-
-[[package]]
-name = "pallet-storage-proofs"
-version = "0.1.0"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-trie",
 ]
 
 [[package]]
@@ -12420,8 +12420,8 @@ dependencies = [
  "pallet-collator-selection",
  "pallet-file-system",
  "pallet-message-queue",
+ "pallet-proofs-dealer-trie",
  "pallet-session",
- "pallet-storage-proofs",
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6698,7 +6698,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-proofs-dealer-trie"
+name = "pallet-proofs-dealer"
 version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
@@ -12420,7 +12420,7 @@ dependencies = [
  "pallet-collator-selection",
  "pallet-file-system",
  "pallet-message-queue",
- "pallet-proofs-dealer-trie",
+ "pallet-proofs-dealer",
  "pallet-session",
  "pallet-sudo",
  "pallet-timestamp",

--- a/pallets/storage-proofs/Cargo.toml
+++ b/pallets/storage-proofs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "pallet-storage-proofs"
-description = "Pallet for managing, challenging and veryfing storage proofs in StorageHub."
+name = "pallet-proofs-dealer-trie"
+description = "Pallet for managing, challenging and veryfing proofs submitted by providers, where each provider's information is stored as a Merkle Patricia Trie."
 version = "0.1.0"
 homepage = { workspace = true }
 license = { workspace = true }

--- a/pallets/storage-proofs/Cargo.toml
+++ b/pallets/storage-proofs/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pallet-proofs-dealer-trie"
+name = "pallet-proofs-dealer"
 description = "Pallet for managing, challenging and veryfing proofs submitted by providers, where each provider's information is stored as a Merkle Patricia Trie."
 version = "0.1.0"
 homepage = { workspace = true }

--- a/pallets/storage-proofs/src/lib.rs
+++ b/pallets/storage-proofs/src/lib.rs
@@ -399,9 +399,7 @@ pub trait ProvidersInterface {
     /// The type which represents a registered Provider.
     type Provider: Parameter + Member + MaybeSerializeDeserialize + Debug + Ord + MaxEncodedLen;
     /// The type corresponding to the staking balance of a registered Provider.
-    type Balance: fungible::Inspect<Self::AccountId>
-        + fungible::hold::Inspect<Self::AccountId>
-        + fungible::freeze::Inspect<Self::AccountId>;
+    type Balance: fungible::hold::Inspect<Self::AccountId>;
     /// The type corresponding to the root of a registered Provider.
     type MerkleHash: Parameter
         + Member

--- a/pallets/storage-proofs/src/lib.rs
+++ b/pallets/storage-proofs/src/lib.rs
@@ -59,13 +59,6 @@ pub mod pallet {
         /// To check if whoever submits a proof is a registered Storage Provider.
         type StorageProviders: crate::StorageProvidersInterface<AccountId = Self::AccountId>;
 
-        /// The File System pallet.
-        /// To check if the root submitted in a proof is valid for the Storage Provider.
-        type FileSystem: crate::FileSystemInterface<
-            StorageProvider = SpFor<Self>,
-            ForestRoot = ForestRootFor<Self>,
-        >;
-
         /// Type to access the Balances Pallet.
         type NativeBalance: fungible::Inspect<Self::AccountId>
             + fungible::hold::Inspect<Self::AccountId>
@@ -430,40 +423,6 @@ pub trait StorageProvidersInterface {
 
     /// Get the stake for a registered Storage Provider.
     fn get_stake(who: Self::StorageProvider) -> Self::Balance;
-}
-
-// TODO: Move this to File System pallet.
-/// A trait to lookup registered Storage Providers.
-///
-/// It is abstracted over the, `StorageProvider` type and `ForestRoot` type.
-pub trait FileSystemInterface {
-    /// The type which represents a registered user.
-    type StorageProvider: Parameter
-        + Member
-        + MaybeSerializeDeserialize
-        + Debug
-        + Ord
-        + MaxEncodedLen;
-
-    /// The type for a root of a Merkle Patricia Forest.
-    /// Generally a hash (the output of a Hasher).
-    type ForestRoot: Parameter
-        + Member
-        + MaybeSerializeDeserialize
-        + Debug
-        + MaybeDisplay
-        + SimpleBitOps
-        + Ord
-        + Default
-        + Copy
-        + CheckEqual
-        + AsRef<[u8]>
-        + AsMut<[u8]>
-        + MaxEncodedLen
-        + FullCodec;
-
-    /// Check if a Merkle Patricia Forest root hash belongs to a given Storage Provider.
-    fn is_valid_root_for_sp(who: Self::StorageProvider, root: Self::ForestRoot) -> bool;
 }
 
 // TODO: Move this to a primitives crate.

--- a/pallets/storage-proofs/src/lib.rs
+++ b/pallets/storage-proofs/src/lib.rs
@@ -428,7 +428,7 @@ pub trait ProvidersInterface {
     fn get_root(who: Self::Provider) -> Option<Self::MerkleHash>;
 
     /// Get the stake for a registered  Provider.
-    fn get_stake(who: Self::Provider) -> Self::Balance;
+    fn get_stake(who: Self::Provider) -> Option<Self::Balance>;
 }
 
 // TODO: Move this to a primitives crate.

--- a/pallets/storage-proofs/src/lib.rs
+++ b/pallets/storage-proofs/src/lib.rs
@@ -285,8 +285,8 @@ pub mod pallet {
             let provider = match provider {
                 Some(provider) => provider,
                 None => {
-                    let sp =
-                        T::ProvidersPallet::get_sp(who.clone()).ok_or(Error::<T>::NotProvider)?;
+                    let sp = T::ProvidersPallet::get_provider(who.clone())
+                        .ok_or(Error::<T>::NotProvider)?;
                     sp
                 }
             };
@@ -419,10 +419,10 @@ pub trait ProvidersInterface {
         + FullCodec;
 
     /// Check if an account is a registered Provider.
-    fn is_sp(who: Self::Provider) -> bool;
+    fn is_provider(who: Self::Provider) -> bool;
 
     // Get Provider from AccountId, if it is a registered Provider.
-    fn get_sp(who: Self::AccountId) -> Option<Self::Provider>;
+    fn get_provider(who: Self::AccountId) -> Option<Self::Provider>;
 
     /// Get the root for a registered Provider.
     fn get_root(who: Self::Provider) -> Option<Self::MerkleHash>;

--- a/pallets/storage-proofs/src/types.rs
+++ b/pallets/storage-proofs/src/types.rs
@@ -17,32 +17,32 @@ pub enum ProofRejectionReason {
 // ********************* Syntactic sugar for types ****************************
 // ****************************************************************************
 
-/// Syntactic sugar for the AccountId type used in the storage proofs pallet.
+/// Syntactic sugar for the AccountId type used in the proofs pallet.
 pub type AccountIdFor<T> = <T as frame_system::Config>::AccountId;
 
 /// The type for keys that identify a file within a Merkle Patricia Forest.
-/// Syntactic sugar for the MerkleHash type used in the storage proofs pallet.
+/// Syntactic sugar for the MerkleHash type used in the proofs pallet.
 pub type FileKeyFor<T> = <T as crate::Config>::MerkleHash;
 
 /// The type for a root of a Merkle Patricia Forest.
-/// Syntactic sugar for the MerkleHash type used in the storage proofs pallet.
+/// Syntactic sugar for the MerkleHash type used in the proofs pallet.
 pub type ForestRootFor<T> = <T as crate::Config>::MerkleHash;
 
-/// Syntactic sugar for the MaxChallengesPerBlock type used in the storage proofs pallet.
+/// Syntactic sugar for the MaxChallengesPerBlock type used in the proofs pallet.
 pub type MaxChallengesPerBlockFor<T> = <T as crate::Config>::MaxChallengesPerBlock;
 
-/// Syntactic sugar for the MaxSpsChallengedPerBlock type used in the storage proofs pallet.
-pub type MaxSpsChallengedPerBlockFor<T> = <T as crate::Config>::MaxSpsChallengedPerBlock;
+/// Syntactic sugar for the MaxSpsChallengedPerBlock type used in the proofs pallet.
+pub type MaxSpsChallengedPerBlockFor<T> = <T as crate::Config>::MaxProvidersChallengedPerBlock;
 
-/// Syntactic sugar for the ChallengesQueueLength type used in the storage proofs pallet.
+/// Syntactic sugar for the ChallengesQueueLength type used in the proofs pallet.
 pub type ChallengesQueueLengthFor<T> = <T as crate::Config>::ChallengesQueueLength;
 
-/// Syntactic sugar for the StorageProviders type used in the storage proofs pallet.
-pub type StorageProvidersFor<T> = <T as crate::Config>::StorageProviders;
+/// Syntactic sugar for the Providers type used in the proofs pallet.
+pub type ProvidersPalletFor<T> = <T as crate::Config>::ProvidersPallet;
 
-/// Syntactic sugar for the StorageProvider type used in the storage proofs pallet.
-pub type SpFor<T> =
-    <<T as crate::Config>::StorageProviders as crate::StorageProvidersInterface>::StorageProvider;
+/// Syntactic sugar for the Provider type used in the proofs pallet.
+pub type ProviderFor<T> =
+    <<T as crate::Config>::ProvidersPallet as crate::ProvidersInterface>::Provider;
 
 /// Syntactic sugar for the type of Balance used in the NativeBalances pallet.
 pub type BalanceFor<T> = <<T as crate::Config>::NativeBalance as fungible::Inspect<

--- a/pallets/storage-proofs/src/utils.rs
+++ b/pallets/storage-proofs/src/utils.rs
@@ -6,7 +6,7 @@ use sp_trie::CompactProof;
 
 use crate::{
     pallet,
-    types::{AccountIdFor, BalanceFor, FileKeyFor, ProvidersPalletFor},
+    types::{AccountIdFor, BalanceFor, FileKeyFor, ProviderFor, ProvidersPalletFor},
     ChallengesQueue, Error, Pallet, ProvidersInterface,
 };
 
@@ -36,7 +36,7 @@ where
 
     // TODO: Document and add proper parameters.
     #[allow(unused_variables)]
-    pub fn do_submit_proof(submitter: &AccountIdFor<T>, proof: &CompactProof) -> DispatchResult {
+    pub fn do_submit_proof(submitter: &ProviderFor<T>, proof: &CompactProof) -> DispatchResult {
         // Check if submitter is a registered Provider.
         ensure!(
             ProvidersPalletFor::<T>::is_sp(submitter.clone()),

--- a/pallets/storage-proofs/src/utils.rs
+++ b/pallets/storage-proofs/src/utils.rs
@@ -6,8 +6,8 @@ use sp_trie::CompactProof;
 
 use crate::{
     pallet,
-    types::{AccountIdFor, BalanceFor, FileKeyFor, StorageProvidersFor},
-    ChallengesQueue, Error, Pallet, StorageProvidersInterface,
+    types::{AccountIdFor, BalanceFor, FileKeyFor, ProvidersPalletFor},
+    ChallengesQueue, Error, Pallet, ProvidersInterface,
 };
 
 impl<T> Pallet<T>
@@ -37,10 +37,10 @@ where
     // TODO: Document and add proper parameters.
     #[allow(unused_variables)]
     pub fn do_submit_proof(submitter: &AccountIdFor<T>, proof: &CompactProof) -> DispatchResult {
-        // Check if submitter is a registered Storage Provider.
+        // Check if submitter is a registered Provider.
         ensure!(
-            StorageProvidersFor::<T>::is_sp(submitter.clone()),
-            Error::<T>::NotStorageProvider
+            ProvidersPalletFor::<T>::is_sp(submitter.clone()),
+            Error::<T>::NotProvider
         );
 
         // TODO

--- a/pallets/storage-proofs/src/utils.rs
+++ b/pallets/storage-proofs/src/utils.rs
@@ -39,7 +39,7 @@ where
     pub fn do_submit_proof(submitter: &ProviderFor<T>, proof: &CompactProof) -> DispatchResult {
         // Check if submitter is a registered Provider.
         ensure!(
-            ProvidersPalletFor::<T>::is_sp(submitter.clone()),
+            ProvidersPalletFor::<T>::is_provider(submitter.clone()),
             Error::<T>::NotProvider
         );
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -30,7 +30,7 @@ smallvec = "1.11.0"
 
 # Local
 pallet-file-system = { path = "../pallets/file-system", default-features = false }
-pallet-proofs-dealer-trie = { path = "../pallets/storage-proofs", default-features = false }
+pallet-proofs-dealer = { path = "../pallets/storage-proofs", default-features = false }
 
 # Substrate
 frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.5.0", default-features = false, optional = true }
@@ -112,7 +112,7 @@ std = [
     "pallet-file-system/std",
     "pallet-message-queue/std",
     "pallet-session/std",
-    "pallet-proofs-dealer-trie/std",
+    "pallet-proofs-dealer/std",
     "pallet-sudo/std",
     "pallet-timestamp/std",
     "pallet-transaction-payment-rpc-runtime-api/std",
@@ -157,7 +157,7 @@ runtime-benchmarks = [
     "pallet-collator-selection/runtime-benchmarks",
     "pallet-message-queue/runtime-benchmarks",
     "pallet-file-system/runtime-benchmarks",
-    "pallet-proofs-dealer-trie/runtime-benchmarks",
+    "pallet-proofs-dealer/runtime-benchmarks",
     "pallet-sudo/runtime-benchmarks",
     "pallet-timestamp/runtime-benchmarks",
     "pallet-xcm/runtime-benchmarks",
@@ -210,7 +210,7 @@ try-runtime = [
     "pallet-message-queue/try-runtime",
     "pallet-file-system/try-runtime",
     "pallet-session/try-runtime",
-    "pallet-proofs-dealer-trie/try-runtime",
+    "pallet-proofs-dealer/try-runtime",
     "pallet-sudo/try-runtime",
     "pallet-timestamp/try-runtime",
     "pallet-transaction-payment/try-runtime",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -30,7 +30,7 @@ smallvec = "1.11.0"
 
 # Local
 pallet-file-system = { path = "../pallets/file-system", default-features = false }
-pallet-storage-proofs = { path = "../pallets/storage-proofs", default-features = false }
+pallet-proofs-dealer-trie = { path = "../pallets/storage-proofs", default-features = false }
 
 # Substrate
 frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.5.0", default-features = false, optional = true }
@@ -112,7 +112,7 @@ std = [
     "pallet-file-system/std",
     "pallet-message-queue/std",
     "pallet-session/std",
-    "pallet-storage-proofs/std",
+    "pallet-proofs-dealer-trie/std",
     "pallet-sudo/std",
     "pallet-timestamp/std",
     "pallet-transaction-payment-rpc-runtime-api/std",
@@ -157,7 +157,7 @@ runtime-benchmarks = [
     "pallet-collator-selection/runtime-benchmarks",
     "pallet-message-queue/runtime-benchmarks",
     "pallet-file-system/runtime-benchmarks",
-    "pallet-storage-proofs/runtime-benchmarks",
+    "pallet-proofs-dealer-trie/runtime-benchmarks",
     "pallet-sudo/runtime-benchmarks",
     "pallet-timestamp/runtime-benchmarks",
     "pallet-xcm/runtime-benchmarks",
@@ -210,7 +210,7 @@ try-runtime = [
     "pallet-message-queue/try-runtime",
     "pallet-file-system/try-runtime",
     "pallet-session/try-runtime",
-    "pallet-storage-proofs/try-runtime",
+    "pallet-proofs-dealer-trie/try-runtime",
     "pallet-sudo/try-runtime",
     "pallet-timestamp/try-runtime",
     "pallet-transaction-payment/try-runtime",


### PR DESCRIPTION
This PR:
- Makes the old `storage-proofs` pallet be abstracted over the fact that the providers are storage providers (now they're just "Providers").
- Defines a trait to be implemented by another pallet, that would give it information of the Providers. This trait should be implemented by the Storage Providers pallet.