### PR TITLE
feat: ✨ add payment accounts to SPs to receive payment from streams

### DIFF
--- a/pallets/file-system/src/lib.rs
+++ b/pallets/file-system/src/lib.rs
@@ -67,12 +67,12 @@ pub mod pallet {
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
         /// The trait for reading and mutating storage provider data.
-        type Providers: storage_hub_traits::ReadProvidersInterface<AccountId = Self::AccountId, Provider = <Self::Providers as storage_hub_traits::MutateProvidersInterface>::Provider>
+        type Providers: storage_hub_traits::ReadProvidersInterface<AccountId = Self::AccountId, ProviderId = <Self::Providers as storage_hub_traits::MutateProvidersInterface>::ProviderId>
             + storage_hub_traits::MutateProvidersInterface<AccountId = Self::AccountId, MerklePatriciaRoot = <Self::ProofDealer as storage_hub_traits::ProofsDealerInterface>::MerkleHash>;
 
         /// The trait for issuing challenges and verifying proofs.
         type ProofDealer: storage_hub_traits::ProofsDealerInterface<
-            Provider = <Self::Providers as storage_hub_traits::ProvidersInterface>::Provider,
+            ProviderId = <Self::Providers as storage_hub_traits::ProvidersInterface>::ProviderId,
         >;
 
         /// Type for identifying a file, generally a hash.

--- a/pallets/file-system/src/tests.rs
+++ b/pallets/file-system/src/tests.rs
@@ -7,7 +7,10 @@ use crate::{
     Config, Error, Event, StorageRequestExpirations,
 };
 use frame_support::{
-    assert_noop, assert_ok, dispatch::DispatchResultWithPostInfo, traits::Hooks, weights::Weight,
+    assert_noop, assert_ok,
+    dispatch::DispatchResultWithPostInfo,
+    traits::{Hooks, OriginTrait},
+    weights::Weight,
 };
 use sp_core::H256;
 use sp_runtime::{
@@ -1138,6 +1141,7 @@ fn bsp_sign_up(
         bsp_signed.clone(),
         storage_amount,
         multiaddresses,
+        bsp_signed.clone().into_signer().unwrap()
     ));
 
     // Advance enough blocks for randomness to be valid

--- a/pallets/file-system/src/utils.rs
+++ b/pallets/file-system/src/utils.rs
@@ -153,7 +153,7 @@ where
         fingerprint: Fingerprint<T>,
     ) -> Result<(MultiAddresses<T>, StorageData<T>, T::AccountId), DispatchError> {
         let bsp =
-            <T::Providers as storage_hub_traits::ProvidersInterface>::get_provider(who.clone())
+            <T::Providers as storage_hub_traits::ProvidersInterface>::get_provider_id(who.clone())
                 .ok_or(Error::<T>::NotABsp)?;
 
         // Check that the provider is indeed a BSP.
@@ -262,7 +262,7 @@ where
         proof: Proof<T>,
     ) -> DispatchResult {
         let bsp =
-            <T::Providers as storage_hub_traits::ProvidersInterface>::get_provider(who.clone())
+            <T::Providers as storage_hub_traits::ProvidersInterface>::get_provider_id(who.clone())
                 .ok_or(Error::<T>::NotABsp)?;
 
         // Check that the provider is indeed a BSP.
@@ -583,9 +583,9 @@ where
 }
 
 impl<T: crate::Config> storage_hub_traits::SubscribeProvidersInterface for Pallet<T> {
-    type Provider = T::AccountId;
+    type ProviderId = T::AccountId;
 
-    fn subscribe_bsp_sign_up(_who: &Self::Provider) -> DispatchResult {
+    fn subscribe_bsp_sign_up(_who: &Self::ProviderId) -> DispatchResult {
         // Adjust bsp assignment threshold by applying the decay function after removing the asymptote
         let mut bsp_assignment_threshold = BspsAssignmentThreshold::<T>::get();
         let base_threshold =
@@ -601,7 +601,7 @@ impl<T: crate::Config> storage_hub_traits::SubscribeProvidersInterface for Palle
         Ok(())
     }
 
-    fn subscribe_bsp_sign_off(_who: &Self::Provider) -> DispatchResult {
+    fn subscribe_bsp_sign_off(_who: &Self::ProviderId) -> DispatchResult {
         // Adjust bsp assignment threshold by applying the inverse of the decay function after removing the asymptote
         let mut bsp_assignment_threshold = BspsAssignmentThreshold::<T>::get();
         let base_threshold =

--- a/pallets/payment-streams/src/mock.rs
+++ b/pallets/payment-streams/src/mock.rs
@@ -143,7 +143,7 @@ impl Convert<BlockNumberFor<Test>, Balance> for BlockNumberToBalance {
 impl crate::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type NativeBalance = Balances;
-    type Providers = StorageProviders;
+    type ProvidersPallet = StorageProviders;
     type RuntimeHoldReason = RuntimeHoldReason;
     type NewUserDeposit = ConstU128<10>;
     type BlockNumberToBalance = BlockNumberToBalance;
@@ -186,12 +186,12 @@ impl ExtBuilder {
 
 pub struct MockedProvidersSubscriber;
 impl SubscribeProvidersInterface for MockedProvidersSubscriber {
-    type Provider = u64;
+    type ProviderId = u64;
 
-    fn subscribe_bsp_sign_up(_who: &Self::Provider) -> DispatchResult {
+    fn subscribe_bsp_sign_up(_who: &Self::ProviderId) -> DispatchResult {
         Ok(())
     }
-    fn subscribe_bsp_sign_off(_who: &Self::Provider) -> DispatchResult {
+    fn subscribe_bsp_sign_off(_who: &Self::ProviderId) -> DispatchResult {
         Ok(())
     }
 }

--- a/pallets/payment-streams/src/tests.rs
+++ b/pallets/payment-streams/src/tests.rs
@@ -1487,6 +1487,7 @@ fn register_account_as_bsp(account: AccountId, storage_amount: StorageData<Test>
         RuntimeOrigin::signed(account),
         storage_amount,
         multiaddresses.clone(),
+        account
     ));
 
     // Advance enough blocks for randomness to be valid

--- a/pallets/payment-streams/src/types.rs
+++ b/pallets/payment-streams/src/types.rs
@@ -6,6 +6,7 @@ use frame_support::pallet_prelude::*;
 use frame_support::traits::fungible::Inspect;
 use frame_system::pallet_prelude::BlockNumberFor;
 use scale_info::TypeInfo;
+use storage_hub_traits::ProvidersInterface;
 
 /// Structure that has the payment stream information
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, RuntimeDebugNoBound, PartialEq, Eq, Clone)]
@@ -23,5 +24,6 @@ pub struct PaymentStream<T: Config> {
 pub type BalanceOf<T> =
     <<T as Config>::NativeBalance as Inspect<<T as frame_system::Config>::AccountId>>::Balance;
 
-/// BackupStorageProviderId is the type that represents an ID of a Backup Storage Provider, uniquely linked with an AccountId
-pub type BackupStorageProviderId<T> = <T as frame_system::Config>::Hash;
+/// Syntactic sugar for the ProviderId type used in the proofs pallet.
+pub type ProviderIdFor<T> =
+    <<T as crate::Config>::ProvidersPallet as ProvidersInterface>::ProviderId;

--- a/pallets/proofs-dealer/src/lib.rs
+++ b/pallets/proofs-dealer/src/lib.rs
@@ -301,7 +301,7 @@ pub mod pallet {
             let provider = match provider {
                 Some(provider) => provider,
                 None => {
-                    let sp = T::ProvidersPallet::get_provider(who.clone())
+                    let sp = T::ProvidersPallet::get_provider_id(who.clone())
                         .ok_or(Error::<T>::NotProvider)?;
                     sp
                 }

--- a/pallets/proofs-dealer/src/mock.rs
+++ b/pallets/proofs-dealer/src/mock.rs
@@ -143,12 +143,12 @@ impl crate::Config for Test {
 
 pub struct MockedProvidersSubscriber;
 impl SubscribeProvidersInterface for MockedProvidersSubscriber {
-    type Provider = u64;
+    type ProviderId = u64;
 
-    fn subscribe_bsp_sign_up(_who: &Self::Provider) -> DispatchResult {
+    fn subscribe_bsp_sign_up(_who: &Self::ProviderId) -> DispatchResult {
         Ok(())
     }
-    fn subscribe_bsp_sign_off(_who: &Self::Provider) -> DispatchResult {
+    fn subscribe_bsp_sign_off(_who: &Self::ProviderId) -> DispatchResult {
         Ok(())
     }
 }

--- a/pallets/proofs-dealer/src/types.rs
+++ b/pallets/proofs-dealer/src/types.rs
@@ -47,8 +47,8 @@ pub type TreasuryAccountFor<T> = <T as crate::Config>::Treasury;
 /// Syntactic sugar for the Providers type used in the proofs pallet.
 pub type ProvidersPalletFor<T> = <T as crate::Config>::ProvidersPallet;
 
-/// Syntactic sugar for the Provider type used in the proofs pallet.
-pub type ProviderFor<T> = <<T as crate::Config>::ProvidersPallet as ProvidersInterface>::Provider;
+/// Syntactic sugar for the ProviderId type used in the proofs pallet.
+pub type ProviderFor<T> = <<T as crate::Config>::ProvidersPallet as ProvidersInterface>::ProviderId;
 
 /// Syntactic sugar for the type of NativeBalance pallet.
 pub type BalancePalletFor<T> = <T as crate::Config>::NativeBalance;

--- a/pallets/proofs-dealer/src/utils.rs
+++ b/pallets/proofs-dealer/src/utils.rs
@@ -34,7 +34,7 @@ where
     /// - `ChallengesQueueOverflow`: If the challenges queue is full.
     pub fn do_challenge(who: &AccountIdFor<T>, key: &KeyFor<T>) -> DispatchResult {
         // Check if sender is a registered Provider.
-        if ProvidersPalletFor::<T>::get_provider(who.clone()).is_none() {
+        if ProvidersPalletFor::<T>::get_provider_id(who.clone()).is_none() {
             // Charge a fee for the challenge if it is not.
             BalancePalletFor::<T>::transfer(
                 &who,
@@ -132,12 +132,12 @@ where
 }
 
 impl<T: pallet::Config> ProofsDealerInterface for Pallet<T> {
-    type Provider = ProviderFor<T>;
+    type ProviderId = ProviderFor<T>;
     type Proof = CompactProof;
     type MerkleHash = T::MerkleHash;
 
     fn verify_proof(
-        who: &Self::Provider,
+        who: &Self::ProviderId,
         root: &Self::MerkleHash,
         proof: &Self::Proof,
     ) -> DispatchResult {

--- a/pallets/providers/src/lib.rs
+++ b/pallets/providers/src/lib.rs
@@ -460,6 +460,7 @@ pub mod pallet {
             capacity: StorageData<T>,
             multiaddresses: BoundedVec<MultiAddress<T>, MaxMultiAddressAmount<T>>,
             value_prop: ValueProposition<T>,
+            payment_account: T::AccountId,
         ) -> DispatchResultWithPostInfo {
             // Check that the extrinsic was signed and get the signer.
             let who = ensure_signed(origin)?;
@@ -472,6 +473,7 @@ pub mod pallet {
                 multiaddresses: multiaddresses.clone(),
                 value_prop: value_prop.clone(),
                 last_capacity_change: frame_system::Pallet::<T>::block_number(),
+                payment_account,
             };
 
             // Sign up the new MSP (if possible), updating storage
@@ -519,6 +521,7 @@ pub mod pallet {
             origin: OriginFor<T>,
             capacity: StorageData<T>,
             multiaddresses: BoundedVec<MultiAddress<T>, MaxMultiAddressAmount<T>>,
+            payment_account: T::AccountId,
         ) -> DispatchResultWithPostInfo {
             // Check that the extrinsic was signed and get the signer.
             let who = ensure_signed(origin)?;
@@ -530,6 +533,7 @@ pub mod pallet {
                 multiaddresses: multiaddresses.clone(),
                 root: MerklePatriciaRoot::<T>::default(),
                 last_capacity_change: frame_system::Pallet::<T>::block_number(),
+                payment_account,
             };
 
             // Sign up the new BSP (if possible), updating storage

--- a/pallets/providers/src/mock.rs
+++ b/pallets/providers/src/mock.rs
@@ -168,12 +168,12 @@ impl ExtBuilder {
 
 pub struct MockedProvidersSubscriber;
 impl SubscribeProvidersInterface for MockedProvidersSubscriber {
-    type Provider = u64;
+    type ProviderId = u64;
 
-    fn subscribe_bsp_sign_up(_who: &Self::Provider) -> DispatchResult {
+    fn subscribe_bsp_sign_up(_who: &Self::ProviderId) -> DispatchResult {
         Ok(())
     }
-    fn subscribe_bsp_sign_off(_who: &Self::Provider) -> DispatchResult {
+    fn subscribe_bsp_sign_off(_who: &Self::ProviderId) -> DispatchResult {
         Ok(())
     }
 }

--- a/pallets/providers/src/tests.rs
+++ b/pallets/providers/src/tests.rs
@@ -94,7 +94,8 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount,
                         multiaddresses.clone(),
-                        value_prop.clone()
+                        value_prop.clone(),
+                        alice
                     ));
 
                     // Check the new free balance of Alice
@@ -137,6 +138,7 @@ mod sign_up {
                                 multiaddresses,
                                 value_prop,
                                 last_capacity_change: current_block,
+                                payment_account: alice
                             }),
                             current_block
                         )
@@ -190,7 +192,8 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount,
                         multiaddresses.clone(),
-                        value_prop.clone()
+                        value_prop.clone(),
+                        alice
                     ));
 
                     // Check the new free balance of Alice
@@ -284,7 +287,8 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount,
                         multiaddresses.clone(),
-                        value_prop.clone()
+                        value_prop.clone(),
+                        alice
                     ));
 
                     // Check the new free balance of Alice
@@ -397,7 +401,8 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount_alice,
                         multiaddresses.clone(),
-                        value_prop.clone()
+                        value_prop.clone(),
+                        alice
                     ));
 
                     // Request sign up Bob as a Main Storage Provider
@@ -405,7 +410,8 @@ mod sign_up {
                         RuntimeOrigin::signed(bob),
                         storage_amount_bob,
                         multiaddresses.clone(),
-                        value_prop.clone()
+                        value_prop.clone(),
+                        bob
                     ));
 
                     // Check the new free balance of Alice
@@ -485,7 +491,8 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount,
                         multiaddresses.clone(),
-                        value_prop.clone()
+                        value_prop.clone(),
+                        alice
                     ));
 
                     // Check that Alice's request to sign up as a Main Storage Provider exists and is the one we just created
@@ -498,7 +505,8 @@ mod sign_up {
                             data_used: 0,
                             multiaddresses: multiaddresses.clone(),
                             value_prop: value_prop.clone(),
-                            last_capacity_change: current_block
+                            last_capacity_change: current_block,
+                            payment_account: alice
                         })));
                     assert!(alice_sign_up_request.is_ok_and(|request| request.1 == current_block));
 
@@ -567,6 +575,7 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount,
                         multiaddresses.clone(),
+                        alice
                     ));
 
                     // Check the new free balance of Alice
@@ -610,6 +619,7 @@ mod sign_up {
                                 data_used: 0,
                                 multiaddresses,
                                 last_capacity_change: current_block,
+                                payment_account: alice
                             }),
                             current_block
                         )
@@ -657,6 +667,7 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount,
                         multiaddresses.clone(),
+                        alice
                     ));
 
                     // Check the new free balance of Alice
