### PR TITLE
feat: ✨ implement `change_capacity` extrinsic on the `Providers` pallet

### DIFF
--- a/pallets/file-system/src/mock.rs
+++ b/pallets/file-system/src/mock.rs
@@ -144,6 +144,7 @@ impl pallet_storage_providers::Config for Test {
     type DepositPerData = ConstU128<2>;
     type Subscribers = FileSystem;
     type MaxBlocksForRandomness = ConstU64<{ EPOCH_DURATION_IN_BLOCKS * 2 }>;
+    type MinBlocksBetweenCapacityChanges = ConstU64<10>;
     type ProvidersRandomness = MockRandomness;
 }
 

--- a/pallets/proofs-dealer/src/mock.rs
+++ b/pallets/proofs-dealer/src/mock.rs
@@ -123,6 +123,7 @@ impl pallet_storage_providers::Config for Test {
     type DepositPerData = ConstU128<2>;
     type Subscribers = MockedProvidersSubscriber;
     type MaxBlocksForRandomness = ConstU64<{ EPOCH_DURATION_IN_BLOCKS * 2 }>;
+    type MinBlocksBetweenCapacityChanges = ConstU64<10>;
     type ProvidersRandomness = MockRandomness;
 }
 impl crate::Config for Test {

--- a/pallets/providers/src/lib.rs
+++ b/pallets/providers/src/lib.rs
@@ -278,7 +278,7 @@ pub mod pallet {
         /// that BSP's account id.
         BspSignOffSuccess { who: T::AccountId },
 
-        /// Event emitted when a SP has changed is total data (stake) successfully. Provides information about
+        /// Event emitted when a SP has changed its capacity successfully. Provides information about
         /// that SP's account id, its old total data that could store, and the new total data.
         CapacityChanged {
             who: T::AccountId,

--- a/pallets/providers/src/lib.rs
+++ b/pallets/providers/src/lib.rs
@@ -587,7 +587,7 @@ pub mod pallet {
         /// 	b. If the new deposit is less than the current deposit, return the held difference to the signer
         /// 7. Update the SPs storage to change the total data
         /// 8. If user is a BSP, update the total capacity of the network (sum of all capacities of BSPs)
-        /// 8. Emit an event confirming that the change of the capacity has been successful
+        /// 9. Emit an event confirming that the change of the capacity has been successful
         #[pallet::call_index(6)]
         #[pallet::weight(Weight::from_parts(10_000, 0) + T::DbWeight::get().writes(1))]
         pub fn change_capacity(

--- a/pallets/providers/src/lib.rs
+++ b/pallets/providers/src/lib.rs
@@ -156,6 +156,10 @@ pub mod pallet {
         /// The maximum amount of blocks after which a sign up request expires so the randomness cannot be chosen
         #[pallet::constant]
         type MaxBlocksForRandomness: Get<BlockNumberFor<Self>>;
+
+        /// The minimum amount of blocks between capacity changes for a SP
+        #[pallet::constant]
+        type MinBlocksBetweenCapacityChanges: Get<BlockNumberFor<Self>>;
     }
 
     #[pallet::pallet]
@@ -280,6 +284,7 @@ pub mod pallet {
             who: T::AccountId,
             old_capacity: StorageData<T>,
             new_capacity: StorageData<T>,
+            next_block_when_change_allowed: BlockNumberFor<T>,
         },
     }
 
@@ -376,6 +381,7 @@ pub mod pallet {
                 data_used: StorageData::<T>::default(),
                 multiaddresses: multiaddresses.clone(),
                 value_prop: value_prop.clone(),
+                last_capacity_change: frame_system::Pallet::<T>::block_number(),
             };
 
             // Sign up the new MSP (if possible), updating storage
@@ -422,6 +428,7 @@ pub mod pallet {
                 data_used: StorageData::<T>::default(),
                 multiaddresses: multiaddresses.clone(),
                 root: MerklePatriciaRoot::<T>::default(),
+                last_capacity_change: frame_system::Pallet::<T>::block_number(),
             };
 
             // Sign up the new BSP (if possible), updating storage
@@ -582,6 +589,8 @@ pub mod pallet {
                 who,
                 old_capacity,
                 new_capacity,
+                next_block_when_change_allowed: frame_system::Pallet::<T>::block_number()
+                    + T::MinBlocksBetweenCapacityChanges::get(),
             });
 
             // Return a successful DispatchResultWithPostInfo

--- a/pallets/providers/src/lib.rs
+++ b/pallets/providers/src/lib.rs
@@ -276,7 +276,7 @@ pub mod pallet {
 
         /// Event emitted when a SP has changed is total data (stake) successfully. Provides information about
         /// that SP's account id, its old total data that could store, and the new total data.
-        TotalDataChanged {
+        CapacityChanged {
             who: T::AccountId,
             old_capacity: StorageData<T>,
             new_capacity: StorageData<T>,
@@ -568,11 +568,23 @@ pub mod pallet {
         #[pallet::call_index(6)]
         #[pallet::weight(Weight::from_parts(10_000, 0) + T::DbWeight::get().writes(1))]
         pub fn change_capacity(
-            _origin: OriginFor<T>,
-            _new_capacity: StorageData<T>,
+            origin: OriginFor<T>,
+            new_capacity: StorageData<T>,
         ) -> DispatchResultWithPostInfo {
-            // TODO: design a way (with timelock probably) to allow a SP to change its stake
+            // Check that the extrinsic was signed and get the signer.
+            let who = ensure_signed(origin)?;
 
+            // Execute checks and logic, update storage
+            let old_capacity = Self::do_change_capacity(&who, new_capacity)?;
+
+            // Emit the corresponding event
+            Self::deposit_event(Event::<T>::CapacityChanged {
+                who,
+                old_capacity,
+                new_capacity,
+            });
+
+            // Return a successful DispatchResultWithPostInfo
             Ok(().into())
         }
 

--- a/pallets/providers/src/mock.rs
+++ b/pallets/providers/src/mock.rs
@@ -120,6 +120,7 @@ impl crate::Config for Test {
     type MaxMultiAddressAmount = ConstU32<5>;
     type MaxProtocols = ConstU32<100>;
     type MaxBlocksForRandomness = ConstU64<{ EPOCH_DURATION_IN_BLOCKS * 2 }>;
+    type MinBlocksBetweenCapacityChanges = ConstU64<10>;
     type MaxBsps = ConstU32<100>;
     type MaxMsps = ConstU32<100>;
     type MaxBuckets = ConstU32<10000>;

--- a/pallets/providers/src/tests.rs
+++ b/pallets/providers/src/tests.rs
@@ -123,6 +123,7 @@ mod sign_up {
                     );
 
                     // Check that Alice's request is in the requests list and matches the info provided
+                    let current_block = frame_system::Pallet::<Test>::block_number();
                     let alice_sign_up_request = StorageProviders::get_sign_up_request(&alice);
                     assert!(alice_sign_up_request.is_ok());
                     assert_eq!(
@@ -134,8 +135,9 @@ mod sign_up {
                                 data_used: 0,
                                 multiaddresses,
                                 value_prop,
+                                last_capacity_change: current_block,
                             }),
-                            frame_system::Pallet::<Test>::block_number()
+                            current_block
                         )
                     );
                 });
@@ -486,6 +488,7 @@ mod sign_up {
                     ));
 
                     // Check that Alice's request to sign up as a Main Storage Provider exists and is the one we just created
+                    let current_block = frame_system::Pallet::<Test>::block_number();
                     let alice_sign_up_request = StorageProviders::get_sign_up_request(&alice);
                     assert!(alice_sign_up_request.as_ref().is_ok_and(|request| request.0
                         == StorageProvider::MainStorageProvider(MainStorageProvider {
@@ -494,10 +497,9 @@ mod sign_up {
                             data_used: 0,
                             multiaddresses: multiaddresses.clone(),
                             value_prop: value_prop.clone(),
+                            last_capacity_change: current_block
                         })));
-                    assert!(alice_sign_up_request.is_ok_and(
-                        |request| request.1 == frame_system::Pallet::<Test>::block_number()
-                    ));
+                    assert!(alice_sign_up_request.is_ok_and(|request| request.1 == current_block));
 
                     // Cancel the sign up of Alice as a Main Storage Provider
                     assert_ok!(StorageProviders::cancel_sign_up(RuntimeOrigin::signed(
@@ -595,6 +597,7 @@ mod sign_up {
                     );
 
                     // Check that Alice's request is in the requests list and matches the info provided
+                    let current_block = frame_system::Pallet::<Test>::block_number();
                     let alice_sign_up_request = StorageProviders::get_sign_up_request(&alice);
                     assert!(alice_sign_up_request.is_ok());
                     assert_eq!(
@@ -605,8 +608,9 @@ mod sign_up {
                                 capacity: storage_amount,
                                 data_used: 0,
                                 multiaddresses,
+                                last_capacity_change: current_block,
                             }),
-                            frame_system::Pallet::<Test>::block_number()
+                            current_block
                         )
                     );
                 });
@@ -956,6 +960,7 @@ mod sign_up {
                     ));
 
                     // Check that Alice's request to sign up as a Backup Storage Provider exists and is the one we just created
+                    let current_block = frame_system::Pallet::<Test>::block_number();
                     let alice_sign_up_request = StorageProviders::get_sign_up_request(&alice);
                     assert!(alice_sign_up_request.as_ref().is_ok_and(|request| request.0
                         == StorageProvider::BackupStorageProvider(BackupStorageProvider {
@@ -963,10 +968,9 @@ mod sign_up {
                             data_used: 0,
                             multiaddresses: multiaddresses.clone(),
                             root: Default::default(),
+                            last_capacity_change: current_block
                         })));
-                    assert!(alice_sign_up_request.is_ok_and(
-                        |request| request.1 == frame_system::Pallet::<Test>::block_number()
-                    ));
+                    assert!(alice_sign_up_request.is_ok_and(|request| request.1 == current_block));
 
                     // Cancel the sign up of Alice as a Backup Storage Provider
                     assert_ok!(StorageProviders::cancel_sign_up(RuntimeOrigin::signed(
@@ -2978,6 +2982,7 @@ fn register_account_as_msp(
             data_used: 0,
             multiaddresses,
             value_prop,
+            last_capacity_change: frame_system::Pallet::<Test>::block_number(),
         },
     )
 }
@@ -3055,6 +3060,7 @@ fn register_account_as_bsp(
             data_used: 0,
             multiaddresses,
             root: Default::default(),
+            last_capacity_change: frame_system::Pallet::<Test>::block_number(),
         },
     )
 }

--- a/pallets/providers/src/tests.rs
+++ b/pallets/providers/src/tests.rs
@@ -3211,10 +3211,6 @@ mod change_capacity {
                 });
             }
         }
