### PR TITLE
feat: ✨ Upgrade trie-db 0.29.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,7 +1477,7 @@ dependencies = [
  "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-v1.9.0)",
  "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git)",
  "storage-hub-infra",
- "trie-db 0.29.0",
+ "trie-db 0.29.1",
 ]
 
 [[package]]
@@ -3203,7 +3203,7 @@ dependencies = [
  "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-v1.9.0)",
  "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git)",
  "storage-hub-infra",
- "trie-db 0.29.0",
+ "trie-db 0.29.1",
 ]
 
 [[package]]
@@ -3306,7 +3306,7 @@ dependencies = [
  "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git)",
  "storage-hub-infra",
  "thiserror",
- "trie-db 0.29.0",
+ "trie-db 0.29.1",
 ]
 
 [[package]]
@@ -13988,7 +13988,7 @@ dependencies = [
  "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git)",
  "thiserror",
  "tracing",
- "trie-db 0.29.0",
+ "trie-db 0.29.1",
  "trie-root",
 ]
 
@@ -14502,7 +14502,7 @@ dependencies = [
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-v1.9.0)",
  "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git)",
  "storage-hub-traits",
- "trie-db 0.29.0",
+ "trie-db 0.29.1",
 ]
 
 [[package]]
@@ -15420,9 +15420,9 @@ dependencies = [
 
 [[package]]
 name = "trie-db"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ed83be775d85ebb0e272914fff6462c39b3ddd6dc67b5c1c41271aad280c69"
+checksum = "0c992b4f40c234a074d48a757efeabb1a6be88af84c0c23f7ca158950cb0ae7f"
 dependencies = [
  "hash-db",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ scale-info = { version = "2.11.0", default-features = false, features = [
 ] }
 thiserror = "1.0.48"
 tokio = "1.36.0"
-trie-db = { version = "0.29.0", default-features = false }
+trie-db = { version = "0.29.1", default-features = false }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.108"
 smallvec = "1.11.0"

--- a/client/forest-manager/src/prove.rs
+++ b/client/forest-manager/src/prove.rs
@@ -147,7 +147,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "double ended iterator has inconsistent behaviour"]
     fn test_prove_challenge_before_first_key() {
         let (memdb, root, keys) = build_merkle_patricia_forest::<LayoutV1<RefHasher>>();
         let trie = TrieDBBuilder::<LayoutV1<RefHasher>>::new(&memdb, &root).build();

--- a/support/primitives/src/lib.rs
+++ b/support/primitives/src/lib.rs
@@ -89,25 +89,6 @@ where
                 .transpose()
                 .map_err(|_| "Failed to get previous leaf.")?;
 
-            // We check before the loop if the iterator has at least one leaf.
-            // Therefore, if `prev_leaf` is `None` here, it means that the behaviour of the double ended iterator has changed.
-            // This is because of an inconsistency in the behaviour of the iterator. If there is no leaf lower than the challenge,
-            // the iterator will return the same for both `next()` and `next_back()`. This is why we check if `prev_leaf` is `None`,
-            // because it shouldn't be, even in that case.
-            if prev_leaf.is_none() {
-                #[cfg(test)]
-                unreachable!(
-                    "This should not happen. We check if the iterator has at least one leaf."
-                );
-
-                #[allow(unreachable_code)]
-                {
-                    return Err(
-                        "Unexpected double ended iterator behaviour: no previous leaf.".into(),
-                    );
-                }
-            }
-
             // Check if there is a valid combination of leaves which validate the proof given the challenged key.
             match (prev_leaf, next_leaf) {
                 // Scenario 1 (valid): `next_leaf` is the challenged leaf which is included in the proof.
@@ -142,14 +123,12 @@ where
                 }
                 // Scenario 3 (valid): `next_leaf` is the first leaf since the next previous leaf is `None`.
                 // The challenge is before the first leaf (i.e. the challenge does not exist in the trie).
-                (Some((prev_key, _)), Some((next_key, _)))
-                    if prev_key == next_key && trie_de_iter.next_back().is_none() =>
-                {
-                    let prev_key = prev_key
+                (None, Some((next_key, _))) => {
+                    let next_key = next_key
                         .try_into()
                         .map_err(|_| "Failed to convert proven key.")?;
 
-                    proven_keys.insert(prev_key);
+                    proven_keys.insert(next_key);
 
                     continue;
                 }

--- a/support/primitives/src/tests.rs
+++ b/support/primitives/src/tests.rs
@@ -348,10 +348,7 @@ fn commitment_verifier_challenge_key_before_first_key_success() {
 
         let challenged_key_vec = challenge_key.to_vec();
 
-        // Assert that challenge_key is below next_leaf and that prev_leaf is equal to next_leaf.
-        // This is due to some inconsistent behaviour in the iterator, that when you seek to a key
-        // that is less than the first key, it will return the first key as the next_back leaf,
-        // even if it is not lower than the challenge key.
+        // Assert that challenge_key is below next_leaf and that prev_leaf is None.
         assert!(prev_leaf.is_none() && challenged_key_vec < next_leaf.unwrap().unwrap().0);
     }
 

--- a/support/primitives/src/tests.rs
+++ b/support/primitives/src/tests.rs
@@ -352,7 +352,7 @@ fn commitment_verifier_challenge_key_before_first_key_success() {
         // This is due to some inconsistent behaviour in the iterator, that when you seek to a key
         // that is less than the first key, it will return the first key as the next_back leaf,
         // even if it is not lower than the challenge key.
-        assert!(prev_leaf == next_leaf && challenged_key_vec < next_leaf.unwrap().unwrap().0);
+        assert!(prev_leaf.is_none() && challenged_key_vec < next_leaf.unwrap().unwrap().0);
     }
 
     // Generate proof


### PR DESCRIPTION
There was a bug with the double ended iteration implemented in `trie-db` which broke the behaviour expected for `next_back()` to yield either `None` or the previous leaf node after `seek(challenge)`. 

The fix was merged in https://github.com/paritytech/trie/pull/215 with a minor version upgrade from  `trie-db@0.29.0` to `trie-db@0.29.1`. Since it is a minor version, we can apply it to our dependencies without requiring `sp-trie` to upgrade it's sub dependency on `trie-db`.

Changes:
- Upgrades `trie-db` to `0.29.1`
- Removed ignored unit tests that were failing before due to bug in previous `trie-db` version
- Remove false check for `prev_leaf` which can be `None` now based on fixed double ended trie iteration behaviour
- Fix broken test to match `prev_leaf` to be `None` instead of being equal to `next_leaf`