@@ -759,6 +770,7 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount,
                         multiaddresses.clone(),
+                        alice
                     ));
 
                     // Check the new free balance of Alice
@@ -880,6 +892,7 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount_alice,
                         multiaddresses.clone(),
+                        alice
                     ));
 
                     // Request sign up Bob as a Backup Storage Provider
@@ -887,6 +900,7 @@ mod sign_up {
                         RuntimeOrigin::signed(bob),
                         storage_amount_bob,
                         multiaddresses.clone(),
+                        bob
                     ));
 
                     // Check the new free balance of Alice
@@ -958,6 +972,7 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount,
                         multiaddresses.clone(),
+                        alice
                     ));
 
                     // Check that Alice's request to sign up as a Backup Storage Provider exists and is the one we just created
@@ -969,7 +984,8 @@ mod sign_up {
                             data_used: 0,
                             multiaddresses: multiaddresses.clone(),
                             root: Default::default(),
-                            last_capacity_change: current_block
+                            last_capacity_change: current_block,
+                            payment_account: alice
                         })));
                     assert!(alice_sign_up_request.is_ok_and(|request| request.1 == current_block));
 
@@ -1062,7 +1078,8 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount_alice,
                         multiaddresses.clone(),
-                        value_prop.clone()
+                        value_prop.clone(),
+                        alice
                     ));
 
                     // Request sign up Bob as a Backup Storage Provider
