### PR TITLE
Refactor: Extract FileDataTrie from FileStorage

### DIFF
--- a/client/common/src/types.rs
+++ b/client/common/src/types.rs
@@ -4,7 +4,6 @@ use codec::decode_from_bytes;
 use codec::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use sp_core::Hasher;
-use sp_core::H256;
 use sp_trie::CompactProof;
 use trie_db::TrieLayout;
 
@@ -26,7 +25,7 @@ type FileLocation = Vec<u8>;
 
 type Hash = [u8; 32];
 
-#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, Default)]
+#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct Fingerprint(Hash);
 
 impl Fingerprint {
@@ -198,5 +197,5 @@ pub struct FileProof {
     /// The compact proof.
     pub proof: SerializableCompactProof,
     /// The root hash of the trie, also known as the fingerprint of the file.
-    pub root: H256,
+    pub root: Fingerprint,
 }

--- a/client/file-manager/src/in_memory.rs
+++ b/client/file-manager/src/in_memory.rs
@@ -1,45 +1,110 @@
 use std::collections::HashMap;
 
-use shc_common::types::{Chunk, ChunkId, FileProof, HasherOutT, Leaf, Metadata};
-use sp_core::H256;
-
 use sp_trie::{recorder::Recorder, MemoryDB, Trie, TrieDBBuilder, TrieLayout, TrieMut};
 use trie_db::TrieDBMutBuilder;
 
-use crate::traits::{FileStorage, FileStorageError, FileStorageWriteStatus};
+use shc_common::types::{Chunk, ChunkId, FileProof, HasherOutT, Leaf, Metadata};
 
-pub struct FileData<T: TrieLayout + 'static> {
+use crate::traits::{FileDataTrie, FileStorage, FileStorageError, FileStorageWriteStatus};
+
+pub struct InMemoryFileDataTrie<T: TrieLayout + 'static> {
     root: HasherOutT<T>,
     memdb: MemoryDB<T::Hash>,
 }
 
-impl<T: TrieLayout + 'static> FileData<T> {
+impl<T: TrieLayout> Default for InMemoryFileDataTrie<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: TrieLayout + 'static> InMemoryFileDataTrie<T> {
     fn new() -> Self {
         Self {
             root: Default::default(),
             memdb: MemoryDB::default(),
         }
     }
+}
 