-        /// This module holds the success cases for changing the capacity of Main Storage Providers and Backup Storage Providers
-        mod msp_and_bsp {
-            use super::*;
-        }
     }
 
     /// This module holds the failure cases for changing the capacity of Main Storage Providers and Backup Storage Providers
@@ -3224,16 +3220,491 @@ mod change_capacity {
         /// This module holds the failure cases for changing the capacity of Main Storage Providers
         mod msp {
             use super::*;
+
+            #[test]
+            fn msp_change_capacity_fails_when_not_registered_as_msp() {
+                ExtBuilder::build().execute_with(|| {
+                    // Get the Account Id of Alice
+                    let alice: AccountId = 0;
+
+                    // Try to change the capacity of Alice as a Main Storage Provider
+                    assert_noop!(
+                        StorageProviders::change_capacity(RuntimeOrigin::signed(alice), 100),
+                        Error::<Test>::NotRegistered
+                    );
+                });
+            }
+
+            #[test]
+            fn msp_change_capacity_fails_if_not_enough_time_passed() {
+                ExtBuilder::build().execute_with(|| {
+                    // Register Alice as MSP:
+                    let alice: AccountId = 0;
+                    let old_storage_amount: StorageData<Test> = 100;
+                    let new_storage_amount: StorageData<Test> = 200;
+                    let (_old_deposit_amount, _alice_msp) =
+                        register_account_as_msp(alice, old_storage_amount);
+
+                    // Try to change the capacity of Alice before enough time has passed
+                    assert_noop!(
+                        StorageProviders::change_capacity(
+                            RuntimeOrigin::signed(alice),
+                            new_storage_amount
+                        ),
+                        Error::<Test>::NotEnoughTimePassed
+                    );
+
+                    // Make sure that the capacity of Alice has not changed
+                    assert_eq!(
+                        StorageProviders::get_total_capacity_of_sp(&alice).unwrap(),
+                        old_storage_amount
+                    );
+                });
+            }
+
+            #[test]
+            fn msp_change_capacity_fails_when_changing_to_zero() {
+                ExtBuilder::build().execute_with(|| {
+                    // Register Alice as MSP:
+                    let alice: AccountId = 0;
+                    let old_storage_amount: StorageData<Test> = 100;
+                    let zero_storage_amount: StorageData<Test> = 0;
+                    let (_old_deposit_amount, _alice_msp) =
+                        register_account_as_msp(alice, old_storage_amount);
+
+                    // Try to change the capacity of Alice to zero
+                    assert_noop!(
+                        StorageProviders::change_capacity(
+                            RuntimeOrigin::signed(alice),
+                            zero_storage_amount
+                        ),
+                        Error::<Test>::NewCapacityCantBeZero
+                    );
+
+                    // Make sure that the capacity of Alice has not changed
+                    assert_eq!(
+                        StorageProviders::get_total_capacity_of_sp(&alice).unwrap(),
+                        old_storage_amount
+                    );
+                });
+            }
+
+            #[test]
+            fn msp_change_capacity_fails_when_using_same_capacity() {
+                ExtBuilder::build().execute_with(|| {
+                    // Register Alice as MSP:
+                    let alice: AccountId = 0;
+                    let old_storage_amount: StorageData<Test> = 100;
+                    let new_storage_amount: StorageData<Test> = old_storage_amount;
+                    let (_old_deposit_amount, _alice_msp) =
+                        register_account_as_msp(alice, old_storage_amount);
+
+                    // Try to change the capacity of Alice to the same as before
+                    assert_noop!(
+                        StorageProviders::change_capacity(
+                            RuntimeOrigin::signed(alice),
+                            new_storage_amount
+                        ),
+                        Error::<Test>::NewCapacityEqualsCurrentCapacity
+                    );
+
+                    // Make sure that the capacity of Alice has not changed
+                    assert_eq!(
+                        StorageProviders::get_total_capacity_of_sp(&alice).unwrap(),
+                        old_storage_amount
+                    );
+                });
+            }
+
+            #[test]
+            fn msp_change_capacity_fails_when_under_min_capacity() {
+                ExtBuilder::build().execute_with(|| {
+                    // Register Alice as MSP:
+                    let alice: AccountId = 0;
+                    let old_storage_amount: StorageData<Test> = 100;
+                    let decreased_storage_amount: StorageData<Test> = 1;
+                    let (_old_deposit_amount, _alice_msp) =
+                        register_account_as_msp(alice, old_storage_amount);
+
+                    // Advance enough blocks to allow Alice to change her capacity
+                    run_to_block(
+                        frame_system::Pallet::<Test>::block_number()
+                            + <MinBlocksBetweenCapacityChanges as Get<BlockNumberFor<Test>>>::get(),
+                    );
+
+                    // Try to change the capacity of Alice to a value under the minimum capacity
+                    assert_noop!(
+                        StorageProviders::change_capacity(
+                            RuntimeOrigin::signed(alice),
+                            decreased_storage_amount
+                        ),
+                        Error::<Test>::StorageTooLow
+                    );
+
+                    // Make sure that the capacity of Alice has not changed
+                    assert_eq!(
+                        StorageProviders::get_total_capacity_of_sp(&alice).unwrap(),
+                        old_storage_amount
+                    );
+                });
+            }
+
+            #[test]
+            fn msp_change_capacity_fails_when_under_used_capacity() {
+                ExtBuilder::build().execute_with(|| {
+                    // Register Alice as MSP:
+                    let alice: AccountId = 0;
+                    let old_storage_amount: StorageData<Test> = 100;
+                    let decreased_storage_amount: StorageData<Test> = 50;
+                    let (_old_deposit_amount, _alice_msp) =
+                        register_account_as_msp(alice, old_storage_amount);
+
+                    // Change used storage to be more than the new capacity
+                    assert_ok!(
+                        <StorageProviders as MutateProvidersInterface>::increase_data_used(
+                            &alice, 60
+                        )
+                    );
+
+                    // Advance enough blocks to allow Alice to change her capacity
+                    run_to_block(
+                        frame_system::Pallet::<Test>::block_number()
+                            + <MinBlocksBetweenCapacityChanges as Get<BlockNumberFor<Test>>>::get(),
+                    );
+
+                    // Try to change the capacity of Alice to a value under the used storage
+                    assert_noop!(
+                        StorageProviders::change_capacity(
+                            RuntimeOrigin::signed(alice),
+                            decreased_storage_amount
+                        ),
+                        Error::<Test>::NewCapacityLessThanUsedStorage
+                    );
+
+                    // Make sure that the capacity of Alice has not changed
+                    assert_eq!(
+                        StorageProviders::get_total_capacity_of_sp(&alice).unwrap(),
+                        old_storage_amount
+                    );
+                });
+            }
+
+            #[test]
+            fn msp_change_capacity_fails_when_not_enough_funds() {
+                ExtBuilder::build().execute_with(|| {
+                    // Register Alice as MSP:
+                    let alice: AccountId = 0;
+                    let old_storage_amount: StorageData<Test> = 100;
+                    let new_storage_amount: StorageData<Test> =
+                        (5_000_000 / <DepositPerData as Get<u128>>::get() + 1)
+                            .try_into()
+                            .unwrap();
+                    let (_old_deposit_amount, _alice_msp) =
+                        register_account_as_msp(alice, old_storage_amount);
+
+                    // Advance enough blocks to allow Alice to change her capacity
+                    run_to_block(
+                        frame_system::Pallet::<Test>::block_number()
+                            + <MinBlocksBetweenCapacityChanges as Get<BlockNumberFor<Test>>>::get(),
+                    );
+
+                    // Try to change the capacity of Alice to a value under the used storage
+                    assert_noop!(
+                        StorageProviders::change_capacity(
+                            RuntimeOrigin::signed(alice),
+                            new_storage_amount
+                        ),
+                        Error::<Test>::NotEnoughBalance
+                    );
+
+                    // Make sure that the capacity of Alice has not changed
+                    assert_eq!(
+                        StorageProviders::get_total_capacity_of_sp(&alice).unwrap(),
+                        old_storage_amount
+                    );
+                });
+            }
         }
 
         /// This module holds the failure cases for changing the capacity of Backup Storage Providers
         mod bsp {
             use super::*;
-        }
 
-        /// This module holds the failure cases for changing the capacity of Main Storage Providers and Backup Storage Providers
-        mod msp_and_bsp {
-            use super::*;
+            #[test]
+            fn bsp_change_capacity_fails_when_not_registered_as_bsp() {
+                ExtBuilder::build().execute_with(|| {
+                    // Get the Account Id of Alice
+                    let alice: AccountId = 0;
+
+                    // Try to change the capacity of Alice as a Backup Storage Provider
+                    assert_noop!(
+                        StorageProviders::change_capacity(RuntimeOrigin::signed(alice), 100),
+                        Error::<Test>::NotRegistered
+                    );
+                });
+            }
+
+            #[test]
+            fn bsp_change_capacity_fails_if_not_enough_time_passed() {
+                ExtBuilder::build().execute_with(|| {
+                    // Register Alice as BSP:
+                    let alice: AccountId = 0;
+                    let old_storage_amount: StorageData<Test> = 100;
+                    let new_storage_amount: StorageData<Test> = 200;
+                    let (_old_deposit_amount, _alice_bsp) =
+                        register_account_as_bsp(alice, old_storage_amount);
+
+                    // Check the total capacity of the network (BSPs)
+                    assert_eq!(
+                        StorageProviders::get_total_bsp_capacity(),
+                        old_storage_amount
+                    );
+
+                    // Try to change the capacity of Alice before enough time has passed
+                    assert_noop!(
+                        StorageProviders::change_capacity(
+                            RuntimeOrigin::signed(alice),
+                            new_storage_amount
+                        ),
+                        Error::<Test>::NotEnoughTimePassed
+                    );
+
+                    // Make sure that the capacity of Alice has not changed
+                    assert_eq!(
+                        StorageProviders::get_total_capacity_of_sp(&alice).unwrap(),
+                        old_storage_amount
+                    );
+
+                    // Make sure that the total capacity of the network has not changed
+                    assert_eq!(
+                        StorageProviders::get_total_bsp_capacity(),
+                        old_storage_amount
+                    );
+                });
+            }
+
+            #[test]
+            fn bsp_change_capacity_fails_when_changing_to_zero() {
+                ExtBuilder::build().execute_with(|| {
+                    // Register Alice as BSP:
+                    let alice: AccountId = 0;
+                    let old_storage_amount: StorageData<Test> = 100;
+                    let zero_storage_amount: StorageData<Test> = 0;
+                    let (_old_deposit_amount, _alice_bsp) =
+                        register_account_as_bsp(alice, old_storage_amount);
+
+                    // Check the total capacity of the network (BSPs)
+                    assert_eq!(
+                        StorageProviders::get_total_bsp_capacity(),
+                        old_storage_amount
+                    );
+
+                    // Try to change the capacity of Alice to zero
+                    assert_noop!(
+                        StorageProviders::change_capacity(
+                            RuntimeOrigin::signed(alice),
+                            zero_storage_amount
+                        ),
+                        Error::<Test>::NewCapacityCantBeZero
+                    );
+
+                    // Make sure that the capacity of Alice has not changed
+                    assert_eq!(
+                        StorageProviders::get_total_capacity_of_sp(&alice).unwrap(),
+                        old_storage_amount
+                    );
+
+                    // Make sure that the total capacity of the network has not changed
+                    assert_eq!(
+                        StorageProviders::get_total_bsp_capacity(),
+                        old_storage_amount
+                    );
+                });
+            }
+
+            #[test]
+            fn bsp_change_capacity_fails_when_using_same_capacity() {
+                ExtBuilder::build().execute_with(|| {
+                    // Register Alice as BSP:
+                    let alice: AccountId = 0;
+                    let old_storage_amount: StorageData<Test> = 100;
+                    let new_storage_amount: StorageData<Test> = old_storage_amount;
+                    let (_old_deposit_amount, _alice_bsp) =
+                        register_account_as_bsp(alice, old_storage_amount);
+
+                    // Check the total capacity of the network (BSPs)
+                    assert_eq!(
+                        StorageProviders::get_total_bsp_capacity(),
+                        old_storage_amount
+                    );
+
+                    // Try to change the capacity of Alice to the same as before
+                    assert_noop!(
+                        StorageProviders::change_capacity(
+                            RuntimeOrigin::signed(alice),
+                            new_storage_amount
+                        ),
+                        Error::<Test>::NewCapacityEqualsCurrentCapacity
+                    );
+
+                    // Make sure that the capacity of Alice has not changed
+                    assert_eq!(
+                        StorageProviders::get_total_capacity_of_sp(&alice).unwrap(),
+                        old_storage_amount
+                    );
+
+                    // Make sure that the total capacity of the network has not changed
+                    assert_eq!(
+                        StorageProviders::get_total_bsp_capacity(),
+                        old_storage_amount
+                    );
+                });
+            }
+
+            #[test]
+            fn bsp_change_capacity_fails_when_under_min_capacity() {
+                ExtBuilder::build().execute_with(|| {
+                    // Register Alice as BSP:
+                    let alice: AccountId = 0;
+                    let old_storage_amount: StorageData<Test> = 100;
+                    let decreased_storage_amount: StorageData<Test> = 1;
+                    let (_old_deposit_amount, _alice_bsp) =
+                        register_account_as_bsp(alice, old_storage_amount);
+
+                    // Check the total capacity of the network (BSPs)
+                    assert_eq!(
+                        StorageProviders::get_total_bsp_capacity(),
+                        old_storage_amount
+                    );
+
+                    // Advance enough blocks to allow Alice to change her capacity
+                    run_to_block(
+                        frame_system::Pallet::<Test>::block_number()
+                            + <MinBlocksBetweenCapacityChanges as Get<BlockNumberFor<Test>>>::get(),
+                    );
+
+                    // Try to change the capacity of Alice to a value under the minimum capacity
+                    assert_noop!(
+                        StorageProviders::change_capacity(
+                            RuntimeOrigin::signed(alice),
+                            decreased_storage_amount
+                        ),
+                        Error::<Test>::StorageTooLow
+                    );
+
+                    // Make sure that the capacity of Alice has not changed
+                    assert_eq!(
+                        StorageProviders::get_total_capacity_of_sp(&alice).unwrap(),
+                        old_storage_amount
+                    );
+
+                    // Make sure that the total capacity of the network has not changed
+                    assert_eq!(
+                        StorageProviders::get_total_bsp_capacity(),
+                        old_storage_amount
+                    );
+                });
+            }
+
+            #[test]
+            fn bsp_change_capacity_fails_when_under_used_capacity() {
+                ExtBuilder::build().execute_with(|| {
+                    // Register Alice as BSP:
+                    let alice: AccountId = 0;
+                    let old_storage_amount: StorageData<Test> = 100;
+                    let decreased_storage_amount: StorageData<Test> = 50;
+                    let (_old_deposit_amount, _alice_bsp) =
+                        register_account_as_bsp(alice, old_storage_amount);
+
+                    // Check the total capacity of the network (BSPs)
+                    assert_eq!(
+                        StorageProviders::get_total_bsp_capacity(),
+                        old_storage_amount
+                    );
+
+                    // Change used storage to be more than the new capacity
+                    assert_ok!(
+                        <StorageProviders as MutateProvidersInterface>::increase_data_used(
+                            &alice, 60
+                        )
+                    );
+
+                    // Advance enough blocks to allow Alice to change her capacity
+                    run_to_block(
+                        frame_system::Pallet::<Test>::block_number()
+                            + <MinBlocksBetweenCapacityChanges as Get<BlockNumberFor<Test>>>::get(),
+                    );
+
+                    // Try to change the capacity of Alice to a value under the used storage
+                    assert_noop!(
+                        StorageProviders::change_capacity(
+                            RuntimeOrigin::signed(alice),
+                            decreased_storage_amount
+                        ),
+                        Error::<Test>::NewCapacityLessThanUsedStorage
+                    );
+
+                    // Make sure that the capacity of Alice has not changed
+                    assert_eq!(
+                        StorageProviders::get_total_capacity_of_sp(&alice).unwrap(),
+                        old_storage_amount
+                    );
+
+                    // Make sure that the total capacity of the network has not changed
+                    assert_eq!(
+                        StorageProviders::get_total_bsp_capacity(),
+                        old_storage_amount
+                    );
+                });
+            }
+
+            #[test]
+            fn bsp_change_capacity_fails_when_not_enough_funds() {
+                ExtBuilder::build().execute_with(|| {
+                    // Register Alice as MSP:
+                    let alice: AccountId = 0;
+                    let old_storage_amount: StorageData<Test> = 100;
+                    let new_storage_amount: StorageData<Test> =
+                        (5_000_000 / <DepositPerData as Get<u128>>::get() + 1)
+                            .try_into()
+                            .unwrap();
+                    let (_old_deposit_amount, _alice_bsp) =
+                        register_account_as_bsp(alice, old_storage_amount);
+
+                    // Check the total capacity of the network (BSPs)
+                    assert_eq!(
+                        StorageProviders::get_total_bsp_capacity(),
+                        old_storage_amount
+                    );
+
+                    // Advance enough blocks to allow Alice to change her capacity
+                    run_to_block(
+                        frame_system::Pallet::<Test>::block_number()
+                            + <MinBlocksBetweenCapacityChanges as Get<BlockNumberFor<Test>>>::get(),
+                    );
+
+                    // Try to change the capacity of Alice to a value under the used storage
+                    assert_noop!(
+                        StorageProviders::change_capacity(
+                            RuntimeOrigin::signed(alice),
+                            new_storage_amount
+                        ),
+                        Error::<Test>::NotEnoughBalance
+                    );
+
+                    // Make sure that the capacity of Alice has not changed
+                    assert_eq!(
+                        StorageProviders::get_total_capacity_of_sp(&alice).unwrap(),
+                        old_storage_amount
+                    );
+
+                    // Make sure that the total capacity of the network has not changed
+                    assert_eq!(
+                        StorageProviders::get_total_bsp_capacity(),
+                        old_storage_amount
+                    );
+                });
+            }
         }
     }
 }