@@ -1070,6 +1087,7 @@ mod sign_up {
                         RuntimeOrigin::signed(bob),
                         storage_amount_bob,
                         multiaddresses.clone(),
+                        bob
                     ));
 
                     // Check the new free balance of Alice
@@ -1162,7 +1180,8 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount_alice,
                         multiaddresses.clone(),
-                        value_prop.clone()
+                        value_prop.clone(),
+                        alice
                     ));
 
                     // Request sign up Bob as a Backup Storage Provider
@@ -1170,6 +1189,7 @@ mod sign_up {
                         RuntimeOrigin::signed(bob),
                         storage_amount_bob,
                         multiaddresses.clone(),
+                        bob
                     ));
 
                     // Advance enough blocks for randomness to be valid
@@ -1251,7 +1271,8 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount_alice,
                         multiaddresses.clone(),
-                        value_prop.clone()
+                        value_prop.clone(),
+                        alice
                     ));
 
                     // Request sign up Bob as a Backup Storage Provider
@@ -1259,6 +1280,7 @@ mod sign_up {
                         RuntimeOrigin::signed(bob),
                         storage_amount_bob,
                         multiaddresses.clone(),
+                        bob
                     ));
 
                     // Advance enough blocks for randomness to be valid
@@ -1357,7 +1379,8 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount_alice,
                         multiaddresses.clone(),