-    pub fn get_root(&self) -> H256 {
-        H256::from_slice(
-            self.root
-                .as_ref()
-                .try_into()
-                .expect("trie hash should be 32 bytes"),
-        )
+impl<T: TrieLayout> FileDataTrie<T> for InMemoryFileDataTrie<T> {
+    fn get_root(&self) -> &HasherOutT<T> {
+        &self.root
     }
 
-    pub fn stored_chunks_count(&self) -> u64 {
+    fn stored_chunks_count(&self) -> u64 {
         let trie = TrieDBBuilder::<T>::new(&self.memdb, &self.root).build();
         let stored_chunks = trie.key_iter().iter().count() as u64;
         stored_chunks
+    }
+
+    fn generate_proof(&self, chunk_id: &ChunkId) -> Result<FileProof, FileStorageError> {
+        let recorder: Recorder<T::Hash> = Recorder::default();
+
+        // A `TrieRecorder` is needed to create a proof of the "visited" leafs, by the end of this process.
+        let mut trie_recorder = recorder.as_trie_recorder(self.root);
+
+        let trie = TrieDBBuilder::<T>::new(&self.memdb, &self.root)
+            .with_recorder(&mut trie_recorder)
+            .build();
+
+        let chunk: Option<Vec<u8>> = trie
+            .get(&chunk_id.to_be_bytes())
+            .map_err(|_| FileStorageError::FailedToGetFileChunk)?;
+
+        let chunk = chunk.ok_or(FileStorageError::FileChunkDoesNotExist)?;
+
+        // Drop the `trie_recorder` to release the `recorder`
+        drop(trie_recorder);
+
+        // Generate proof
+        let proof = recorder
+            .drain_storage_proof()
+            .to_compact_proof::<T::Hash>(self.root)
+            .map_err(|_| FileStorageError::FailedToGenerateCompactProof)?;
+
+        Ok(FileProof {
+            proven: Leaf {
+                key: (*chunk_id),
+                data: chunk,
+            },
+            proof: proof.into(),
+            root: self.get_root().as_ref().into(),
+        })
+    }
+
+    fn get_chunk(&self, chunk_id: &ChunkId) -> Result<Chunk, FileStorageError> {
+        let trie = TrieDBBuilder::<T>::new(&self.memdb, &self.root).build();
+
+        trie.get(&chunk_id.to_be_bytes())
+            .map_err(|_| FileStorageError::FailedToGetFileChunk)?
+            .ok_or(FileStorageError::FileChunkDoesNotExist)
+    }
+
+    fn write_chunk(&mut self, chunk_id: &ChunkId, data: &Chunk) -> Result<(), FileStorageError> {
+        let mut trie = TrieDBMutBuilder::<T>::new(&mut self.memdb, &mut self.root).build();
+
+        // Check that we don't have a chunk already stored.
+        if trie
+            .contains(&chunk_id.to_be_bytes())
+            .map_err(|_| FileStorageError::FailedToGetFileChunk)?
+        {
+            return Err(FileStorageError::FileChunkAlreadyExists);
+        }
+
+        // Insert the chunk into the file trie.
+        trie.insert(&chunk_id.to_be_bytes(), &data)
+            .map_err(|_| FileStorageError::FailedToInsertFileChunk)?;
+
+        drop(trie);
+
+        Ok(())
     }
 }
 
 pub struct InMemoryFileStorage<T: TrieLayout + 'static> {
     pub metadata: HashMap<HasherOutT<T>, Metadata>,
-    pub file_data: HashMap<HasherOutT<T>, FileData<T>>,
+    pub file_data: HashMap<HasherOutT<T>, InMemoryFileDataTrie<T>>,
 }
 
 impl<T: TrieLayout> InMemoryFileStorage<T> {
@@ -52,6 +117,8 @@ impl<T: TrieLayout> InMemoryFileStorage<T> {
 }
 
 impl<T: TrieLayout + 'static> FileStorage<T> for InMemoryFileStorage<T> {
+    type FileDataTrie = InMemoryFileDataTrie<T>;
+
     fn generate_proof(
         &self,
         file_key: &HasherOutT<T>,
@@ -78,38 +145,7 @@ impl<T: TrieLayout + 'static> FileStorage<T> for InMemoryFileStorage<T> {
             return Err(FileStorageError::FingerprintAndStoredFileMismatch);
         }
 
-        let recorder: Recorder<T::Hash> = Recorder::default();
-
-        // A `TrieRecorder` is needed to create a proof of the "visited" leafs, by the end of this process.
-        let mut trie_recorder = recorder.as_trie_recorder(file_data.root);
-
-        let trie = TrieDBBuilder::<T>::new(&file_data.memdb, &file_data.root)
-            .with_recorder(&mut trie_recorder)
-            .build();
-
-        let chunk: Option<Vec<u8>> = trie
-            .get(&chunk_id.to_be_bytes())
-            .map_err(|_| FileStorageError::FailedToGetFileChunk)?;
-
-        let chunk = chunk.ok_or(FileStorageError::FileChunkDoesNotExist)?;
-
-        // Drop the `trie_recorder` to release the `recorder`
-        drop(trie_recorder);
-
-        // Generate proof
-        let proof = recorder
-            .drain_storage_proof()
-            .to_compact_proof::<T::Hash>(file_data.root)
-            .map_err(|_| FileStorageError::FailedToGenerateCompactProof)?;
-
-        Ok(FileProof {
-            proven: Leaf {
-                key: (*chunk_id),
-                data: chunk,
-            },
-            proof: proof.into(),
-            root: file_data.get_root(),
-        })
+        file_data.generate_proof(chunk_id)
     }
 
     fn delete_file(&mut self, file_key: &HasherOutT<T>) {
@@ -124,9 +160,41 @@ impl<T: TrieLayout + 'static> FileStorage<T> for InMemoryFileStorage<T> {
             .ok_or(FileStorageError::FileDoesNotExist)
     }
 
-    fn set_metadata(&mut self, file_key: HasherOutT<T>, metadata: Metadata) {
-        self.metadata.insert(file_key, metadata);
-        self.file_data.insert(file_key, FileData::new());
+    fn insert_file(
+        &mut self,
+        key: HasherOutT<T>,
+        metadata: Metadata,
+    ) -> Result<(), FileStorageError> {
+        if self.metadata.contains_key(&key) {
+            return Err(FileStorageError::FileAlreadyExists);
+        }
+        self.metadata.insert(key, metadata);
+
+        let previous = self.file_data.insert(key, InMemoryFileDataTrie::default());
+        if previous.is_some() {
+            panic!("Invariant broken! Inconsistent metadata and file data storage.");
+        }
+
+        Ok(())
+    }
+
+    fn insert_file_with_data(
+        &mut self,
+        key: HasherOutT<T>,
+        metadata: Metadata,
+        file_data: Self::FileDataTrie,
+    ) -> Result<(), FileStorageError> {
+        if self.metadata.contains_key(&key) {
+            return Err(FileStorageError::FileAlreadyExists);
+        }
+        self.metadata.insert(key, metadata);
+
+        let previous = self.file_data.insert(key, file_data);
+        if previous.is_some() {
+            panic!("Invariant broken! Inconsistent metadata and file data storage.");
+        }
+
+        Ok(())
     }
 
     fn get_chunk(
@@ -137,11 +205,7 @@ impl<T: TrieLayout + 'static> FileStorage<T> for InMemoryFileStorage<T> {
         let file_data = self.file_data.get(file_key);
         let file_data = file_data.ok_or(FileStorageError::FileDoesNotExist)?;
 
-        let trie = TrieDBBuilder::<T>::new(&file_data.memdb, &file_data.root).build();
-
-        trie.get(&chunk_id.to_be_bytes())
-            .map_err(|_| FileStorageError::FailedToGetFileChunk)?
-            .ok_or(FileStorageError::FileChunkDoesNotExist)
+        file_data.get_chunk(chunk_id)
     }
 
     fn write_chunk(
@@ -155,22 +219,7 @@ impl<T: TrieLayout + 'static> FileStorage<T> for InMemoryFileStorage<T> {
             .get_mut(file_key)
             .ok_or(FileStorageError::FileDoesNotExist)?;
 
-        let mut trie =
-            TrieDBMutBuilder::<T>::new(&mut file_data.memdb, &mut file_data.root).build();
-
-        // Check that we don't have a chunk already stored.
-        if trie
-            .contains(&chunk_id.to_be_bytes())
-            .map_err(|_| FileStorageError::FailedToGetFileChunk)?
-        {
-            return Err(FileStorageError::FileChunkAlreadyExists);
-        }
-
-        // Insert the chunk into the file trie.
-        trie.insert(&chunk_id.to_be_bytes(), &data)
-            .map_err(|_| FileStorageError::FailedToInsertFileChunk)?;
-
-        drop(trie);
+        file_data.write_chunk(chunk_id, data)?;
 
         let metadata = self.metadata.get(file_key).expect(
             format!(

--- a/client/file-manager/src/traits.rs
+++ b/client/file-manager/src/traits.rs
@@ -3,6 +3,8 @@ use trie_db::TrieLayout;
 
 #[derive(Debug)]
 pub enum FileStorageError {
+    /// File already exists.
+    FileAlreadyExists,
     /// File chunk already exists.
     FileChunkAlreadyExists,
     /// File chunk does not exist.
@@ -30,8 +32,27 @@ pub enum FileStorageWriteStatus {
     FileIncomplete,
 }
 
+pub trait FileDataTrie<T: TrieLayout> {
+    /// Get the root of the trie.
+    fn get_root(&self) -> &HasherOutT<T>;
+
+    /// Get the number of stored chunks in the trie.
+    fn stored_chunks_count(&self) -> u64;
+
+    /// Generate proof for a chunk of a file. Returns error if the chunk does not exist.
+    fn generate_proof(&self, chunk_id: &ChunkId) -> Result<FileProof, FileStorageError>;
+
+    /// Get a file chunk from storage. Returns error if the chunk does not exist.
+    fn get_chunk(&self, chunk_id: &ChunkId) -> Result<Chunk, FileStorageError>;
+
+    /// Write a file chunk in storage updating the root hash of the trie.
+    fn write_chunk(&mut self, chunk_id: &ChunkId, data: &Chunk) -> Result<(), FileStorageError>;
+}
+
 /// Storage interface to be implemented by the storage providers.
 pub trait FileStorage<T: TrieLayout>: 'static {
+    type FileDataTrie: FileDataTrie<T> + Default;
+
     /// Generate proof for a chunk of a file. If the file does not exists or any chunk is missing,
     /// no proof will be returned.
     fn generate_proof(
@@ -46,9 +67,23 @@ pub trait FileStorage<T: TrieLayout>: 'static {
     /// Get metadata for a file.
     fn get_metadata(&self, key: &HasherOutT<T>) -> Result<Metadata, FileStorageError>;
 
-    /// Set metadata for a file. This should be called before you start adding chunks since it
-    /// will overwrite any previous Metadata and delete already stored file chunks.
-    fn set_metadata(&mut self, key: HasherOutT<T>, metadata: Metadata);
+    /// Inserts a new file. If the file already exists, it will return an error.
+    /// It is expected that the file key is indeed computed from the [Metadata].
+    /// This method does not require the actual data, file [Chunk]s being inserted separately.
+    fn insert_file(
+        &mut self,
+        key: HasherOutT<T>,
+        metadata: Metadata,
+    ) -> Result<(), FileStorageError>;
+
+    /// Inserts a new file with the associated trie data. If the file already exists, it will
+    /// return an error.
+    fn insert_file_with_data(
+        &mut self,
+        key: HasherOutT<T>,
+        metadata: Metadata,
+        file_data: Self::FileDataTrie,
+    ) -> Result<(), FileStorageError>;
 
     /// Get a file chunk from storage.
     fn get_chunk(&self, key: &HasherOutT<T>, chunk_id: &ChunkId)


### PR DESCRIPTION
This PR extracts `FileDataTrie` from `FileStorage`, allowing the use of the file data trie and building of the file `Fingerprint` without the use of `FileStorage`. `FileStorage` now also accepts adding complete files.