--- a/pallets/providers/src/types.rs
+++ b/pallets/providers/src/types.rs
@@ -2,6 +2,7 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::pallet_prelude::*;
 use frame_support::traits::fungible::Inspect;
 use frame_support::BoundedVec;
+use frame_system::pallet_prelude::BlockNumberFor;
 use scale_info::TypeInfo;
 
 use crate::Config;
@@ -41,6 +42,7 @@ pub struct MainStorageProvider<T: Config> {
     pub data_used: StorageData<T>,
     pub multiaddresses: BoundedVec<MultiAddress<T>, MaxMultiAddressAmount<T>>,
     pub value_prop: ValueProposition<T>,
+    pub last_capacity_change: BlockNumberFor<T>,
 }
 
 /// Structure that represents a Backup Storage Provider. It holds the total data that the BSP is able to store, the amount of data that it is storing,
@@ -52,6 +54,7 @@ pub struct BackupStorageProvider<T: Config> {
     pub data_used: StorageData<T>,
     pub multiaddresses: BoundedVec<MultiAddress<T>, MaxMultiAddressAmount<T>>,
     pub root: MerklePatriciaRoot<T>,
+    pub last_capacity_change: BlockNumberFor<T>,
 }
 
 /// Structure that represents a Bucket. It holds the root of the Merkle Patricia Trie, the User ID that owns the bucket,