-                        value_prop.clone()
+                        value_prop.clone(),
+                        alice
                     ));
 
                     // Request sign up Bob as a Backup Storage Provider
@@ -1365,6 +1388,7 @@ mod sign_up {
                         RuntimeOrigin::signed(bob),
                         storage_amount_bob,
                         multiaddresses.clone(),
+                        bob
                     ));
 
                     // Advance enough blocks for randomness to be valid
@@ -1443,7 +1467,8 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount,
                         multiaddresses.clone(),
-                        value_prop.clone()
+                        value_prop.clone(),
+                        alice
                     ));
 
                     // Advance enough blocks for randomness to be valid
@@ -1541,14 +1566,16 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount_alice,
                         multiaddresses.clone(),
-                        value_prop.clone()
+                        value_prop.clone(),
+                        alice
                     ));
 
                     // Request sign up Bob as a Backup Storage Provider
                     assert_ok!(StorageProviders::request_bsp_sign_up(
                         RuntimeOrigin::signed(bob),
                         storage_amount_bob,
-                        multiaddresses.clone()
+                        multiaddresses.clone(),
+                        bob
                     ));
 
                     // Check the new free balance of Alice
@@ -1679,7 +1706,8 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount,
                         multiaddresses.clone(),
-                        value_prop.clone()
+                        value_prop.clone(),
+                        alice
                     ));
 
                     // Check that Alice is not a Storage Provider
