### PR TITLE
ci: :sparkles: Add rust-test ci

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -31,6 +31,8 @@ jobs:
       - uses: rui314/setup-mold@v1
       - name: Install nextest
         uses: taiki-e/install-action@nextest
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
       - name: Build and archive tests
         run: cargo nextest archive --archive-file nextest-archive.tar.zst
       - name: Upload archive to workflow

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.4
       - uses: rui314/setup-mold@v1
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
       - name: Build and archive tests
         run: cargo nextest archive --archive-file nextest-archive.tar.zst
       - name: Upload archive to workflow

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -22,10 +22,9 @@ jobs:
           # By default actions/checkout checks out a merge commit. Check out the PR head instead.
           # https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.8
         with:
-          toolchain: stable
-          override: true
+          cache: false
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.4
       - uses: rui314/setup-mold@v1

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -61,6 +61,5 @@ jobs:
       - name: Run Tests for All Projects!
         run: |
           ~/.cargo/bin/cargo-nextest nextest run \
-            --workspace \
             --archive-file nextest-archive.tar.zst \
             --partition count:${{ matrix.partition }}/2

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -61,6 +61,6 @@ jobs:
       - name: Run Tests for All Projects!
         run: |
           ~/.cargo/bin/cargo-nextest nextest run \
+            --workspace \
             --archive-file nextest-archive.tar.zst \
-            ## If partitions change remember to update v divisor here 
             --partition count:${{ matrix.partition }}/2

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -28,6 +28,8 @@ jobs:
           cache: false
       - uses: rui314/setup-mold@v1
       - uses: taiki-e/install-action@nextest
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
       - name: Run Tests for All Projects!
         run: |
           cargo nextest run

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -1,3 +1,11 @@
+# Rust Tests: CI for Rust components (Blockchain & Storage Providers)
+#
+# Overview:
+# 1. Prepare: This job handles the setup phase where the cargo nextest archive is created
+#    and uploaded to the workflow for use in the subsequent jobs
+# 2. All Rust Tests: Executes the full suite of Rust tests across two partitions to
+#    to reduce total execution time.
+
 name: Rust Tests
 
 on:

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -1,0 +1,33 @@
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - perm-*
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: set to pull_request number to execute on external pr
+        required: false
+
+jobs:
+  all-rust-tests:
+    name: "Run all Rust tests"
+    runs-on: ubuntu-latest
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+      CARGO_INCREMENTAL: "0"
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.8
+        with:
+          cache: false
+      - uses: rui314/setup-mold@v1
+      - uses: taiki-e/install-action@nextest
+      - name: Run Tests for All Projects!
+        run: |
+          cargo nextest run

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -1,18 +1,15 @@
+name: Rust Tests
+
 on:
   pull_request:
   push:
     branches:
       - main
-      - perm-*
   workflow_dispatch:
-    inputs:
-      pull_request:
-        description: set to pull_request number to execute on external pr
-        required: false
 
 jobs:
-  all-rust-tests:
-    name: "Run all Rust tests"
+  prepare:
+    name: Prepare artifacts
     runs-on: ubuntu-latest
     env:
       SCCACHE_GHA_ENABLED: "true"
@@ -21,15 +18,46 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v4
+        with:
+          # By default actions/checkout checks out a merge commit. Check out the PR head instead.
+          # https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1.8
-        with:
-          cache: false
       - uses: rui314/setup-mold@v1
-      - uses: taiki-e/install-action@nextest
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+      - name: Build and archive tests
+        run: cargo nextest archive --archive-file nextest-archive.tar.zst
+      - name: Upload archive to workflow
+        uses: actions/upload-artifact@v4
+        with:
+          name: nextest-archive
+          path: nextest-archive.tar.zst
+
+  all-rust-tests:
+    name: Run all tests (/w partitioning)
+    runs-on: ubuntu-latest
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [1, 2]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+      - name: Download archive
+        uses: actions/download-artifact@v4
+        with:
+          name: nextest-archive
       - name: Run Tests for All Projects!
         run: |
-          cargo nextest run
+          ~/.cargo/bin/cargo-nextest nextest run \
+            --archive-file nextest-archive.tar.zst \
+            ## If partitions change remember to update v divisor here 
+            --partition count:${{ matrix.partition }}/2


### PR DESCRIPTION
Added new CI for our rust tests.

- Uses `nextest` because it's just better than `cargo test`
- Uses archive and partitions so that it runs across multiple runners
- Is very slow, but that's unsurprising considering the specs of GHA basic tier runners