--- a/pallets/providers/src/utils.rs
+++ b/pallets/providers/src/utils.rs
@@ -498,15 +498,6 @@ where
 
         Ok(())
     }
-
-    /// Remove a root from a BSP. It will remove the whole BSP from storage, so it should only be called when the BSP is being removed.
-    pub fn remove_root_bsp(who: &<T>::AccountId) -> DispatchResult {
-        let bsp_id =
-            AccountIdToBackupStorageProviderId::<T>::get(who).ok_or(Error::<T>::NotRegistered)?;
-        BackupStorageProviders::<T>::remove(&bsp_id);
-        AccountIdToBackupStorageProviderId::<T>::remove(&who);
-        Ok(())
-    }
 }
 
 impl<T: Config> From<MainStorageProvider<T>> for BackupStorageProvider<T> {

--- a/pallets/providers/src/utils.rs
+++ b/pallets/providers/src/utils.rs
@@ -563,6 +563,7 @@ impl<T: Config> From<MainStorageProvider<T>> for BackupStorageProvider<T> {
             data_used: msp.data_used,
             multiaddresses: msp.multiaddresses,
             root: MerklePatriciaRoot::<T>::default(),
+            last_capacity_change: msp.last_capacity_change,
         }
     }
 }

--- a/pallets/providers/src/utils.rs
+++ b/pallets/providers/src/utils.rs
@@ -404,6 +404,9 @@ where
         Ok(())
     }
 