@@ -1738,7 +1766,8 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount,
                         multiaddresses.clone(),
-                        value_prop.clone()
+                        value_prop.clone(),
+                        alice
                     ));
 
                     // Check that Alice is not a Storage Provider
@@ -1796,7 +1825,8 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount,
                         multiaddresses.clone(),
-                        value_prop.clone()
+                        value_prop.clone(),
+                        alice
                     ));
 
                     // Try to request to sign up Alice as a Main Storage Provider
@@ -1805,7 +1835,8 @@ mod sign_up {
                             RuntimeOrigin::signed(alice),
                             storage_amount,
                             multiaddresses.clone(),
-                            value_prop.clone()
+                            value_prop.clone(),
+                            alice
                         ),
                         Error::<Test>::SignUpRequestPending
                     );
@@ -1849,7 +1880,8 @@ mod sign_up {
                             RuntimeOrigin::signed(account_id),
                             storage_amount,
                             multiaddresses.clone(),
-                            value_prop.clone()
+                            value_prop.clone(),
+                            account_id
                         ));
                     }
 
@@ -1874,7 +1906,8 @@ mod sign_up {
                             RuntimeOrigin::signed(alice),
                             storage_amount,
                             multiaddresses.clone(),
-                            value_prop.clone()
+                            value_prop.clone(),
+                            alice
                         ),
                         Error::<Test>::MaxMspsReached
                     );
@@ -1911,7 +1944,8 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount,
                         multiaddresses.clone(),
-                        value_prop.clone()
+                        value_prop.clone(),
+                        alice
                     ));
 
                     // Request to sign up the maximum amount of Main Storage Providers
@@ -1926,7 +1960,8 @@ mod sign_up {
                             RuntimeOrigin::signed(account_id),
                             storage_amount,
                             multiaddresses.clone(),
-                            value_prop.clone()
+                            value_prop.clone(),
+                            account_id
                         ));
                     }
 
@@ -1986,6 +2021,7 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount,
                         multiaddresses.clone(),
+                        alice
                     ));
 
                     // Check that Alice is not a Storage Provider
@@ -2039,6 +2075,7 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount,
                         multiaddresses.clone(),
+                        alice
                     ));
 
                     // Check that Alice is not a Storage Provider
@@ -2091,6 +2128,7 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount,
                         multiaddresses.clone(),
+                        alice
                     ));
 
                     // Try to request to sign up Alice as a Backup Storage Provider
@@ -2099,6 +2137,7 @@ mod sign_up {
                             RuntimeOrigin::signed(alice),
                             storage_amount,
                             multiaddresses.clone(),
+                            alice
                         ),
                         Error::<Test>::SignUpRequestPending
                     );
@@ -2137,6 +2176,7 @@ mod sign_up {
                             RuntimeOrigin::signed(account_id),
                             storage_amount,
                             multiaddresses.clone(),
+                            account_id
                         ));
                     }
 
@@ -2161,6 +2201,7 @@ mod sign_up {
                             RuntimeOrigin::signed(alice),
                             storage_amount,
                             multiaddresses.clone(),
+                            alice
                         ),
                         Error::<Test>::MaxBspsReached
                     );
@@ -2192,6 +2233,7 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount,
                         multiaddresses.clone(),
+                        alice
                     ));
 
                     // Request to sign up the maximum amount of Backup Storage Providers
@@ -2206,6 +2248,7 @@ mod sign_up {
                             RuntimeOrigin::signed(account_id),
                             storage_amount,
                             multiaddresses.clone(),
+                            account_id
                         ));
                     }
 
@@ -2270,7 +2313,8 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount,
                         multiaddresses.clone(),
-                        value_prop.clone()
+                        value_prop.clone(),
+                        alice
                     ));
 
                     // Advance blocks but not enough for randomness to be valid
@@ -2336,7 +2380,8 @@ mod sign_up {
                             RuntimeOrigin::signed(alice),
                             alice_msp.capacity,
                             alice_msp.multiaddresses.clone(),
-                            alice_msp.value_prop.clone()
+                            alice_msp.value_prop.clone(),
+                            alice
                         ),
                         Error::<Test>::AlreadyRegistered
                     );
@@ -2347,6 +2392,7 @@ mod sign_up {
                             RuntimeOrigin::signed(alice),
                             alice_msp.capacity,
                             alice_msp.multiaddresses.clone(),
+                            alice
                         ),
                         Error::<Test>::AlreadyRegistered
                     );
@@ -2361,7 +2407,8 @@ mod sign_up {
                                 identifier: ValuePropId::<Test>::default(),
                                 data_limit: 10,
                                 protocols: BoundedVec::new(),
-                            }
+                            },
+                            bob
                         ),
                         Error::<Test>::AlreadyRegistered
                     );
@@ -2372,6 +2419,7 @@ mod sign_up {
                             RuntimeOrigin::signed(bob),
                             bob_bsp.capacity,
                             bob_bsp.multiaddresses.clone(),
+                            bob
                         ),
                         Error::<Test>::AlreadyRegistered
                     );
@@ -2409,7 +2457,8 @@ mod sign_up {
                         RuntimeOrigin::signed(alice),
                         storage_amount,
                         multiaddresses.clone(),
-                        value_prop.clone()
+                        value_prop.clone(),
+                        alice
                     ));
 
                     // Request to sign up Bob as a Backup Storage Provider
@@ -2417,6 +2466,7 @@ mod sign_up {
                         RuntimeOrigin::signed(bob),
                         storage_amount,
                         multiaddresses.clone(),
+                        bob
                     ));
 
                     // Try to request to sign up Alice as a Backup Storage Provider
@@ -2425,6 +2475,7 @@ mod sign_up {
                             RuntimeOrigin::signed(alice),
                             storage_amount,
                             multiaddresses.clone(),
+                            alice
                         ),
                         Error::<Test>::SignUpRequestPending
                     );
@@ -2435,7 +2486,8 @@ mod sign_up {
                             RuntimeOrigin::signed(bob),
                             storage_amount,
                             multiaddresses.clone(),
-                            value_prop.clone()
+                            value_prop.clone(),
+                            bob
                         ),
                         Error::<Test>::SignUpRequestPending
                     );
@@ -2473,7 +2525,8 @@ mod sign_up {
                             RuntimeOrigin::signed(alice),
                             storage_amount,
                             multiaddresses.clone(),
-                            value_prop.clone()
+                            value_prop.clone(),
+                            alice
                         ),
                         Error::<Test>::StorageTooLow
                     );
@@ -2484,6 +2537,7 @@ mod sign_up {
                             RuntimeOrigin::signed(alice),
                             storage_amount,
                             multiaddresses.clone(),
+                            alice
                         ),
                         Error::<Test>::StorageTooLow
                     );
@@ -2521,7 +2575,8 @@ mod sign_up {
                             RuntimeOrigin::signed(helen),
                             storage_amount,
                             multiaddresses.clone(),
-                            value_prop.clone()
+                            value_prop.clone(),
+                            helen
                         ),
                         Error::<Test>::NotEnoughBalance
                     );
@@ -2532,6 +2587,7 @@ mod sign_up {
                             RuntimeOrigin::signed(helen),
                             storage_amount,
                             multiaddresses.clone(),
+                            helen
                         ),
                         Error::<Test>::NotEnoughBalance
                     );
@@ -2562,7 +2618,8 @@ mod sign_up {
                             RuntimeOrigin::signed(alice),
                             storage_amount,
                             multiaddresses.clone(),
-                            value_prop.clone()
+                            value_prop.clone(),
+                            alice
                         ),
                         Error::<Test>::NoMultiAddress
                     );
@@ -2573,6 +2630,7 @@ mod sign_up {
                             RuntimeOrigin::signed(alice),
                             storage_amount,
                             multiaddresses.clone(),
+                            alice
                         ),
                         Error::<Test>::NoMultiAddress
                     );
@@ -3890,7 +3948,8 @@ fn register_account_as_msp(
         RuntimeOrigin::signed(account),
         storage_amount,
         multiaddresses.clone(),
-        value_prop.clone()
+        value_prop.clone(),
+        account
     ));
 
     // Check that the request sign up event was emitted
@@ -3934,6 +3993,7 @@ fn register_account_as_msp(
             multiaddresses,
             value_prop,
             last_capacity_change: frame_system::Pallet::<Test>::block_number(),
+            payment_account: account,
         },
     )
 }
@@ -3972,6 +4032,7 @@ fn register_account_as_bsp(
         RuntimeOrigin::signed(account),
         storage_amount,
         multiaddresses.clone(),
+        account
     ));
 
     // Check that the request sign up event was emitted
@@ -4012,6 +4073,7 @@ fn register_account_as_bsp(
             multiaddresses,
             root: Default::default(),
             last_capacity_change: frame_system::Pallet::<Test>::block_number(),
+            payment_account: account,
         },
     )
 }

--- a/pallets/providers/src/tests.rs
+++ b/pallets/providers/src/tests.rs
@@ -110,7 +110,7 @@ mod sign_up {
                     );
 
                     // Check that Alice is still NOT a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_none());
 
                     // Check the event was emitted
@@ -208,7 +208,7 @@ mod sign_up {
                     );
 
                     // Check that Alice is still NOT a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_none());
 
                     // Advance enough blocks for randomness to be valid
@@ -224,7 +224,7 @@ mod sign_up {
                     ));
 
                     // Check that Alice is now a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_some());
                     assert!(StorageProviders::is_provider(alice_sp_id.unwrap()));
 
@@ -303,7 +303,7 @@ mod sign_up {
                     );
 
                     // Check that Alice is still NOT a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_none());
 
                     // Advance enough blocks for randomness to be valid
@@ -319,7 +319,7 @@ mod sign_up {
                     ));
 
                     // Check that Alice is now a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_some());
                     assert!(StorageProviders::is_provider(alice_sp_id.unwrap()));
 