+    /// This function holds the logic that checks if a user can sign off as a Main Storage Provider
+    /// and, if so, updates the storage to remove the user as a Main Storage Provider, decrements the counter of Main Storage Providers,
+    /// and returns the deposit to the user
     pub fn do_msp_sign_off(who: &T::AccountId) -> DispatchResult {
         // Check that the signer is registered as a MSP and get its info
         let msp_id =
@@ -447,6 +450,9 @@ where
         Ok(())
     }
 
+    /// This function holds the logic that checks if a user can sign off as a Backup Storage Provider
+    /// and, if so, updates the storage to remove the user as a Backup Storage Provider, decrements the counter of Backup Storage Providers,
+    /// decrements the total capacity of the network (which is the sum of all BSPs capacities), and returns the deposit to the user
     pub fn do_bsp_sign_off(who: &T::AccountId) -> DispatchResult {
         // Check that the signer is registered as a BSP and get its info
         let bsp_id =
@@ -499,11 +505,14 @@ where
         Ok(())
     }
 
-    // TODO: design a way (with timelock probably) to allow a SP to change its stake
+    /// This function is in charge of dispatching the logic to change the capacity of a Storage Provider
+    /// It checks if the signer is registered as a SP and dispatches the corresponding function
+    /// that checks if the user can change its capacity and, if so, updates the storage to reflect the new capacity
     pub fn do_change_capacity(
         who: &T::AccountId,
         new_capacity: StorageData<T>,
     ) -> Result<StorageData<T>, DispatchError> {
+        // TODO: design a way (with timelock probably) to allow a SP to change its stake
         // Check that the signer is registered as a SP and dispatch the corresponding function, getting its old capacity
         let old_capacity = if let Some(msp_id) = AccountIdToMainStorageProviderId::<T>::get(who) {
             Self::do_change_capacity_msp(msp_id, new_capacity)?
@@ -516,6 +525,9 @@ where
         Ok(old_capacity)
     }
 
+    /// This function holds the logic that checks if a user can change its capacity as a Main Storage Provider
+    /// and, if so, updates the storage to reflect the new capacity, modifying the user's deposit accordingly
+    /// and returning the old capacity if successful
     pub fn do_change_capacity_msp(
         who: MainStorageProviderId<T>,
         new_capacity: StorageData<T>,
@@ -528,6 +540,9 @@ where
         Ok(old_capacity)
     }
 
+    /// This function holds the logic that checks if a user can change its capacity as a Backup Storage Provider
+    /// and, if so, updates the storage to reflect the new capacity, modifying the user's deposit accordingly
+    /// and returning the old capacity if successful
     pub fn do_change_capacity_bsp(
         who: BackupStorageProviderId<T>,
         new_capacity: StorageData<T>,

--- a/pallets/providers/src/utils.rs
+++ b/pallets/providers/src/utils.rs
@@ -541,7 +541,7 @@ where
         // Check that the MSP is registered and get its info
         let mut msp = MainStorageProviders::<T>::get(&msp_id).ok_or(Error::<T>::NotRegistered)?;
 
-        // Check that the new capacity is diferent from the current capacity
+        // Check that the new capacity is different from the current capacity
         ensure!(
             new_capacity != msp.capacity,
             Error::<T>::NewCapacityEqualsCurrentCapacity
@@ -577,7 +577,7 @@ where
             .checked_add(&deposit_for_capacity_over_minimum)
             .ok_or(DispatchError::Arithmetic(ArithmeticError::Overflow))?;
 
-        // Check how much has the used already deposited for the current capacity
+        // Check how much has the MSP already deposited for the current capacity
         let current_deposit = T::NativeBalance::balance_on_hold(
             &HoldReason::StorageProviderDeposit.into(),
             account_id,
@@ -617,7 +617,7 @@ where
         // Check that the BSP is registered and get its info
         let mut bsp = BackupStorageProviders::<T>::get(&bsp_id).ok_or(Error::<T>::NotRegistered)?;
 
-        // Check that the new capacity is diferent from the current capacity
+        // Check that the new capacity is different from the current capacity
         ensure!(
             new_capacity != bsp.capacity,
             Error::<T>::NewCapacityEqualsCurrentCapacity

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -357,6 +357,7 @@ impl pallet_storage_providers::Config for Runtime {
     type Subscribers = FileSystem;
     type ProvidersRandomness = MockRandomness;
     type MaxBlocksForRandomness = ConstU32<{ 2 * EPOCH_DURATION_IN_BLOCKS }>;
+    type MinBlocksBetweenCapacityChanges = ConstU32<10>;
 }
 
 // TODO: remove this and replace with pallet treasury


### PR DESCRIPTION
In this PR we:
- Organize the errors of the `Providers` pallet to keep them tidy
- Implement the `change_capacity` extrinsic to allow SPs to change their "contracted" capacity
- Refactor the Main Storage Provider and Backup Storage Provider structures to add a timestamp of the last block where the capacity was changed, to use for the timelock of `change_capacity`
- Add errors for the `change_capacity` extrinsic
- Improved documentation for the functions of the `Providers` pallet
- Add success and failure tests for new functionality