@@ -516,7 +516,7 @@ mod sign_up {
                     )));
 
                     // Check that Alice is not a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_none());
 
                     // Check that Alice's sign up request no longer exists
@@ -590,7 +590,7 @@ mod sign_up {
                     );
 
                     // Check that Alice is still NOT a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_none());
 
                     // Check that the total capacity of the Backup Storage Providers has NOT yet increased
@@ -682,7 +682,7 @@ mod sign_up {
                     );
 
                     // Check that Alice is still NOT a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_none());
 
                     // Check that the total capacity of the Backup Storage Providers has NOT yet increased
@@ -711,7 +711,7 @@ mod sign_up {
                     ));
 
                     // Check that Alice is now a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_some());
                     assert!(StorageProviders::is_provider(alice_sp_id.unwrap()));
 
@@ -785,7 +785,7 @@ mod sign_up {
                     );
 
                     // Check that Alice is still NOT a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_none());
 
                     // Check that the total capacity of the Backup Storage Providers has NOT yet increased
@@ -814,7 +814,7 @@ mod sign_up {
                     ));
 
                     // Check that Alice is now a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_some());
                     assert!(StorageProviders::is_provider(alice_sp_id.unwrap()));
 
@@ -995,7 +995,7 @@ mod sign_up {
                     )));
 
                     // Check that Alice is not a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_none());
 
                     // Check that Alice's sign up request no longer exists
@@ -1205,7 +1205,7 @@ mod sign_up {
                     ));
 
                     // Check that Alice is now a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_some());
                     assert!(StorageProviders::is_provider(alice_sp_id.unwrap()));
 
@@ -1221,7 +1221,7 @@ mod sign_up {
                     );
 
                     // Check that Bob is still NOT a Storage Provider
-                    let bob_sp_id = StorageProviders::get_provider(bob);
+                    let bob_sp_id = StorageProviders::get_provider_id(bob);
                     assert!(bob_sp_id.is_none());
                 });
             }
@@ -1296,7 +1296,7 @@ mod sign_up {
                     ));
 
                     // Check that Alice is now a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_some());
                     assert!(StorageProviders::is_provider(alice_sp_id.unwrap()));
 
@@ -1318,7 +1318,7 @@ mod sign_up {
                     ));
 
                     // Check that Bob is now a Storage Provider
-                    let bob_sp_id = StorageProviders::get_provider(bob);
+                    let bob_sp_id = StorageProviders::get_provider_id(bob);
                     assert!(bob_sp_id.is_some());
                     assert!(StorageProviders::is_provider(bob_sp_id.unwrap()));
 
@@ -1404,7 +1404,7 @@ mod sign_up {
                     ));
 
                     // Check that Alice is now a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_some());
                     assert!(StorageProviders::is_provider(alice_sp_id.unwrap()));
 
@@ -1423,7 +1423,7 @@ mod sign_up {
                     assert_ok!(StorageProviders::cancel_sign_up(RuntimeOrigin::signed(bob)));
 
                     // Check that Bob is still not a Storage Provider
-                    let bob_sp_id = StorageProviders::get_provider(bob);
+                    let bob_sp_id = StorageProviders::get_provider_id(bob);
                     assert!(bob_sp_id.is_none());
 
                     // Check that Bob's request no longer exists
@@ -1485,7 +1485,7 @@ mod sign_up {
                     assert_eq!(confirm_result, Ok(Pays::No.into()));
 
                     // Check that Alice is now a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_some());
                     assert!(StorageProviders::is_provider(alice_sp_id.unwrap()));
 
@@ -1711,7 +1711,7 @@ mod sign_up {
                     ));
 
                     // Check that Alice is not a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_none());
 
                     // Advance blocks but not enough for randomness to be valid
@@ -1731,7 +1731,7 @@ mod sign_up {
                     );
 
                     // Check that Alice is still not a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_none());
                 });
             }
@@ -1771,7 +1771,7 @@ mod sign_up {
                     ));
 
                     // Check that Alice is not a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_none());
 
                     // Advance enough blocks for randomness to be too old (expiring the request)
@@ -1790,7 +1790,7 @@ mod sign_up {
                     );
 
                     // Check that Alice is still not a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_none());
                 });
             }
@@ -2025,7 +2025,7 @@ mod sign_up {
                     ));
 
                     // Check that Alice is not a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_none());
 
                     // Advance blocks but not enough for randomness to be valid
@@ -2045,7 +2045,7 @@ mod sign_up {
                     );
 
                     // Check that Alice is still not a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_none());
                 });
             }
@@ -2079,7 +2079,7 @@ mod sign_up {
                     ));
 
                     // Check that Alice is not a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_none());
 
                     // Advance enough blocks for randomness to be too old (expiring the request)
@@ -2098,7 +2098,7 @@ mod sign_up {
                     );
 
                     // Check that Alice is still not a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_none());
                 });
             }
@@ -2334,7 +2334,7 @@ mod sign_up {
                     );
 
                     // Check that Alice is still not a Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_none());
                 });
             }
@@ -2734,7 +2734,7 @@ mod sign_off {
                     assert_eq!(StorageProviders::get_msp_count(), 0);
 
                     // Check that Alice is not a Main Storage Provider anymore
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_none());
 
                     // Check the MSP Sign Off event was emitted
@@ -2788,7 +2788,7 @@ mod sign_off {
                     );
 
                     // Check that Alice is not a Backup Storage Provider anymore
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_none());
 
                     // Check that the counter of registered BSPs has decreased
@@ -2848,7 +2848,7 @@ mod sign_off {
                     assert_eq!(StorageProviders::get_msp_count(), 1);
 
                     // Check that Alice does not have any used storage
-                    let alice_sp_id = StorageProviders::get_provider(alice).unwrap();
+                    let alice_sp_id = StorageProviders::get_provider_id(alice).unwrap();
                     assert_eq!(
                         StorageProviders::get_used_storage_of_msp(&alice_sp_id).unwrap(),
                         0
@@ -2868,7 +2868,7 @@ mod sign_off {
                     );
 
                     // Make sure that Alice is still registered as a Main Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_some());
                     assert!(StorageProviders::is_provider(alice_sp_id.unwrap()));
 
@@ -2922,7 +2922,7 @@ mod sign_off {
                     assert_eq!(StorageProviders::get_total_bsp_capacity(), storage_amount);
 
                     // Check that Alice does not have any used storage
-                    let alice_sp_id = StorageProviders::get_provider(alice).unwrap();
+                    let alice_sp_id = StorageProviders::get_provider_id(alice).unwrap();
                     assert_eq!(
                         StorageProviders::get_used_storage_of_bsp(&alice_sp_id).unwrap(),
                         0
@@ -2942,7 +2942,7 @@ mod sign_off {
                     );
 
                     // Make sure that Alice is still registered as a Backup Storage Provider
-                    let alice_sp_id = StorageProviders::get_provider(alice);
+                    let alice_sp_id = StorageProviders::get_provider_id(alice);
                     assert!(alice_sp_id.is_some());
                     assert!(StorageProviders::is_provider(alice_sp_id.unwrap()));
 

--- a/pallets/providers/src/types.rs
+++ b/pallets/providers/src/types.rs
@@ -29,6 +29,7 @@ pub struct MainStorageProvider<T: Config> {
     pub multiaddresses: BoundedVec<MultiAddress<T>, MaxMultiAddressAmount<T>>,
     pub value_prop: ValueProposition<T>,
     pub last_capacity_change: BlockNumberFor<T>,
+    pub payment_account: T::AccountId,
 }
 
 /// Structure that represents a Backup Storage Provider. It holds the total data that the BSP is able to store, the amount of data that it is storing,
@@ -41,6 +42,7 @@ pub struct BackupStorageProvider<T: Config> {
     pub multiaddresses: BoundedVec<MultiAddress<T>, MaxMultiAddressAmount<T>>,
     pub root: MerklePatriciaRoot<T>,
     pub last_capacity_change: BlockNumberFor<T>,
+    pub payment_account: T::AccountId,
 }
 
 /// Structure that represents a Bucket. It holds the root of the Merkle Patricia Trie, the User ID that owns the bucket,

--- a/pallets/providers/src/utils.rs
+++ b/pallets/providers/src/utils.rs
@@ -782,6 +782,7 @@ impl<T: Config> From<MainStorageProvider<T>> for BackupStorageProvider<T> {
             multiaddresses: msp.multiaddresses,
             root: MerklePatriciaRoot::<T>::default(),
             last_capacity_change: msp.last_capacity_change,
+            payment_account: msp.payment_account,
         }
     }
 }

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -414,7 +414,7 @@ impl Convert<BlockNumber, Balance> for BlockNumberToBalance {
 impl pallet_payment_streams::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type NativeBalance = Balances;
-    type Providers = Providers;
+    type ProvidersPallet = Providers;
     type RuntimeHoldReason = RuntimeHoldReason;
     type NewUserDeposit = ConstU128<10>;
     type BlockNumberToBalance = BlockNumberToBalance;


### PR DESCRIPTION
This PR:
- Adds a field to the Storage Provider structures called `payment_account`, which is the address where the storage provider wants to receive payment for its services.
- Changes naming on the common interfaces between pallets to better reflect what the types and methods actually represent (`Provider` to `ProviderId`, `get_provider` to `get_provider_id`).
- Updates all pallets to use this new naming.
- Adds a new method to the `ProvidersInterface` called `get_provider_payment_account`, which receives a `ProviderId` and returns the payment account of that provider (if it exists). Used in the `payment-streams` pallet.
- Updates the `payment-stream` pallet to use provider IDs directly instead of account IDs that are registered as providers, and adds the necessary checks for that.

Note: a possible improvement, since we are now using generic provider IDs, would be to revamp naming on the `payment-streams` pallet to never mention "Backup Storage Providers" and to refer to them as simply "Providers", reflecting on the generic aspect of it.