### PR TITLE
feat: :sparkles: generalize `payment-streams` pallet over a Provider

### DIFF
--- a/pallets/payment-streams/README.md
+++ b/pallets/payment-streams/README.md
@@ -1,4 +1,11 @@
 # Payment Streams pallet
 
-A pallet to create payment streams between Storage Providers and users, where other pallets through the provided interfaces can create new payment streams with a given rate of tokens per block, update those rates and delete a payment stream altogether.
-The pallet aims to be configurable but not usage agnostic as it is tightly related to the Storage Providers identity from the `storage-providers` pallet that can be found in the StorageHub runtime.
+A pallet to manage payment streams between Providers and Users.
+Other pallets can use the implemented interfaces/traits (`PaymentStreamsInterface` interface and `PaymentManager` trait) to create, update, delete and manage payment streams.
+Payment streams can be of two types:
+
+- Fixed rate stream: This one holds the last charged block, the last chargeable block and the rate (the rate holds the information about the amount of units are being provided to the User by the Provider). They are intended to be used when the Provider has some sort of contract with the User in which it agrees to provide its services for a fixed price per block. The rate can be updated, which is useful for example if the terms between the Provider and the User change. The amount charged is equal to: `rate * (last_chargeable_block - last_charged_block)`.
+An example of a fixed rate stream is a Main Storage Provider charging a User for the storage space it uses in its storage system: If the contract between the MSP and User stipulates that the User will be charged 1 token per unit of data per block and the User is storing 100 units with this MSP, then the rate would be equal to 100 tokens per block. If the User has been storing data for 10 blocks, then the amount charged would be 1000 tokens.
+
+- Dynamic rate stream: This one holds the price index at the time of the last charge, the price index at the time of the last chargeable block and the amount of units. They are intended to be used when the price the Provider charges is not directly negotiated with the User, but it is based on a common changing price that gets accumulated over time in the price index storage of this pallet. The amount charged is equal to: `amount_of_units * (price_index_at_last_chargeable_block - price_index_at_last_charge)`.
+An example of a dynamic rate stream is a Backup Storage Provider charging a User for the storage space it uses in its storage system: If the price index at the time of the last charge was 100 and the price index at the time of the last chargeable block (when the BSP last provided a valid proof for a file of the User) is 110 and the User is storing 100 units with this BSP, then the amount charged would be 1000 tokens.

--- a/pallets/payment-streams/src/lib.rs
+++ b/pallets/payment-streams/src/lib.rs
@@ -504,17 +504,12 @@ pub mod pallet {
             origin: OriginFor<T>,
             provider_id: ProviderIdFor<T>,
             user_account: T::AccountId,
-            current_price: BalanceOf<T>,
         ) -> DispatchResultWithPostInfo {
             // Check that the extrinsic was executed by the root origin
             ensure_root(origin)?;
 
             // Execute checks and logic, update storage
-            Self::do_delete_dynamic_rate_payment_stream(
-                &provider_id,
-                &user_account,
-                current_price,
-            )?;
+            Self::do_delete_dynamic_rate_payment_stream(&provider_id, &user_account)?;
 
             // Emit the corresponding event
             Self::deposit_event(Event::<T>::DynamicRatePaymentStreamDeleted {

--- a/pallets/payment-streams/src/mock.rs
+++ b/pallets/payment-streams/src/mock.rs
@@ -16,6 +16,7 @@ use system::pallet_prelude::BlockNumberFor;
 
 type Block = frame_system::mocking::MockBlock<Test>;
 type Balance = u128;
+type StorageUnit = u32;
 const EPOCH_DURATION_IN_BLOCKS: BlockNumberFor<Test> = 10;
 
 // We mock the Randomness trait to use a simple randomness function when testing the pallet
@@ -108,7 +109,7 @@ impl pallet_storage_providers::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type NativeBalance = Balances;
     type RuntimeHoldReason = RuntimeHoldReason;
-    type StorageData = u32;
+    type StorageData = StorageUnit;
     type SpCount = u32;
     type MerklePatriciaRoot = H256;
     type ValuePropId = H256;
@@ -145,7 +146,8 @@ impl crate::Config for Test {
     type NativeBalance = Balances;
     type ProvidersPallet = StorageProviders;
     type RuntimeHoldReason = RuntimeHoldReason;
-    type NewUserDeposit = ConstU128<10>;
+    type Units = StorageUnit;
+    type NewStreamDeposit = ConstU64<10>;
     type BlockNumberToBalance = BlockNumberToBalance;
 }
 

--- a/pallets/payment-streams/src/mock.rs
+++ b/pallets/payment-streams/src/mock.rs
@@ -129,7 +129,7 @@ impl pallet_storage_providers::Config for Test {
 }
 
 parameter_types! {
-    pub const PaymentStreamHoldReason: RuntimeHoldReason = RuntimeHoldReason::PaymentStreams(pallet_payment_streams::HoldReason::PaymentStreamStorageDeposit);
+    pub const PaymentStreamHoldReason: RuntimeHoldReason = RuntimeHoldReason::PaymentStreams(pallet_payment_streams::HoldReason::PaymentStreamDeposit);
 }
 
 // Converter from the BlockNumber type to the Balance type for math

--- a/pallets/payment-streams/src/tests.rs
+++ b/pallets/payment-streams/src/tests.rs
@@ -6,6 +6,7 @@ use frame_support::traits::fungible::Mutate;
 use frame_support::traits::{Get, OnFinalize, OnIdle, OnInitialize};
 use frame_support::{assert_ok, BoundedVec};
 use sp_core::H256;
+use sp_runtime::traits::Convert;
 use sp_runtime::DispatchError;
 use storage_hub_traits::PaymentManager;
 use storage_hub_traits::PaymentStreamsInterface;
@@ -14,7 +15,8 @@ use storage_hub_traits::ProvidersInterface;
 // `payment-streams` types:
 type NativeBalance = <Test as crate::Config>::NativeBalance;
 type AccountId = <Test as frame_system::Config>::AccountId;
-pub type NewUserDeposit = <Test as crate::Config>::NewUserDeposit;
+pub type NewStreamDeposit = <Test as crate::Config>::NewStreamDeposit;
+pub type BlockNumberToBalance = <Test as crate::Config>::BlockNumberToBalance;
 
 // `storage-providers` types:
 pub type StorageData<Test> = <Test as pallet_storage_providers::Config>::StorageData;
@@ -27,1544 +29,1594 @@ pub type MaxMultiAddressSize<Test> =
     <Test as pallet_storage_providers::Config>::MaxMultiAddressSize;
 pub type MultiAddress<T> = BoundedVec<u8, MaxMultiAddressSize<T>>;
 
-/// This module holds the tests for the creation of a payment stream
-mod create_stream {
-
+/// This module holds all tests for fixed-rate payment streams
+mod fixed_rate_streams {
     use super::*;
 
-    #[test]
-    fn create_payment_stream_works() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-            let bob_initial_balance = NativeBalance::free_balance(&bob);
+    /// This module holds the tests for the creation of a payment stream
+    mod create_stream {
 
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
+        use super::*;
 
-            // Create a payment stream from Bob to Alice of 10 units per block
-            let rate: BalanceOf<Test> = 10;
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                )
-            );
+        #[test]
+        fn create_payment_stream_works() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
+                let bob_initial_balance = NativeBalance::free_balance(&bob);
 
-            // The new balance of Bob should be his original balance - 10 (deposit to be a user)
-            assert_eq!(
-                NativeBalance::free_balance(&bob),
-                bob_initial_balance - <NewUserDeposit as Get<BalanceOf<Test>>>::get()
-            );
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
 
-            // Get the payment stream information
-            let payment_stream_info =
-                PaymentStreams::get_payment_stream_info(&alice_bsp_id, &bob).unwrap();
-            // The payment stream should be created with the correct rate
-            assert_eq!(payment_stream_info.rate, rate);
+                // Create a payment stream from Bob to Alice of 10 units per block
+                let rate: BalanceOf<Test> = 10;
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    )
+                );
 
-            // The payment stream should be created with the correct last valid proof
-            assert_eq!(payment_stream_info.last_valid_proof, System::block_number());
+                // The new balance of Bob should be his original balance minus `rate * NewStreamDeposit` (in this case 100)
+                let new_stream_deposit_blocks_balance_typed =
+                    BlockNumberToBalance::convert(<NewStreamDeposit as Get<u64>>::get());
+                assert_eq!(
+                    NativeBalance::free_balance(&bob),
+                    bob_initial_balance - rate * new_stream_deposit_blocks_balance_typed
+                );
 
-            // The payment stream should be created with the correct last charged proof
-            assert_eq!(
-                payment_stream_info.last_charged_proof,
-                System::block_number()
-            );
+                // Get the payment stream information
+                let payment_stream_info =
+                    PaymentStreams::get_fixed_rate_payment_stream_info(&alice_bsp_id, &bob)
+                        .unwrap();
+                // The payment stream should be created with the correct rate
+                assert_eq!(payment_stream_info.rate, rate);
 
-            // Bob should have 1 payment stream open
-            assert_eq!(PaymentStreams::get_payment_streams_count_of_user(&bob), 1);
-
-            // And that payment stream should be the one just created
-            assert_eq!(
-                PaymentStreams::get_payment_streams_of_user(&bob)[0],
-                (alice_bsp_id, payment_stream_info)
-            );
-
-            // The event should be emitted
-            System::assert_last_event(
-                Event::<Test>::PaymentStreamCreated {
-                    user_account: bob,
-                    storage_provider_id: alice_bsp_id,
-                    rate,
-                }
-                .into(),
-            );
-        });
-    }
-
-    #[test]
-    fn create_payment_stream_fails_if_stream_already_exists() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
-
-            // Create a payment stream from Bob to Alice of 10 units per block
-            let rate: BalanceOf<Test> = 10;
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                )
-            );
-
-            // Try to create a payment stream from Bob to Alice of 10 units per block again
-            assert_noop!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                ),
-                Error::<Test>::PaymentStreamAlreadyExists
-            );
-        });
-    }
-
-    #[test]
-    fn create_payment_stream_fails_if_bsp_account_has_not_registered_as_bsp() {
-        ExtBuilder::build().execute_with(|| {
-            let bob: AccountId = 1;
-
-            // Try to create a payment stream from Bob to a random not registered BSP of 10 units per block
-            let rate: BalanceOf<Test> = 10;
-            assert_noop!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &H256::random(),
-                    &bob,
-                    rate
-                ),
-                Error::<Test>::NotAProvider
-            );
-        });
-    }
-
-    #[test]
-    fn create_payment_stream_fails_if_user_is_flagged_as_without_funds() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let charlie: AccountId = 2;
-            let bob: AccountId = 1;
-            let bob_initial_balance = NativeBalance::free_balance(&bob);
-
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
-
-            // Register Charlie as a BSP with 1000 units of data and get his BSP ID
-            register_account_as_bsp(charlie, 1000);
-            let charlie_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(charlie).unwrap();
-
-            // Create a payment stream from Bob to Alice of `bob_initial_balance / 10` units per block
-            let rate: BalanceOf<Test> = bob_initial_balance / 10; // Bob will have enough balance to pay for only 9 blocks, will come short on the 10th because of the deposit
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                )
-            );
-
-            // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
-            run_to_block(System::block_number() + 10);
-            assert_ok!(
-                <PaymentStreams as PaymentManager>::update_last_chargeable_block(
-                    &alice_bsp_id,
-                    &bob,
+                // The payment stream should be created with the correct last valid proof
+                assert_eq!(
+                    payment_stream_info.last_chargeable_block,
                     System::block_number()
-                )
-            );
+                );
 
-            // Try to charge the payment stream (Bob will not have enough balance to pay for the 10th block and will get flagged as without funds)
-            assert_ok!(PaymentStreams::charge_payment_stream(
-                RuntimeOrigin::signed(alice),
-                bob
-            ));
-
-            // Check that the UserWithoutFunds event was emitted for Bob
-            System::assert_has_event(Event::<Test>::UserWithoutFunds { who: bob }.into());
-
-            // Try to create a payment stream from Bob to Charlie of 10 units per block
-            let rate: BalanceOf<Test> = 10;
-            assert_noop!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &charlie_bsp_id,
-                    &bob,
-                    rate
-                ),
-                Error::<Test>::UserWithoutFunds
-            );
-        });
-    }
-
-    #[test]
-    fn create_payment_stream_fails_if_user_cant_pay_deposit() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-            let bob_initial_balance = NativeBalance::free_balance(&bob);
-
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
-
-            // Transfer almost all of Bob's balance to Alice (Bob keeps `NewUserDeposit - 1` balance)
-            assert_ok!(Balances::transfer(
-                &bob,
-                &alice,
-                bob_initial_balance - <NewUserDeposit as Get<BalanceOf<Test>>>::get() + 1,
-                frame_support::traits::tokens::Preservation::Preserve
-            ));
-
-            // Try to create a payment stream from Bob to Alice of 10 units per block
-            let rate: BalanceOf<Test> = 10;
-            assert_noop!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                ),
-                Error::<Test>::CannotHoldDeposit
-            );
-        });
-    }
-
-    #[test]
-    fn create_payment_stream_fails_if_user_has_too_many_streams() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-            let charlie: AccountId = 2;
-
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
-
-            // Register Charlie as a BSP with 1000 units of data and get his BSP ID
-            register_account_as_bsp(charlie, 1000);
-            let charlie_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(charlie).unwrap();
-
-            // Set the amount of payment streams that Bob has to u32::MAX - 1
-            RegisteredUsers::<Test>::insert(&bob, u32::MAX - 1);
-
-            // Create a payment stream from Bob to Alice of 10 units per block
-            let rate: BalanceOf<Test> = 10;
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                ),
-            );
-
-            // Check how many streams Bob has
-            assert_eq!(
-                PaymentStreams::get_payment_streams_count_of_user(&bob),
-                u32::MAX
-            );
-
-            // Create a payment stream from Bob to Charlie of 10 units per block
-            let rate: BalanceOf<Test> = 10;
-            assert_noop!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &charlie_bsp_id,
-                    &bob,
-                    rate
-                ),
-                DispatchError::Arithmetic(sp_runtime::ArithmeticError::Overflow)
-            );
-        });
-    }
-}
-
-/// This module holds the tests for updating a payment stream (right now, only the rate can be updated)
-mod update_stream {
-
-    use super::*;
-
-    #[test]
-    fn update_payment_stream_works() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
-
-            // Create a payment stream from Bob to Alice of 10 units per block
-            let rate: BalanceOf<Test> = 10;
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                )
-            );
-
-            // Update the rate of the payment stream from Bob to Alice to 20 units per block
-            let new_rate: BalanceOf<Test> = 20;
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::update_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    new_rate
-                )
-            );
-
-            // Get the payment stream information
-            let payment_stream_info =
-                PaymentStreams::get_payment_stream_info(&alice_bsp_id, &bob).unwrap();
-
-            // The payment stream should be updated with the correct rate
-            assert_eq!(payment_stream_info.rate, new_rate);
-
-            // The event should be emitted
-            System::assert_last_event(
-                Event::<Test>::PaymentStreamUpdated {
-                    user_account: bob,
-                    storage_provider_id: alice_bsp_id,
-                    new_rate,
-                }
-                .into(),
-            );
-        });
-    }
-
-    #[test]
-    fn update_payment_stream_fails_if_new_rate_is_zero() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
-
-            // Create a payment stream from Bob to Alice of 10 units per block
-            let rate: BalanceOf<Test> = 10;
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                )
-            );
-
-            // Try to update the rate of the payment stream from Bob to Alice to 0 units per block
-            let new_rate: BalanceOf<Test> = 0;
-            assert_noop!(
-                <PaymentStreams as PaymentStreamsInterface>::update_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    new_rate
-                ),
-                Error::<Test>::RateCantBeZero
-            );
-        });
-    }
-
-    #[test]
-    fn update_payment_stream_fails_if_new_rate_is_equal_to_old_rate() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
-
-            // Create a payment stream from Bob to Alice of 10 units per block
-            let rate: BalanceOf<Test> = 10;
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                )
-            );
-
-            // Try to update the rate of the payment stream from Bob to Alice to 10 units per block
-            assert_noop!(
-                <PaymentStreams as PaymentStreamsInterface>::update_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                ),
-                Error::<Test>::UpdateRateToSameRate
-            );
-        });
-    }
-
-    #[test]
-    fn update_payment_stream_fails_if_stream_does_not_exist() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
-
-            // Try to update the rate of a payment stream that does not exist
-            assert_noop!(
-                <PaymentStreams as PaymentStreamsInterface>::update_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    10
-                ),
-                Error::<Test>::PaymentStreamNotFound
-            );
-        });
-    }
-
-    #[test]
-    fn update_payment_stream_fails_if_bsp_account_has_not_registered_as_bsp() {
-        ExtBuilder::build().execute_with(|| {
-            let bob: AccountId = 1;
-
-            // Try to update a payment stream from Bob to a random not registered BSP of 10 units per block
-            let new_rate: BalanceOf<Test> = 20;
-            assert_noop!(
-                <PaymentStreams as PaymentStreamsInterface>::update_payment_stream(
-                    &H256::random(),
-                    &bob,
-                    new_rate
-                ),
-                Error::<Test>::NotAProvider
-            );
-        });
-    }
-
-    #[test]
-    fn update_payment_stream_fails_if_user_is_flagged_as_without_funds() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-            let bob_initial_balance = NativeBalance::free_balance(&bob);
-
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
-
-            // Create a payment stream from Bob to Alice of `bob_initial_balance / 10` units per block
-            let rate: BalanceOf<Test> = bob_initial_balance / 10; // Bob will have enough balance to pay for only 9 blocks, will come short on the 10th because of the deposit
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                )
-            );
-
-            // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
-            run_to_block(System::block_number() + 10);
-            assert_ok!(
-                <PaymentStreams as PaymentManager>::update_last_chargeable_block(
-                    &alice_bsp_id,
-                    &bob,
+                // The payment stream should be created with the correct last charged proof
+                assert_eq!(
+                    payment_stream_info.last_charged_block,
                     System::block_number()
-                )
-            );
+                );
 
-            // Try to charge the payment stream (Bob will not have enough balance to pay for the 10th block and will get flagged as without funds)
-            assert_ok!(PaymentStreams::charge_payment_stream(
-                RuntimeOrigin::signed(alice),
-                bob
-            ));
+                // Bob should have 1 payment stream open
+                assert_eq!(PaymentStreams::get_payment_streams_count_of_user(&bob), 1);
 
-            // Check that the UserWithoutFunds event was emitted for Bob
-            System::assert_has_event(Event::<Test>::UserWithoutFunds { who: bob }.into());
+                // And that payment stream should be the one just created
+                assert_eq!(
+                    PaymentStreams::get_fixed_rate_payment_streams_of_user(&bob)[0],
+                    (alice_bsp_id, payment_stream_info)
+                );
 
-            // Try to update the rate of the payment stream from Bob to Alice to 20 units per block
-            let new_rate: BalanceOf<Test> = 20;
-            assert_noop!(
-                <PaymentStreams as PaymentStreamsInterface>::update_payment_stream(
-                    &alice_bsp_id,
+                // The event should be emitted
+                System::assert_last_event(
+                    Event::<Test>::FixedRatePaymentStreamCreated {
+                        user_account: bob,
+                        provider_id: alice_bsp_id,
+                        rate,
+                    }
+                    .into(),
+                );
+            });
+        }
+
+        #[test]
+        fn create_payment_stream_fails_if_stream_already_exists() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
+
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
+
+                // Create a payment stream from Bob to Alice of 10 units per block
+                let rate: BalanceOf<Test> = 10;
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    )
+                );
+
+                // Try to create a payment stream from Bob to Alice of 10 units per block again
+                assert_noop!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    ),
+                    Error::<Test>::PaymentStreamAlreadyExists
+                );
+            });
+        }
+
+        #[test]
+        fn create_payment_stream_fails_if_bsp_account_has_not_registered_as_bsp() {
+            ExtBuilder::build().execute_with(|| {
+                let bob: AccountId = 1;
+
+                // Try to create a payment stream from Bob to a random not registered BSP of 10 units per block
+                let rate: BalanceOf<Test> = 10;
+                assert_noop!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &H256::random(),
+                        &bob,
+                        rate
+                    ),
+                    Error::<Test>::NotAProvider
+                );
+            });
+        }
+
+        #[test]
+        fn create_payment_stream_fails_if_user_is_flagged_as_without_funds() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let charlie: AccountId = 2;
+                let bob: AccountId = 1;
+                let bob_initial_balance = NativeBalance::free_balance(&bob);
+
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
+
+                // Register Charlie as a BSP with 1000 units of data and get his BSP ID
+                register_account_as_bsp(charlie, 1000);
+                let charlie_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(charlie).unwrap();
+
+                // Create a payment stream from Bob to Alice of `bob_initial_balance / 10` units per block
+                let rate: BalanceOf<Test> = bob_initial_balance / 10; // Bob will have enough balance to pay for only 9 blocks, will come short on the 10th because of the deposit
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    )
+                );
+
+                // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
+                run_to_block(System::block_number() + 10);
+                assert_ok!(
+                    <PaymentStreams as PaymentManager>::update_last_chargeable_block(
+                        &alice_bsp_id,
+                        &bob,
+                        System::block_number()
+                    )
+                );
+
+                // Try to charge the payment stream (Bob will not have enough balance to pay for the 10th block and will get flagged as without funds)
+                assert_ok!(PaymentStreams::charge_payment_streams(
+                    RuntimeOrigin::signed(alice),
+                    bob
+                ));
+
+                // Check that the UserWithoutFunds event was emitted for Bob
+                System::assert_has_event(Event::<Test>::UserWithoutFunds { who: bob }.into());
+
+                // Try to create a payment stream from Bob to Charlie of 10 units per block
+                let rate: BalanceOf<Test> = 10;
+                assert_noop!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &charlie_bsp_id,
+                        &bob,
+                        rate
+                    ),
+                    Error::<Test>::UserWithoutFunds
+                );
+            });
+        }
+
+        #[test]
+        fn create_payment_stream_fails_if_user_cant_pay_deposit() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
+                let bob_initial_balance = NativeBalance::free_balance(&bob);
+                let rate: BalanceOf<Test> = 10;
+
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
+
+                // Transfer almost all of Bob's balance to Alice (Bob keeps `rate * NewStreamDeposit - 1` balance)
+                let new_stream_deposit_blocks_balance_typed =
+                    BlockNumberToBalance::convert(<NewStreamDeposit as Get<u64>>::get());
+                assert_ok!(Balances::transfer(
                     &bob,
-                    new_rate
-                ),
-                Error::<Test>::UserWithoutFunds
-            );
-        });
+                    &alice,
+                    bob_initial_balance - rate * new_stream_deposit_blocks_balance_typed + 1,
+                    frame_support::traits::tokens::Preservation::Preserve
+                ));
+
+                // Try to create a payment stream from Bob to Alice of 10 units per block
+                assert_noop!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    ),
+                    Error::<Test>::CannotHoldDeposit
+                );
+            });
+        }
+
+        #[test]
+        fn create_payment_stream_fails_if_user_has_too_many_streams() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
+                let charlie: AccountId = 2;
+
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
+
+                // Register Charlie as a BSP with 1000 units of data and get his BSP ID
+                register_account_as_bsp(charlie, 1000);
+                let charlie_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(charlie).unwrap();
+
+                // Set the amount of payment streams that Bob has to u32::MAX - 1
+                RegisteredUsers::<Test>::insert(&bob, u32::MAX - 1);
+
+                // Create a payment stream from Bob to Alice of 10 units per block
+                let rate: BalanceOf<Test> = 10;
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    ),
+                );
+
+                // Check how many streams Bob has
+                assert_eq!(
+                    PaymentStreams::get_payment_streams_count_of_user(&bob),
+                    u32::MAX
+                );
+
+                // Create a payment stream from Bob to Charlie of 10 units per block
+                let rate: BalanceOf<Test> = 10;
+                assert_noop!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &charlie_bsp_id,
+                        &bob,
+                        rate
+                    ),
+                    DispatchError::Arithmetic(sp_runtime::ArithmeticError::Overflow)
+                );
+            });
+        }
     }
 
-    #[test]
-    fn updated_payment_stream_charges_pending_blocks_with_old_rate() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-            let bob_initial_balance = NativeBalance::free_balance(&bob);
+    /// This module holds the tests for updating a payment stream (right now, only the rate can be updated)
+    mod update_stream {
 
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
+        use super::*;
 
-            // Create a payment stream from Bob to Alice of 10 units per block
-            let rate: BalanceOf<Test> = 10;
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                )
-            );
+        #[test]
+        fn update_payment_stream_works() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
 
-            // Check the new free balance of Bob (after the new user deposit)
-            let bob_new_balance =
-                bob_initial_balance - <NewUserDeposit as Get<BalanceOf<Test>>>::get();
-            assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
 
-            // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
-            run_to_block(System::block_number() + 10);
-            assert_ok!(
-                <PaymentStreams as PaymentManager>::update_last_chargeable_block(
-                    &alice_bsp_id,
-                    &bob,
+                // Create a payment stream from Bob to Alice of 10 units per block
+                let rate: BalanceOf<Test> = 10;
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    )
+                );
+
+                // Update the rate of the payment stream from Bob to Alice to 20 units per block
+                let new_rate: BalanceOf<Test> = 20;
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::update_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        new_rate
+                    )
+                );
+
+                // Get the payment stream information
+                let payment_stream_info =
+                    PaymentStreams::get_fixed_rate_payment_stream_info(&alice_bsp_id, &bob)
+                        .unwrap();
+
+                // The payment stream should be updated with the correct rate
+                assert_eq!(payment_stream_info.rate, new_rate);
+
+                // The event should be emitted
+                System::assert_last_event(
+                    Event::<Test>::FixedRatePaymentStreamUpdated {
+                        user_account: bob,
+                        provider_id: alice_bsp_id,
+                        new_rate,
+                    }
+                    .into(),
+                );
+            });
+        }
+
+        #[test]
+        fn update_payment_stream_fails_if_new_rate_is_zero() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
+
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
+
+                // Create a payment stream from Bob to Alice of 10 units per block
+                let rate: BalanceOf<Test> = 10;
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    )
+                );
+
+                // Try to update the rate of the payment stream from Bob to Alice to 0 units per block
+                let new_rate: BalanceOf<Test> = 0;
+                assert_noop!(
+                    <PaymentStreams as PaymentStreamsInterface>::update_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        new_rate
+                    ),
+                    Error::<Test>::RateCantBeZero
+                );
+            });
+        }
+
+        #[test]
+        fn update_payment_stream_fails_if_new_rate_is_equal_to_old_rate() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
+
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
+
+                // Create a payment stream from Bob to Alice of 10 units per block
+                let rate: BalanceOf<Test> = 10;
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    )
+                );
+
+                // Try to update the rate of the payment stream from Bob to Alice to 10 units per block
+                assert_noop!(
+                    <PaymentStreams as PaymentStreamsInterface>::update_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    ),
+                    Error::<Test>::UpdateRateToSameRate
+                );
+            });
+        }
+
+        #[test]
+        fn update_payment_stream_fails_if_stream_does_not_exist() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
+
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
+
+                // Try to update the rate of a payment stream that does not exist
+                assert_noop!(
+                    <PaymentStreams as PaymentStreamsInterface>::update_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        10
+                    ),
+                    Error::<Test>::PaymentStreamNotFound
+                );
+            });
+        }
+
+        #[test]
+        fn update_payment_stream_fails_if_bsp_account_has_not_registered_as_bsp() {
+            ExtBuilder::build().execute_with(|| {
+                let bob: AccountId = 1;
+
+                // Try to update a payment stream from Bob to a random not registered BSP of 10 units per block
+                let new_rate: BalanceOf<Test> = 20;
+                assert_noop!(
+                    <PaymentStreams as PaymentStreamsInterface>::update_fixed_rate_payment_stream(
+                        &H256::random(),
+                        &bob,
+                        new_rate
+                    ),
+                    Error::<Test>::NotAProvider
+                );
+            });
+        }
+
+        #[test]
+        fn update_payment_stream_fails_if_user_is_flagged_as_without_funds() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
+                let bob_initial_balance = NativeBalance::free_balance(&bob);
+
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
+
+                // Create a payment stream from Bob to Alice of `bob_initial_balance / 10` units per block
+                let rate: BalanceOf<Test> = bob_initial_balance / 10; // Bob will have enough balance to pay for only 9 blocks, will come short on the 10th because of the deposit
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    )
+                );
+
+                // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
+                run_to_block(System::block_number() + 10);
+                assert_ok!(
+                    <PaymentStreams as PaymentManager>::update_last_chargeable_block(
+                        &alice_bsp_id,
+                        &bob,
+                        System::block_number()
+                    )
+                );
+
+                // Try to charge the payment stream (Bob will not have enough balance to pay for the 10th block and will get flagged as without funds)
+                assert_ok!(PaymentStreams::charge_payment_streams(
+                    RuntimeOrigin::signed(alice),
+                    bob
+                ));
+
+                // Check that the UserWithoutFunds event was emitted for Bob
+                System::assert_has_event(Event::<Test>::UserWithoutFunds { who: bob }.into());
+
+                // Try to update the rate of the payment stream from Bob to Alice to 20 units per block
+                let new_rate: BalanceOf<Test> = 20;
+                assert_noop!(
+                    <PaymentStreams as PaymentStreamsInterface>::update_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        new_rate
+                    ),
+                    Error::<Test>::UserWithoutFunds
+                );
+            });
+        }
+
+        #[test]
+        fn updated_payment_stream_charges_pending_blocks_with_old_rate() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
+                let bob_initial_balance = NativeBalance::free_balance(&bob);
+
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
+
+                // Create a payment stream from Bob to Alice of 10 units per block
+                let rate: BalanceOf<Test> = 10;
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    )
+                );
+
+                // Check the new free balance of Bob (after the new user deposit)
+                let new_stream_deposit_blocks_balance_typed =
+                    BlockNumberToBalance::convert(<NewStreamDeposit as Get<u64>>::get());
+                let bob_new_balance =
+                    bob_initial_balance - rate * new_stream_deposit_blocks_balance_typed;
+                assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
+
+                // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
+                run_to_block(System::block_number() + 10);
+                assert_ok!(
+                    <PaymentStreams as PaymentManager>::update_last_chargeable_block(
+                        &alice_bsp_id,
+                        &bob,
+                        System::block_number()
+                    )
+                );
+
+                // Update the rate of the payment stream from Bob to Alice to 20 units per block
+                let new_rate: BalanceOf<Test> = 20;
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::update_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        new_rate
+                    )
+                );
+
+                // Check that Bob was charged 10 blocks at the old 10 units/block rate after the payment stream was updated
+                assert_eq!(
+                    NativeBalance::free_balance(&bob),
+                    bob_new_balance - 10 * rate
+                );
+                System::assert_has_event(
+                    Event::<Test>::PaymentStreamCharged {
+                        user_account: bob,
+                        provider_id: alice_bsp_id,
+                        amount: 10 * rate,
+                    }
+                    .into(),
+                );
+
+                // Get the payment stream information
+                let payment_stream_info =
+                    PaymentStreams::get_fixed_rate_payment_stream_info(&alice_bsp_id, &bob)
+                        .unwrap();
+
+                // The payment stream should be updated with the correct rate
+                assert_eq!(payment_stream_info.rate, new_rate);
+
+                // The payment stream should be updated with the correct last valid proof
+                assert_eq!(
+                    payment_stream_info.last_chargeable_block,
                     System::block_number()
-                )
-            );
+                );
 
-            // Update the rate of the payment stream from Bob to Alice to 20 units per block
-            let new_rate: BalanceOf<Test> = 20;
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::update_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    new_rate
-                )
-            );
-
-            // Check that Bob was charged 10 blocks at the old 10 units/block rate after the payment stream was updated
-            assert_eq!(
-                NativeBalance::free_balance(&bob),
-                bob_new_balance - 10 * rate
-            );
-            System::assert_has_event(
-                Event::<Test>::PaymentStreamCharged {
-                    user_account: bob,
-                    storage_provider_id: alice_bsp_id,
-                    amount: 10 * rate,
-                }
-                .into(),
-            );
-
-            // Get the payment stream information
-            let payment_stream_info =
-                PaymentStreams::get_payment_stream_info(&alice_bsp_id, &bob).unwrap();
-
-            // The payment stream should be updated with the correct rate
-            assert_eq!(payment_stream_info.rate, new_rate);
-
-            // The payment stream should be updated with the correct last valid proof
-            assert_eq!(payment_stream_info.last_valid_proof, System::block_number());
-
-            // The payment stream should be updated with the correct last charged proof
-            assert_eq!(
-                payment_stream_info.last_charged_proof,
-                System::block_number()
-            );
-        });
-    }
-}
-
-mod delete_stream {
-
-    use super::*;
-
-    #[test]
-    fn delete_payment_stream_works() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-            let bob_initial_balance = NativeBalance::free_balance(&bob);
-
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
-
-            // Create a payment stream from Bob to Alice of 10 units per block
-            let rate: BalanceOf<Test> = 10;
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                )
-            );
-
-            // Check the new free balance of Bob (after the new user deposit)
-            let bob_new_balance =
-                bob_initial_balance - <NewUserDeposit as Get<BalanceOf<Test>>>::get();
-            assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
-
-            // Delete the payment stream from Bob to Alice
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::delete_payment_stream(
-                    &alice_bsp_id,
-                    &bob
-                )
-            );
-
-            // The payment stream should be deleted
-            assert!(matches!(
-                PaymentStreams::get_payment_stream_info(&alice_bsp_id, &bob),
-                Err(Error::<Test>::PaymentStreamNotFound)
-            ));
-
-            // Bob should have 0 payment streams open
-            assert_eq!(PaymentStreams::get_payment_streams_count_of_user(&bob), 0);
-
-            // Bob should have his initial balance back
-            assert_eq!(NativeBalance::free_balance(&bob), bob_initial_balance);
-
-            // The event should be emitted
-            System::assert_last_event(
-                Event::<Test>::PaymentStreamDeleted {
-                    user_account: bob,
-                    storage_provider_id: alice_bsp_id,
-                }
-                .into(),
-            );
-        });
-    }
-
-    #[test]
-    fn delete_payment_stream_fails_if_stream_does_not_exist() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
-
-            // Try to delete a payment stream that does not exist
-            assert_noop!(
-                <PaymentStreams as PaymentStreamsInterface>::delete_payment_stream(
-                    &alice_bsp_id,
-                    &bob
-                ),
-                Error::<Test>::PaymentStreamNotFound
-            );
-        });
-    }
-
-    #[test]
-    fn delete_payment_stream_fails_if_bsp_account_has_not_registered_as_bsp() {
-        ExtBuilder::build().execute_with(|| {
-            let bob: AccountId = 1;
-
-            // Try to delete a payment stream from Bob to a random not registered BSP
-            assert_noop!(
-                <PaymentStreams as PaymentStreamsInterface>::delete_payment_stream(
-                    &H256::random(),
-                    &bob
-                ),
-                Error::<Test>::NotAProvider
-            );
-        });
-    }
-
-    #[test]
-    fn delete_payment_stream_fails_if_user_is_flagged_as_without_funds() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-            let bob_initial_balance = NativeBalance::free_balance(&bob);
-
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
-
-            // Create a payment stream from Bob to Alice of `bob_initial_balance / 10` units per block
-            let rate: BalanceOf<Test> = bob_initial_balance / 10; // Bob will have enough balance to pay for only 9 blocks, will come short on the 10th because of the deposit
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                )
-            );
-
-            // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
-            run_to_block(System::block_number() + 10);
-            assert_ok!(
-                <PaymentStreams as PaymentManager>::update_last_chargeable_block(
-                    &alice_bsp_id,
-                    &bob,
+                // The payment stream should be updated with the correct last charged proof
+                assert_eq!(
+                    payment_stream_info.last_charged_block,
                     System::block_number()
-                )
-            );
-
-            // Try to charge the payment stream (Bob will not have enough balance to pay for the 10th block and will get flagged as without funds)
-            assert_ok!(PaymentStreams::charge_payment_stream(
-                RuntimeOrigin::signed(alice),
-                bob
-            ));
-
-            // Check that the UserWithoutFunds event was emitted for Bob
-            System::assert_has_event(Event::<Test>::UserWithoutFunds { who: bob }.into());
-
-            // Try to delete the payment stream from Bob to Alice
-            assert_noop!(
-                <PaymentStreams as PaymentStreamsInterface>::delete_payment_stream(
-                    &alice_bsp_id,
-                    &bob
-                ),
-                Error::<Test>::UserWithoutFunds
-            );
-        });
+                );
+            });
+        }
     }
 
-    #[test]
-    fn delete_payment_stream_charges_pending_blocks() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-            let bob_initial_balance = NativeBalance::free_balance(&bob);
+    mod delete_stream {
 
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
+        use super::*;
 
-            // Create a payment stream from Bob to Alice of 10 units per block
-            let rate: BalanceOf<Test> = 10;
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                )
-            );
+        #[test]
+        fn delete_payment_stream_works() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
+                let bob_initial_balance = NativeBalance::free_balance(&bob);
 
-            // Check the new free balance of Bob (after the new user deposit)
-            let bob_new_balance =
-                bob_initial_balance - <NewUserDeposit as Get<BalanceOf<Test>>>::get();
-            assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
 
-            // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
-            run_to_block(System::block_number() + 10);
-            assert_ok!(
-                <PaymentStreams as PaymentManager>::update_last_chargeable_block(
-                    &alice_bsp_id,
-                    &bob,
+                // Create a payment stream from Bob to Alice of 10 units per block
+                let rate: BalanceOf<Test> = 10;
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    )
+                );
+
+                // Check the new free balance of Bob (after the new stream deposit)
+                let new_stream_deposit_blocks_balance_typed =
+                    BlockNumberToBalance::convert(<NewStreamDeposit as Get<u64>>::get());
+                let bob_new_balance =
+                    bob_initial_balance - rate * new_stream_deposit_blocks_balance_typed;
+                assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
+
+                // Delete the payment stream from Bob to Alice
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::delete_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob
+                    )
+                );
+
+                // The payment stream should be deleted
+                assert!(matches!(
+                    PaymentStreams::get_fixed_rate_payment_stream_info(&alice_bsp_id, &bob),
+                    Err(Error::<Test>::PaymentStreamNotFound)
+                ));
+
+                // Bob should have 0 payment streams open
+                assert_eq!(PaymentStreams::get_payment_streams_count_of_user(&bob), 0);
+
+                // Bob should have his initial balance back
+                assert_eq!(NativeBalance::free_balance(&bob), bob_initial_balance);
+
+                // The event should be emitted
+                System::assert_last_event(
+                    Event::<Test>::FixedRatePaymentStreamDeleted {
+                        user_account: bob,
+                        provider_id: alice_bsp_id,
+                    }
+                    .into(),
+                );
+            });
+        }
+
+        #[test]
+        fn delete_payment_stream_fails_if_stream_does_not_exist() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
+
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
+
+                // Try to delete a payment stream that does not exist
+                assert_noop!(
+                    <PaymentStreams as PaymentStreamsInterface>::delete_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob
+                    ),
+                    Error::<Test>::PaymentStreamNotFound
+                );
+            });
+        }
+
+        #[test]
+        fn delete_payment_stream_fails_if_bsp_account_has_not_registered_as_bsp() {
+            ExtBuilder::build().execute_with(|| {
+                let bob: AccountId = 1;
+
+                // Try to delete a payment stream from Bob to a random not registered BSP
+                assert_noop!(
+                    <PaymentStreams as PaymentStreamsInterface>::delete_fixed_rate_payment_stream(
+                        &H256::random(),
+                        &bob
+                    ),
+                    Error::<Test>::NotAProvider
+                );
+            });
+        }
+
+        #[test]
+        fn delete_payment_stream_fails_if_user_is_flagged_as_without_funds() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
+                let bob_initial_balance = NativeBalance::free_balance(&bob);
+
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
+
+                // Create a payment stream from Bob to Alice of `bob_initial_balance / 10` units per block
+                let rate: BalanceOf<Test> = bob_initial_balance / 10; // Bob will have enough balance to pay for only 9 blocks, will come short on the 10th because of the deposit
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    )
+                );
+
+                // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
+                run_to_block(System::block_number() + 10);
+                assert_ok!(
+                    <PaymentStreams as PaymentManager>::update_last_chargeable_block(
+                        &alice_bsp_id,
+                        &bob,
+                        System::block_number()
+                    )
+                );
+
+                // Try to charge the payment stream (Bob will not have enough balance to pay for the 10th block and will get flagged as without funds)
+                assert_ok!(PaymentStreams::charge_payment_streams(
+                    RuntimeOrigin::signed(alice),
+                    bob
+                ));
+
+                // Check that the UserWithoutFunds event was emitted for Bob
+                System::assert_has_event(Event::<Test>::UserWithoutFunds { who: bob }.into());
+
+                // Try to delete the payment stream from Bob to Alice
+                assert_noop!(
+                    <PaymentStreams as PaymentStreamsInterface>::delete_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob
+                    ),
+                    Error::<Test>::UserWithoutFunds
+                );
+            });
+        }
+
+        #[test]
+        fn delete_payment_stream_charges_pending_blocks() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
+                let bob_initial_balance = NativeBalance::free_balance(&bob);
+
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
+
+                // Create a payment stream from Bob to Alice of 10 units per block
+                let rate: BalanceOf<Test> = 10;
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    )
+                );
+
+                // Check the new free balance of Bob (after the new stream deposit)
+                let new_stream_deposit_blocks_balance_typed =
+                    BlockNumberToBalance::convert(<NewStreamDeposit as Get<u64>>::get());
+                let bob_new_balance =
+                    bob_initial_balance - rate * new_stream_deposit_blocks_balance_typed;
+                assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
+
+                // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
+                run_to_block(System::block_number() + 10);
+                assert_ok!(
+                    <PaymentStreams as PaymentManager>::update_last_chargeable_block(
+                        &alice_bsp_id,
+                        &bob,
+                        System::block_number()
+                    )
+                );
+
+                // Delete the payment stream from Bob to Alice
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::delete_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob
+                    )
+                );
+
+                // Check that Bob was returned his deposit AND charged 10 blocks at the 10 units/block rate after the payment stream was deleted
+                assert_eq!(
+                    NativeBalance::free_balance(&bob),
+                    bob_new_balance + rate * (new_stream_deposit_blocks_balance_typed - 10)
+                );
+                System::assert_has_event(
+                    Event::<Test>::PaymentStreamCharged {
+                        user_account: bob,
+                        provider_id: alice_bsp_id,
+                        amount: 10 * rate,
+                    }
+                    .into(),
+                );
+
+                // The payment stream should be deleted
+                assert!(matches!(
+                    PaymentStreams::get_fixed_rate_payment_stream_info(&alice_bsp_id, &bob),
+                    Err(Error::<Test>::PaymentStreamNotFound)
+                ));
+
+                // Bob should have 0 payment streams open
+                assert_eq!(PaymentStreams::get_payment_streams_count_of_user(&bob), 0);
+
+                // Bob should have his deposit back (but not the charged amount)
+                assert_eq!(
+                    NativeBalance::free_balance(&bob),
+                    bob_initial_balance - 10 * rate
+                );
+            });
+        }
+    }
+
+    mod charge_stream {
+
+        use crate::UsersWithoutFunds;
+
+        use super::*;
+
+        #[test]
+        fn charge_payment_streams_works() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
+                let bob_initial_balance = NativeBalance::free_balance(&bob);
+
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
+
+                // Create a payment stream from Bob to Alice of 10 units per block
+                let rate: BalanceOf<Test> = 10;
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    )
+                );
+
+                // Check the new free balance of Bob (after the new stream deposit)
+                let new_stream_deposit_blocks_balance_typed =
+                    BlockNumberToBalance::convert(<NewStreamDeposit as Get<u64>>::get());
+                let bob_new_balance =
+                    bob_initial_balance - rate * new_stream_deposit_blocks_balance_typed;
+                assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
+
+                // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
+                run_to_block(System::block_number() + 10);
+                assert_ok!(
+                    <PaymentStreams as PaymentManager>::update_last_chargeable_block(
+                        &alice_bsp_id,
+                        &bob,
+                        System::block_number()
+                    )
+                );
+
+                // Charge the payment stream from Bob to Alice
+                assert_ok!(PaymentStreams::charge_payment_streams(
+                    RuntimeOrigin::signed(alice),
+                    bob
+                ));
+
+                // Check that Bob was charged 10 blocks at the 10 units/block rate
+                assert_eq!(
+                    NativeBalance::free_balance(&bob),
+                    bob_new_balance - 10 * rate
+                );
+                System::assert_has_event(
+                    Event::<Test>::PaymentStreamCharged {
+                        user_account: bob,
+                        provider_id: alice_bsp_id,
+                        amount: 10 * rate,
+                    }
+                    .into(),
+                );
+
+                // Get the payment stream information
+                let payment_stream_info =
+                    PaymentStreams::get_fixed_rate_payment_stream_info(&alice_bsp_id, &bob)
+                        .unwrap();
+
+                // The payment stream should be updated with the correct last charged proof
+                assert_eq!(
+                    payment_stream_info.last_charged_block,
                     System::block_number()
-                )
-            );
+                );
+            });
+        }
 
-            // Delete the payment stream from Bob to Alice
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::delete_payment_stream(
-                    &alice_bsp_id,
-                    &bob
-                )
-            );
+        #[test]
+        fn charge_payment_streams_correctly_updates_last_charged_proof_to_last_valid_proof() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
+                let bob_initial_balance = NativeBalance::free_balance(&bob);
 
-            // Check that Bob was returned his deposit AND charged 10 blocks at the 10 units/block rate after the payment stream was deleted
-            assert_eq!(
-                NativeBalance::free_balance(&bob),
-                bob_new_balance + <NewUserDeposit as Get<BalanceOf<Test>>>::get() - 10 * rate
-            );
-            System::assert_has_event(
-                Event::<Test>::PaymentStreamCharged {
-                    user_account: bob,
-                    storage_provider_id: alice_bsp_id,
-                    amount: 10 * rate,
-                }
-                .into(),
-            );
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
 
-            // The payment stream should be deleted
-            assert!(matches!(
-                PaymentStreams::get_payment_stream_info(&alice_bsp_id, &bob),
-                Err(Error::<Test>::PaymentStreamNotFound)
-            ));
+                // Create a payment stream from Bob to Alice of 10 units per block
+                let rate: BalanceOf<Test> = 10;
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    )
+                );
 
-            // Bob should have 0 payment streams open
-            assert_eq!(PaymentStreams::get_payment_streams_count_of_user(&bob), 0);
+                // Check the new free balance of Bob (after the new stream deposit)
+                let new_stream_deposit_blocks_balance_typed =
+                    BlockNumberToBalance::convert(<NewStreamDeposit as Get<u64>>::get());
+                let bob_new_balance =
+                    bob_initial_balance - rate * new_stream_deposit_blocks_balance_typed;
+                assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
 
-            // Bob should have his deposit back (but not the charged amount)
-            assert_eq!(
-                NativeBalance::free_balance(&bob),
-                bob_initial_balance - 10 * rate
-            );
-        });
-    }
-}
+                // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
+                run_to_block(System::block_number() + 10);
+                assert_ok!(
+                    <PaymentStreams as PaymentManager>::update_last_chargeable_block(
+                        &alice_bsp_id,
+                        &bob,
+                        System::block_number()
+                    )
+                );
 
-mod charge_stream {
+                // Advance some blocks so the last valid proof is not the same as the current block
+                run_to_block(System::block_number() + 5);
 
-    use crate::UsersWithoutFunds;
+                // Charge the payment stream from Bob to Alice
+                assert_ok!(PaymentStreams::charge_payment_streams(
+                    RuntimeOrigin::signed(alice),
+                    bob
+                ));
 
-    use super::*;
+                // Check that Bob was charged 10 blocks at the 10 units/block rate
+                assert_eq!(
+                    NativeBalance::free_balance(&bob),
+                    bob_new_balance - 10 * rate
+                );
+                System::assert_has_event(
+                    Event::<Test>::PaymentStreamCharged {
+                        user_account: bob,
+                        provider_id: alice_bsp_id,
+                        amount: 10 * rate,
+                    }
+                    .into(),
+                );
 
-    #[test]
-    fn charge_payment_stream_works() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-            let bob_initial_balance = NativeBalance::free_balance(&bob);
+                // Get the payment stream information
+                let payment_stream_info =
+                    PaymentStreams::get_fixed_rate_payment_stream_info(&alice_bsp_id, &bob)
+                        .unwrap();
 
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
+                // The payment stream should be updated with the correct last charged proof
+                assert_eq!(
+                    payment_stream_info.last_charged_block,
+                    payment_stream_info.last_chargeable_block
+                );
 
-            // Create a payment stream from Bob to Alice of 10 units per block
-            let rate: BalanceOf<Test> = 10;
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                )
-            );
-
-            // Check the new free balance of Bob (after the new user deposit)
-            let bob_new_balance =
-                bob_initial_balance - <NewUserDeposit as Get<BalanceOf<Test>>>::get();
-            assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
-
-            // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
-            run_to_block(System::block_number() + 10);
-            assert_ok!(
-                <PaymentStreams as PaymentManager>::update_last_chargeable_block(
-                    &alice_bsp_id,
-                    &bob,
+                // And not with the current block
+                assert_ne!(
+                    payment_stream_info.last_charged_block,
                     System::block_number()
-                )
-            );
+                );
+            });
+        }
 
-            // Charge the payment stream from Bob to Alice
-            assert_ok!(PaymentStreams::charge_payment_stream(
-                RuntimeOrigin::signed(alice),
-                bob
-            ));
+        #[test]
+        fn charge_payment_streams_correctly_uses_the_latest_rate() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
+                let bob_initial_balance = NativeBalance::free_balance(&bob);
 
-            // Check that Bob was charged 10 blocks at the 10 units/block rate
-            assert_eq!(
-                NativeBalance::free_balance(&bob),
-                bob_new_balance - 10 * rate
-            );
-            System::assert_has_event(
-                Event::<Test>::PaymentStreamCharged {
-                    user_account: bob,
-                    storage_provider_id: alice_bsp_id,
-                    amount: 10 * rate,
-                }
-                .into(),
-            );
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
 
-            // Get the payment stream information
-            let payment_stream_info =
-                PaymentStreams::get_payment_stream_info(&alice_bsp_id, &bob).unwrap();
+                // Create a payment stream from Bob to Alice of 10 units per block
+                let rate: BalanceOf<Test> = 10;
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    )
+                );
 
-            // The payment stream should be updated with the correct last charged proof
-            assert_eq!(
-                payment_stream_info.last_charged_proof,
-                System::block_number()
-            );
-        });
-    }
+                // Check the new free balance of Bob (after the new stream deposit)
+                let new_stream_deposit_blocks_balance_typed =
+                    BlockNumberToBalance::convert(<NewStreamDeposit as Get<u64>>::get());
+                let bob_new_balance =
+                    bob_initial_balance - rate * new_stream_deposit_blocks_balance_typed;
+                assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
 
-    #[test]
-    fn charge_payment_stream_correctly_updates_last_charged_proof_to_last_valid_proof() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-            let bob_initial_balance = NativeBalance::free_balance(&bob);
+                // Update the rate of the payment stream from Bob to Alice to 20 units per block
+                let new_rate: BalanceOf<Test> = 20;
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::update_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        new_rate
+                    )
+                );
 
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
+                // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
+                run_to_block(System::block_number() + 10);
+                assert_ok!(
+                    <PaymentStreams as PaymentManager>::update_last_chargeable_block(
+                        &alice_bsp_id,
+                        &bob,
+                        System::block_number()
+                    )
+                );
 
-            // Create a payment stream from Bob to Alice of 10 units per block
-            let rate: BalanceOf<Test> = 10;
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                )
-            );
+                // Charge the payment stream from Bob to Alice
+                assert_ok!(PaymentStreams::charge_payment_streams(
+                    RuntimeOrigin::signed(alice),
+                    bob
+                ));
 
-            // Check the new free balance of Bob (after the new user deposit)
-            let bob_new_balance =
-                bob_initial_balance - <NewUserDeposit as Get<BalanceOf<Test>>>::get();
-            assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
+                // Check that Bob was charged 10 blocks at the 20 units/block rate
+                assert_eq!(
+                    NativeBalance::free_balance(&bob),
+                    bob_new_balance - 10 * new_rate
+                );
+                System::assert_has_event(
+                    Event::<Test>::PaymentStreamCharged {
+                        user_account: bob,
+                        provider_id: alice_bsp_id,
+                        amount: 10 * new_rate,
+                    }
+                    .into(),
+                );
 
-            // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
-            run_to_block(System::block_number() + 10);
-            assert_ok!(
-                <PaymentStreams as PaymentManager>::update_last_chargeable_block(
-                    &alice_bsp_id,
-                    &bob,
+                // Get the payment stream information
+                let payment_stream_info =
+                    PaymentStreams::get_fixed_rate_payment_stream_info(&alice_bsp_id, &bob)
+                        .unwrap();
+
+                // The payment stream should be updated with the correct last charged proof
+                assert_eq!(
+                    payment_stream_info.last_charged_block,
                     System::block_number()
-                )
-            );
+                );
 
-            // Advance some blocks so the last valid proof is not the same as the current block
-            run_to_block(System::block_number() + 5);
+                // The payment stream should be updated with the correct rate
+                assert_eq!(payment_stream_info.rate, new_rate);
 
-            // Charge the payment stream from Bob to Alice
-            assert_ok!(PaymentStreams::charge_payment_stream(
-                RuntimeOrigin::signed(alice),
-                bob
-            ));
-
-            // Check that Bob was charged 10 blocks at the 10 units/block rate
-            assert_eq!(
-                NativeBalance::free_balance(&bob),
-                bob_new_balance - 10 * rate
-            );
-            System::assert_has_event(
-                Event::<Test>::PaymentStreamCharged {
-                    user_account: bob,
-                    storage_provider_id: alice_bsp_id,
-                    amount: 10 * rate,
-                }
-                .into(),
-            );
-
-            // Get the payment stream information
-            let payment_stream_info =
-                PaymentStreams::get_payment_stream_info(&alice_bsp_id, &bob).unwrap();
-
-            // The payment stream should be updated with the correct last charged proof
-            assert_eq!(
-                payment_stream_info.last_charged_proof,
-                payment_stream_info.last_valid_proof
-            );
-
-            // And not with the current block
-            assert_ne!(
-                payment_stream_info.last_charged_proof,
-                System::block_number()
-            );
-        });
-    }
-
-    #[test]
-    fn charge_payment_stream_correctly_uses_the_latest_rate() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-            let bob_initial_balance = NativeBalance::free_balance(&bob);
-
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
-
-            // Create a payment stream from Bob to Alice of 10 units per block
-            let rate: BalanceOf<Test> = 10;
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                )
-            );
-
-            // Check the new free balance of Bob (after the new user deposit)
-            let bob_new_balance =
-                bob_initial_balance - <NewUserDeposit as Get<BalanceOf<Test>>>::get();
-            assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
-
-            // Update the rate of the payment stream from Bob to Alice to 20 units per block
-            let new_rate: BalanceOf<Test> = 20;
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::update_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    new_rate
-                )
-            );
-
-            // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
-            run_to_block(System::block_number() + 10);
-            assert_ok!(
-                <PaymentStreams as PaymentManager>::update_last_chargeable_block(
-                    &alice_bsp_id,
-                    &bob,
+                // The payment stream should be updated with the correct last valid proof
+                assert_eq!(
+                    payment_stream_info.last_chargeable_block,
                     System::block_number()
-                )
-            );
+                );
+            });
+        }
 
-            // Charge the payment stream from Bob to Alice
-            assert_ok!(PaymentStreams::charge_payment_stream(
-                RuntimeOrigin::signed(alice),
-                bob
-            ));
+        #[test]
+        fn charge_payment_works_after_two_charges() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
+                let bob_initial_balance = NativeBalance::free_balance(&bob);
 
-            // Check that Bob was charged 10 blocks at the 20 units/block rate
-            assert_eq!(
-                NativeBalance::free_balance(&bob),
-                bob_new_balance - 10 * new_rate
-            );
-            System::assert_has_event(
-                Event::<Test>::PaymentStreamCharged {
-                    user_account: bob,
-                    storage_provider_id: alice_bsp_id,
-                    amount: 10 * new_rate,
-                }
-                .into(),
-            );
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
 
-            // Get the payment stream information
-            let payment_stream_info =
-                PaymentStreams::get_payment_stream_info(&alice_bsp_id, &bob).unwrap();
+                // Create a payment stream from Bob to Alice of 10 units per block
+                let rate: BalanceOf<Test> = 10;
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    )
+                );
 
-            // The payment stream should be updated with the correct last charged proof
-            assert_eq!(
-                payment_stream_info.last_charged_proof,
-                System::block_number()
-            );
+                // Check the new free balance of Bob (after the new user deposit)
+                let new_stream_deposit_blocks_balance_typed =
+                    BlockNumberToBalance::convert(<NewStreamDeposit as Get<u64>>::get());
+                let bob_new_balance =
+                    bob_initial_balance - rate * new_stream_deposit_blocks_balance_typed;
+                assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
 
-            // The payment stream should be updated with the correct rate
-            assert_eq!(payment_stream_info.rate, new_rate);
+                // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
+                run_to_block(System::block_number() + 10);
+                assert_ok!(
+                    <PaymentStreams as PaymentManager>::update_last_chargeable_block(
+                        &alice_bsp_id,
+                        &bob,
+                        System::block_number()
+                    )
+                );
 
-            // The payment stream should be updated with the correct last valid proof
-            assert_eq!(payment_stream_info.last_valid_proof, System::block_number());
-        });
-    }
+                // Charge the payment stream from Bob to Alice
+                assert_ok!(PaymentStreams::charge_payment_streams(
+                    RuntimeOrigin::signed(alice),
+                    bob
+                ));
 
-    #[test]
-    fn charge_payment_works_after_two_charges() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-            let bob_initial_balance = NativeBalance::free_balance(&bob);
+                // Check that Bob was charged 10 blocks at the 10 units/block rate
+                assert_eq!(
+                    NativeBalance::free_balance(&bob),
+                    bob_new_balance - 10 * rate
+                );
+                System::assert_has_event(
+                    Event::<Test>::PaymentStreamCharged {
+                        user_account: bob,
+                        provider_id: alice_bsp_id,
+                        amount: 10 * rate,
+                    }
+                    .into(),
+                );
 
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
+                // Get the payment stream information
+                let payment_stream_info =
+                    PaymentStreams::get_fixed_rate_payment_stream_info(&alice_bsp_id, &bob)
+                        .unwrap();
 
-            // Create a payment stream from Bob to Alice of 10 units per block
-            let rate: BalanceOf<Test> = 10;
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                )
-            );
-
-            // Check the new free balance of Bob (after the new user deposit)
-            let bob_new_balance =
-                bob_initial_balance - <NewUserDeposit as Get<BalanceOf<Test>>>::get();
-            assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
-
-            // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
-            run_to_block(System::block_number() + 10);
-            assert_ok!(
-                <PaymentStreams as PaymentManager>::update_last_chargeable_block(
-                    &alice_bsp_id,
-                    &bob,
+                // The payment stream should be updated with the correct last charged proof
+                assert_eq!(
+                    payment_stream_info.last_charged_block,
                     System::block_number()
-                )
-            );
+                );
 
-            // Charge the payment stream from Bob to Alice
-            assert_ok!(PaymentStreams::charge_payment_stream(
-                RuntimeOrigin::signed(alice),
-                bob
-            ));
+                // Set the last valid proof of the payment stream from Bob to Alice to 20 blocks ahead
+                run_to_block(System::block_number() + 20);
+                assert_ok!(
+                    <PaymentStreams as PaymentManager>::update_last_chargeable_block(
+                        &alice_bsp_id,
+                        &bob,
+                        System::block_number()
+                    )
+                );
 
-            // Check that Bob was charged 10 blocks at the 10 units/block rate
-            assert_eq!(
-                NativeBalance::free_balance(&bob),
-                bob_new_balance - 10 * rate
-            );
-            System::assert_has_event(
-                Event::<Test>::PaymentStreamCharged {
-                    user_account: bob,
-                    storage_provider_id: alice_bsp_id,
-                    amount: 10 * rate,
-                }
-                .into(),
-            );
+                // Charge the payment stream from Bob to Alice
+                assert_ok!(PaymentStreams::charge_payment_streams(
+                    RuntimeOrigin::signed(alice),
+                    bob
+                ));
 
-            // Get the payment stream information
-            let payment_stream_info =
-                PaymentStreams::get_payment_stream_info(&alice_bsp_id, &bob).unwrap();
+                // Check that Bob was charged 20 blocks at the 10 units/block rate
+                assert_eq!(
+                    NativeBalance::free_balance(&bob),
+                    bob_new_balance - 10 * rate - 20 * rate
+                );
+                System::assert_has_event(
+                    Event::<Test>::PaymentStreamCharged {
+                        user_account: bob,
+                        provider_id: alice_bsp_id,
+                        amount: 20 * rate,
+                    }
+                    .into(),
+                );
 
-            // The payment stream should be updated with the correct last charged proof
-            assert_eq!(
-                payment_stream_info.last_charged_proof,
-                System::block_number()
-            );
+                // Get the payment stream information
+                let payment_stream_info =
+                    PaymentStreams::get_fixed_rate_payment_stream_info(&alice_bsp_id, &bob)
+                        .unwrap();
 
-            // Set the last valid proof of the payment stream from Bob to Alice to 20 blocks ahead
-            run_to_block(System::block_number() + 20);
-            assert_ok!(
-                <PaymentStreams as PaymentManager>::update_last_chargeable_block(
-                    &alice_bsp_id,
-                    &bob,
+                // The payment stream should be updated with the correct last charged proof
+                assert_eq!(
+                    payment_stream_info.last_charged_block,
                     System::block_number()
-                )
-            );
+                );
+            });
+        }
 
-            // Charge the payment stream from Bob to Alice
-            assert_ok!(PaymentStreams::charge_payment_stream(
-                RuntimeOrigin::signed(alice),
-                bob
-            ));
+        #[test]
+        fn charge_payment_streams_fails_if_bsp_account_has_not_registered_as_bsp() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
 
-            // Check that Bob was charged 20 blocks at the 10 units/block rate
-            assert_eq!(
-                NativeBalance::free_balance(&bob),
-                bob_new_balance - 10 * rate - 20 * rate
-            );
-            System::assert_has_event(
-                Event::<Test>::PaymentStreamCharged {
-                    user_account: bob,
-                    storage_provider_id: alice_bsp_id,
-                    amount: 20 * rate,
-                }
-                .into(),
-            );
+                // Try to charge a payment stream from Bob to Alice without registering Alice as a BSP
+                assert_noop!(
+                    PaymentStreams::charge_payment_streams(RuntimeOrigin::signed(alice), bob),
+                    Error::<Test>::NotAProvider
+                );
+            });
+        }
 
-            // Get the payment stream information
-            let payment_stream_info =
-                PaymentStreams::get_payment_stream_info(&alice_bsp_id, &bob).unwrap();
+        #[test]
+        fn charge_payment_streams_fails_if_stream_does_not_exist() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
 
-            // The payment stream should be updated with the correct last charged proof
-            assert_eq!(
-                payment_stream_info.last_charged_proof,
-                System::block_number()
-            );
-        });
+                // Register Alice as a BSP with 100 units of data
+                register_account_as_bsp(alice, 100);
+
+                // Try to charge a payment stream that does not exist
+                assert_noop!(
+                    PaymentStreams::charge_payment_streams(RuntimeOrigin::signed(alice), bob),
+                    Error::<Test>::PaymentStreamNotFound
+                );
+            });
+        }
+
+        #[test]
+        fn charge_payment_streams_fails_if_total_amount_would_overflow_balance_type() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
+                let bob_initial_balance = NativeBalance::free_balance(&bob);
+
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
+
+                // Create a payment stream from Bob to Alice of u128::MAX - 1 units per block
+                let rate: BalanceOf<Test> = u128::MAX - 1;
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    )
+                );
+
+                // Check the new free balance of Bob (after the new stream deposit)
+                let new_stream_deposit_blocks_balance_typed =
+                    BlockNumberToBalance::convert(<NewStreamDeposit as Get<u64>>::get());
+                let bob_new_balance =
+                    bob_initial_balance - rate * new_stream_deposit_blocks_balance_typed;
+                assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
+
+                // Set the last valid proof of the payment stream from Bob to Alice to 2 blocks ahead
+                run_to_block(System::block_number() + 2);
+                assert_ok!(
+                    <PaymentStreams as PaymentManager>::update_last_chargeable_block(
+                        &alice_bsp_id,
+                        &bob,
+                        System::block_number()
+                    )
+                );
+
+                // Try to charge the payment stream from Bob to Alice
+                assert_noop!(
+                    PaymentStreams::charge_payment_streams(RuntimeOrigin::signed(alice), bob),
+                    Error::<Test>::ChargeOverflow
+                );
+
+                // Check that Bob's balance has not changed
+                assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
+            });
+        }
+
+        #[test]
+        fn charge_payment_streams_correctly_flags_user_as_without_funds() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
+                let charlie: AccountId = 2;
+                let bob_initial_balance = NativeBalance::free_balance(&bob);
+
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
+
+                // Register Charlie as a BSP with 1000 units of data and get his BSP ID
+                register_account_as_bsp(charlie, 1000);
+                let charlie_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(charlie).unwrap();
+
+                // Create a payment stream from Bob to Alice of `bob_initial_balance / 10` units per block
+                let rate: BalanceOf<Test> = bob_initial_balance / 10; // Bob will have enough balance to pay for only 9 blocks, will come short on the 10th because of the deposit
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    )
+                );
+
+                // Check the new free balance of Bob (after the new stream deposit)
+                let new_stream_deposit_blocks_balance_typed =
+                    BlockNumberToBalance::convert(<NewStreamDeposit as Get<u64>>::get());
+                let bob_new_balance =
+                    bob_initial_balance - rate * new_stream_deposit_blocks_balance_typed;
+                assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
+
+                // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
+                run_to_block(System::block_number() + 10);
+                assert_ok!(
+                    <PaymentStreams as PaymentManager>::update_last_chargeable_block(
+                        &alice_bsp_id,
+                        &bob,
+                        System::block_number()
+                    )
+                );
+
+                // Try to charge the payment stream (Bob will not have enough balance to pay for it and will get flagged as without funds)
+                assert_ok!(PaymentStreams::charge_payment_streams(
+                    RuntimeOrigin::signed(alice),
+                    bob
+                ));
+
+                // Check that the UserWithoutFunds event was emitted for Bob
+                System::assert_has_event(Event::<Test>::UserWithoutFunds { who: bob }.into());
+
+                // Check that no funds where charged from Bob's account
+                assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
+                System::assert_has_event(
+                    Event::<Test>::PaymentStreamCharged {
+                        user_account: bob,
+                        provider_id: alice_bsp_id,
+                        amount: 0,
+                    }
+                    .into(),
+                );
+
+                // Try to create a new stream from Charlie to Bob
+                assert_noop!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &charlie_bsp_id,
+                        &bob,
+                        rate
+                    ),
+                    Error::<Test>::UserWithoutFunds
+                );
+            });
+        }
+
+        #[test]
+        fn charge_payment_streams_unflags_user_if_it_now_has_enough_funds() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
+                let charlie: AccountId = 2;
+                let bob_initial_balance = NativeBalance::free_balance(&bob);
+
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
+
+                // Register Charlie as a BSP with 1000 units of data
+                register_account_as_bsp(charlie, 1000);
+
+                // Create a payment stream from Bob to Alice of `bob_initial_balance / 10` units per block
+                let rate: BalanceOf<Test> = bob_initial_balance / 10; // Bob will have enough balance to pay for only 9 blocks, will come short on the 10th because of the deposit
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    )
+                );
+
+                // Check the new free balance of Bob (after the new user deposit)
+                let new_stream_deposit_blocks_balance_typed =
+                    BlockNumberToBalance::convert(<NewStreamDeposit as Get<u64>>::get());
+                let bob_new_balance =
+                    bob_initial_balance - rate * new_stream_deposit_blocks_balance_typed;
+                assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
+
+                // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
+                run_to_block(System::block_number() + 10);
+                assert_ok!(
+                    <PaymentStreams as PaymentManager>::update_last_chargeable_block(
+                        &alice_bsp_id,
+                        &bob,
+                        System::block_number()
+                    )
+                );
+
+                // Try to charge the payment stream (Bob will not have enough balance to pay for it and will get flagged as without funds)
+                assert_ok!(PaymentStreams::charge_payment_streams(
+                    RuntimeOrigin::signed(alice),
+                    bob
+                ));
+
+                // Check that the UserWithoutFunds event was emitted for Bob
+                System::assert_has_event(Event::<Test>::UserWithoutFunds { who: bob }.into());
+
+                // Check that no funds where charged from Bob's account
+                assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
+                System::assert_has_event(
+                    Event::<Test>::PaymentStreamCharged {
+                        user_account: bob,
+                        provider_id: alice_bsp_id,
+                        amount: 0,
+                    }
+                    .into(),
+                );
+
+                // Deposit enough funds to Bob's account
+                let deposit_amount = rate * 5;
+                assert_ok!(NativeBalance::mint_into(&bob, deposit_amount));
+
+                // Try to charge the payment stream again
+                assert_ok!(PaymentStreams::charge_payment_streams(
+                    RuntimeOrigin::signed(alice),
+                    bob
+                ));
+
+                // Check that Bob was charged 10 blocks at the (bob_initial_balance / 10) units/block rate
+                assert_eq!(
+                    NativeBalance::free_balance(&bob),
+                    bob_new_balance + deposit_amount - 10 * rate
+                );
+                System::assert_last_event(
+                    Event::<Test>::PaymentStreamCharged {
+                        user_account: bob,
+                        provider_id: alice_bsp_id,
+                        amount: 10 * rate,
+                    }
+                    .into(),
+                );
+
+                // Check that Bob is no longer flagged as a user without funds (TODO: we should have an event about this if we leave this behavior in prod)
+                assert!(!UsersWithoutFunds::<Test>::contains_key(bob));
+            });
+        }
     }
+    mod update_last_valid_proof {
 
-    #[test]
-    fn charge_payment_stream_fails_if_bsp_account_has_not_registered_as_bsp() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
+        use super::*;
 
-            // Try to charge a payment stream from Bob to Alice without registering Alice as a BSP
-            assert_noop!(
-                PaymentStreams::charge_payment_stream(RuntimeOrigin::signed(alice), bob),
-                Error::<Test>::NotAProvider
-            );
-        });
-    }
+        #[test]
+        fn update_last_valid_proof_works() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
 
-    #[test]
-    fn charge_payment_stream_fails_if_stream_does_not_exist() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
 
-            // Register Alice as a BSP with 100 units of data
-            register_account_as_bsp(alice, 100);
+                // Create a payment stream from Bob to Alice of 10 units per block
+                let rate: BalanceOf<Test> = 10;
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    )
+                );
 
-            // Try to charge a payment stream that does not exist
-            assert_noop!(
-                PaymentStreams::charge_payment_stream(RuntimeOrigin::signed(alice), bob),
-                Error::<Test>::PaymentStreamNotFound
-            );
-        });
-    }
+                // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
+                run_to_block(System::block_number() + 10);
+                assert_ok!(
+                    <PaymentStreams as PaymentManager>::update_last_chargeable_block(
+                        &alice_bsp_id,
+                        &bob,
+                        System::block_number()
+                    )
+                );
 
-    #[test]
-    fn charge_payment_stream_fails_if_total_amount_would_overflow_balance_type() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-            let bob_initial_balance = NativeBalance::free_balance(&bob);
+                // Get the payment stream information
+                let payment_stream_info =
+                    PaymentStreams::get_fixed_rate_payment_stream_info(&alice_bsp_id, &bob)
+                        .unwrap();
 
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
-
-            // Create a payment stream from Bob to Alice of u128::MAX - 1 units per block
-            let rate: BalanceOf<Test> = u128::MAX - 1;
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                )
-            );
-
-            // Check the new free balance of Bob (after the new user deposit)
-            let bob_new_balance =
-                bob_initial_balance - <NewUserDeposit as Get<BalanceOf<Test>>>::get();
-            assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
-
-            // Set the last valid proof of the payment stream from Bob to Alice to 2 blocks ahead
-            run_to_block(System::block_number() + 2);
-            assert_ok!(
-                <PaymentStreams as PaymentManager>::update_last_chargeable_block(
-                    &alice_bsp_id,
-                    &bob,
+                // The payment stream should be updated with the correct last valid proof
+                assert_eq!(
+                    payment_stream_info.last_chargeable_block,
                     System::block_number()
-                )
-            );
+                );
+            });
+        }
 
-            // Try to charge the payment stream from Bob to Alice
-            assert_noop!(
-                PaymentStreams::charge_payment_stream(RuntimeOrigin::signed(alice), bob),
-                Error::<Test>::ChargeOverflow
-            );
+        #[test]
+        fn update_last_valid_proof_fails_if_stream_does_not_exist() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
 
-            // Check that Bob's balance has not changed
-            assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
-        });
-    }
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
 
-    #[test]
-    fn charge_payment_stream_correctly_flags_user_as_without_funds() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-            let charlie: AccountId = 2;
-            let bob_initial_balance = NativeBalance::free_balance(&bob);
+                // Try to update the last valid proof of a payment stream that does not exist
+                assert_noop!(
+                    <PaymentStreams as PaymentManager>::update_last_chargeable_block(
+                        &alice_bsp_id,
+                        &bob,
+                        System::block_number()
+                    ),
+                    Error::<Test>::PaymentStreamNotFound
+                );
+            });
+        }
 
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
+        #[test]
+        fn update_last_valid_proof_fails_if_bsp_account_has_not_registered_as_bsp() {
+            ExtBuilder::build().execute_with(|| {
+                let bob: AccountId = 1;
 
-            // Register Charlie as a BSP with 1000 units of data and get his BSP ID
-            register_account_as_bsp(charlie, 1000);
-            let charlie_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(charlie).unwrap();
+                // Try to update the last valid proof of a payment stream from Bob to a random not registered BSP
+                assert_noop!(
+                    <PaymentStreams as PaymentManager>::update_last_chargeable_block(
+                        &H256::random(),
+                        &bob,
+                        System::block_number()
+                    ),
+                    Error::<Test>::NotAProvider
+                );
+            });
+        }
 
-            // Create a payment stream from Bob to Alice of `bob_initial_balance / 10` units per block
-            let rate: BalanceOf<Test> = bob_initial_balance / 10; // Bob will have enough balance to pay for only 9 blocks, will come short on the 10th because of the deposit
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                )
-            );
+        #[test]
+        fn update_last_valid_proof_fails_if_trying_to_set_greater_than_current_block_number() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
 
-            // Check the new free balance of Bob (after the new user deposit)
-            let bob_new_balance =
-                bob_initial_balance - <NewUserDeposit as Get<BalanceOf<Test>>>::get();
-            assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
 
-            // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
-            run_to_block(System::block_number() + 10);
-            assert_ok!(
-                <PaymentStreams as PaymentManager>::update_last_chargeable_block(
-                    &alice_bsp_id,
-                    &bob,
-                    System::block_number()
-                )
-            );
+                // Create a payment stream from Bob to Alice of 10 units per block
+                let rate: BalanceOf<Test> = 10;
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    )
+                );
 
-            // Try to charge the payment stream (Bob will not have enough balance to pay for it and will get flagged as without funds)
-            assert_ok!(PaymentStreams::charge_payment_stream(
-                RuntimeOrigin::signed(alice),
-                bob
-            ));
+                // Try to set the last valid proof of the payment stream from Bob to Alice to a block number greater than the current block number
+                assert_noop!(
+                    <PaymentStreams as PaymentManager>::update_last_chargeable_block(
+                        &alice_bsp_id,
+                        &bob,
+                        System::block_number() + 1
+                    ),
+                    Error::<Test>::InvalidLastChargeableBlockNumber
+                );
+            });
+        }
 
-            // Check that the UserWithoutFunds event was emitted for Bob
-            System::assert_has_event(Event::<Test>::UserWithoutFunds { who: bob }.into());
+        #[test]
+        fn update_last_valid_proof_fails_if_trying_to_set_less_than_previous_value() {
+            ExtBuilder::build().execute_with(|| {
+                let alice: AccountId = 0;
+                let bob: AccountId = 1;
 
-            // Check that no funds where charged from Bob's account
-            assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
-            System::assert_has_event(
-                Event::<Test>::PaymentStreamCharged {
-                    user_account: bob,
-                    storage_provider_id: alice_bsp_id,
-                    amount: 0,
-                }
-                .into(),
-            );
+                // Register Alice as a BSP with 100 units of data and get her BSP ID
+                register_account_as_bsp(alice, 100);
+                let alice_bsp_id =
+                    <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
 
-            // Try to create a new stream from Charlie to Bob
-            assert_noop!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &charlie_bsp_id,
-                    &bob,
-                    rate
-                ),
-                Error::<Test>::UserWithoutFunds
-            );
-        });
-    }
+                // Create a payment stream from Bob to Alice of 10 units per block
+                let rate: BalanceOf<Test> = 10;
+                assert_ok!(
+                    <PaymentStreams as PaymentStreamsInterface>::create_fixed_rate_payment_stream(
+                        &alice_bsp_id,
+                        &bob,
+                        rate
+                    )
+                );
 
-    #[test]
-    fn charge_payment_stream_unflags_user_if_it_now_has_enough_funds() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-            let charlie: AccountId = 2;
-            let bob_initial_balance = NativeBalance::free_balance(&bob);
+                // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
+                run_to_block(System::block_number() + 10);
+                assert_ok!(
+                    <PaymentStreams as PaymentManager>::update_last_chargeable_block(
+                        &alice_bsp_id,
+                        &bob,
+                        System::block_number()
+                    )
+                );
 
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
-
-            // Register Charlie as a BSP with 1000 units of data
-            register_account_as_bsp(charlie, 1000);
-
-            // Create a payment stream from Bob to Alice of `bob_initial_balance / 10` units per block
-            let rate: BalanceOf<Test> = bob_initial_balance / 10; // Bob will have enough balance to pay for only 9 blocks, will come short on the 10th because of the deposit
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                )
-            );
-
-            // Check the new free balance of Bob (after the new user deposit)
-            let bob_new_balance =
-                bob_initial_balance - <NewUserDeposit as Get<BalanceOf<Test>>>::get();
-            assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
-
-            // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
-            run_to_block(System::block_number() + 10);
-            assert_ok!(
-                <PaymentStreams as PaymentManager>::update_last_chargeable_block(
-                    &alice_bsp_id,
-                    &bob,
-                    System::block_number()
-                )
-            );
-
-            // Try to charge the payment stream (Bob will not have enough balance to pay for it and will get flagged as without funds)
-            assert_ok!(PaymentStreams::charge_payment_stream(
-                RuntimeOrigin::signed(alice),
-                bob
-            ));
-
-            // Check that the UserWithoutFunds event was emitted for Bob
-            System::assert_has_event(Event::<Test>::UserWithoutFunds { who: bob }.into());
-
-            // Check that no funds where charged from Bob's account
-            assert_eq!(NativeBalance::free_balance(&bob), bob_new_balance);
-            System::assert_has_event(
-                Event::<Test>::PaymentStreamCharged {
-                    user_account: bob,
-                    storage_provider_id: alice_bsp_id,
-                    amount: 0,
-                }
-                .into(),
-            );
-
-            // Deposit enough funds to Bob's account
-            let deposit_amount = rate * 5;
-            assert_ok!(NativeBalance::mint_into(&bob, deposit_amount));
-
-            // Try to charge the payment stream again
-            assert_ok!(PaymentStreams::charge_payment_stream(
-                RuntimeOrigin::signed(alice),
-                bob
-            ));
-
-            // Check that Bob was charged 10 blocks at the (bob_initial_balance / 10) units/block rate
-            assert_eq!(
-                NativeBalance::free_balance(&bob),
-                bob_new_balance + deposit_amount - 10 * rate
-            );
-            System::assert_last_event(
-                Event::<Test>::PaymentStreamCharged {
-                    user_account: bob,
-                    storage_provider_id: alice_bsp_id,
-                    amount: 10 * rate,
-                }
-                .into(),
-            );
-
-            // Check that Bob is no longer flagged as a user without funds (TODO: we should have an event about this if we leave this behavior in prod)
-            assert!(!UsersWithoutFunds::<Test>::contains_key(bob));
-        });
-    }
-}
-mod update_last_valid_proof {
-
-    use super::*;
-
-    #[test]
-    fn update_last_valid_proof_works() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
-
-            // Create a payment stream from Bob to Alice of 10 units per block
-            let rate: BalanceOf<Test> = 10;
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                )
-            );
-
-            // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
-            run_to_block(System::block_number() + 10);
-            assert_ok!(
-                <PaymentStreams as PaymentManager>::update_last_chargeable_block(
-                    &alice_bsp_id,
-                    &bob,
-                    System::block_number()
-                )
-            );
-
-            // Get the payment stream information
-            let payment_stream_info =
-                PaymentStreams::get_payment_stream_info(&alice_bsp_id, &bob).unwrap();
-
-            // The payment stream should be updated with the correct last valid proof
-            assert_eq!(payment_stream_info.last_valid_proof, System::block_number());
-        });
-    }
-
-    #[test]
-    fn update_last_valid_proof_fails_if_stream_does_not_exist() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
-
-            // Try to update the last valid proof of a payment stream that does not exist
-            assert_noop!(
-                <PaymentStreams as PaymentManager>::update_last_chargeable_block(
-                    &alice_bsp_id,
-                    &bob,
-                    System::block_number()
-                ),
-                Error::<Test>::PaymentStreamNotFound
-            );
-        });
-    }
-
-    #[test]
-    fn update_last_valid_proof_fails_if_bsp_account_has_not_registered_as_bsp() {
-        ExtBuilder::build().execute_with(|| {
-            let bob: AccountId = 1;
-
-            // Try to update the last valid proof of a payment stream from Bob to a random not registered BSP
-            assert_noop!(
-                <PaymentStreams as PaymentManager>::update_last_chargeable_block(
-                    &H256::random(),
-                    &bob,
-                    System::block_number()
-                ),
-                Error::<Test>::NotAProvider
-            );
-        });
-    }
-
-    #[test]
-    fn update_last_valid_proof_fails_if_trying_to_set_greater_than_current_block_number() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
-
-            // Create a payment stream from Bob to Alice of 10 units per block
-            let rate: BalanceOf<Test> = 10;
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                )
-            );
-
-            // Try to set the last valid proof of the payment stream from Bob to Alice to a block number greater than the current block number
-            assert_noop!(
-                <PaymentStreams as PaymentManager>::update_last_chargeable_block(
-                    &alice_bsp_id,
-                    &bob,
-                    System::block_number() + 1
-                ),
-                Error::<Test>::InvalidLastValidProofBlockNumber
-            );
-        });
-    }
-
-    #[test]
-    fn update_last_valid_proof_fails_if_trying_to_set_less_than_previous_value() {
-        ExtBuilder::build().execute_with(|| {
-            let alice: AccountId = 0;
-            let bob: AccountId = 1;
-
-            // Register Alice as a BSP with 100 units of data and get her BSP ID
-            register_account_as_bsp(alice, 100);
-            let alice_bsp_id =
-                <StorageProviders as ProvidersInterface>::get_provider_id(alice).unwrap();
-
-            // Create a payment stream from Bob to Alice of 10 units per block
-            let rate: BalanceOf<Test> = 10;
-            assert_ok!(
-                <PaymentStreams as PaymentStreamsInterface>::create_payment_stream(
-                    &alice_bsp_id,
-                    &bob,
-                    rate
-                )
-            );
-
-            // Set the last valid proof of the payment stream from Bob to Alice to 10 blocks ahead
-            run_to_block(System::block_number() + 10);
-            assert_ok!(
-                <PaymentStreams as PaymentManager>::update_last_chargeable_block(
-                    &alice_bsp_id,
-                    &bob,
-                    System::block_number()
-                )
-            );
-
-            // Try to set the last valid proof of the payment stream from Bob to Alice to a block number less than the last valid proof block number already set
-            assert_noop!(
-                <PaymentStreams as PaymentManager>::update_last_chargeable_block(
-                    &alice_bsp_id,
-                    &bob,
-                    System::block_number() - 1
-                ),
-                Error::<Test>::InvalidLastValidProofBlockNumber
-            );
-        });
+                // Try to set the last valid proof of the payment stream from Bob to Alice to a block number less than the last valid proof block number already set
+                assert_noop!(
+                    <PaymentStreams as PaymentManager>::update_last_chargeable_block(
+                        &alice_bsp_id,
+                        &bob,
+                        System::block_number() - 1
+                    ),
+                    Error::<Test>::InvalidLastChargeableBlockNumber
+                );
+            });
+        }
     }
 }
 

--- a/pallets/payment-streams/src/tests.rs
+++ b/pallets/payment-streams/src/tests.rs
@@ -2090,7 +2090,7 @@ mod dynamic_rate_streams {
         }
 
         #[test]
-        fn update_payment_stream_fails_if_new_rate_is_zero() {
+        fn update_payment_stream_fails_if_new_amount_is_zero() {
             ExtBuilder::build().execute_with(|| {
                 let alice: AccountId = 0;
                 let bob: AccountId = 1;
@@ -2129,7 +2129,7 @@ mod dynamic_rate_streams {
         }
 
         #[test]
-        fn update_payment_stream_fails_if_new_rate_is_equal_to_old_rate() {
+        fn update_payment_stream_fails_if_new_amount_is_equal_to_old_amount() {
             ExtBuilder::build().execute_with(|| {
                 let alice: AccountId = 0;
                 let bob: AccountId = 1;
@@ -2283,7 +2283,7 @@ mod dynamic_rate_streams {
         }
 
         #[test]
-        fn updated_payment_stream_charges_pending_blocks_with_old_rate() {
+        fn updated_payment_stream_charges_pending_blocks_with_old_amount() {
             ExtBuilder::build().execute_with(|| {
                 let alice: AccountId = 0;
                 let bob: AccountId = 1;
@@ -2730,8 +2730,8 @@ mod dynamic_rate_streams {
         }
 
         #[test]
-        fn charge_payment_streams_correctly_updates_last_chargeable_proof_to_last_chargeable_block()
-        {
+        fn charge_payment_streams_correctly_updates_last_charged_price_index_to_last_chargeable_one(
+        ) {
             ExtBuilder::build().execute_with(|| {
                 let alice: AccountId = 0;
                 let bob: AccountId = 1;
@@ -2811,7 +2811,7 @@ mod dynamic_rate_streams {
         }
 
         #[test]
-        fn charge_payment_streams_correctly_uses_the_latest_rate() {
+        fn charge_payment_streams_correctly_uses_the_latest_amount() {
             ExtBuilder::build().execute_with(|| {
                 let alice: AccountId = 0;
                 let bob: AccountId = 1;

--- a/pallets/payment-streams/src/types.rs
+++ b/pallets/payment-streams/src/types.rs
@@ -15,6 +15,7 @@ pub struct FixedRatePaymentStream<T: Config> {
     pub rate: BalanceOf<T>,
     pub last_charged_block: BlockNumberFor<T>,
     pub last_chargeable_block: BlockNumberFor<T>,
+    pub user_deposit: BalanceOf<T>,
 }
 
 /// Structure that has the Dynamic-Rate Payment Stream information
@@ -24,6 +25,7 @@ pub struct DynamicRatePaymentStream<T: Config> {
     pub amount_provided: UnitsProvidedFor<T>,
     pub price_index_when_last_charged: BalanceOf<T>,
     pub price_index_at_last_chargeable_block: BalanceOf<T>,
+    pub user_deposit: BalanceOf<T>,
 }
 
 // Type aliases:

--- a/pallets/payment-streams/src/types.rs
+++ b/pallets/payment-streams/src/types.rs
@@ -8,14 +8,22 @@ use frame_system::pallet_prelude::BlockNumberFor;
 use scale_info::TypeInfo;
 use storage_hub_traits::ProvidersInterface;
 
-/// Structure that has the payment stream information
+/// Structure that has the Fixed-Rate Payment Stream information
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, RuntimeDebugNoBound, PartialEq, Eq, Clone)]
 #[scale_info(skip_type_params(T))]
-pub struct PaymentStream<T: Config> {
+pub struct FixedRatePaymentStream<T: Config> {
     pub rate: BalanceOf<T>,
-    pub last_valid_proof: BlockNumberFor<T>,
-    pub last_charged_proof: BlockNumberFor<T>,
-    // todo!("add relevant fields here")
+    pub last_charged_block: BlockNumberFor<T>,
+    pub last_chargeable_block: BlockNumberFor<T>,
+}
+
+/// Structure that has the Dynamic-Rate Payment Stream information
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, RuntimeDebugNoBound, PartialEq, Eq, Clone)]
+#[scale_info(skip_type_params(T))]
+pub struct DynamicRatePaymentStream<T: Config> {
+    pub amount_provided: UnitsProvidedFor<T>,
+    pub price_index_when_last_charged: BalanceOf<T>,
+    pub price_index_at_last_chargeable_block: BalanceOf<T>,
 }
 
 // Type aliases:
@@ -23,6 +31,9 @@ pub struct PaymentStream<T: Config> {
 /// BalanceOf is the balance type of the runtime.
 pub type BalanceOf<T> =
     <<T as Config>::NativeBalance as Inspect<<T as frame_system::Config>::AccountId>>::Balance;
+
+/// UnitsProvidedFor is the type of the units provided by the provider.
+pub type UnitsProvidedFor<T> = <T as Config>::Units;
 
 /// Syntactic sugar for the ProviderId type used in the proofs pallet.
 pub type ProviderIdFor<T> =

--- a/pallets/payment-streams/src/utils.rs
+++ b/pallets/payment-streams/src/utils.rs
@@ -181,6 +181,8 @@ where
         // Check if the new rate is lower or higher than the current one
         // If the new rate is lower than the current one, we should release the difference in deposit
         // If the new rate is higher than the current one, we should hold the difference in deposit
+        // TODO: we should probably keep track of user deposits since the runtime constant `NewStreamDeposit` could be changed in a runtime
+        // upgrade. This is a potential security issue.
         if new_rate < payment_stream.rate {
             // Calculate the difference in deposit
             let difference_in_deposit = payment_stream
@@ -283,36 +285,297 @@ where
             .ok_or(ArithmeticError::Underflow)?;
         RegisteredUsers::<T>::insert(user_account, user_payment_streams_count);
 
-        // TODO: Release the deposit of this payment stream to the User
+        // Release the deposit of this payment stream to the User
+        // TODO: The same as in the `update_fixed_rate_payment_stream`: we should keep track of user deposits since the runtime constant `NewStreamDeposit`
+        // could be changed in a runtime upgrade. This is a potential security issue.
+        let deposit = FixedRatePaymentStreams::<T>::get(provider_id, user_account)
+            .ok_or(Error::<T>::PaymentStreamNotFound)?
+            .rate
+            .checked_mul(&T::BlockNumberToBalance::convert(T::NewStreamDeposit::get()))
+            .ok_or(ArithmeticError::Overflow)?;
+        T::NativeBalance::release(
+            &HoldReason::PaymentStreamDeposit.into(),
+            &user_account,
+            deposit,
+            Precision::Exact,
+        )?;
 
         Ok(())
     }
 
     /// This function holds the logic that checks if a dynamic-rate payment stream can be created and, if so, stores the payment
     /// stream in the DynamicRatePaymentStreams mapping and holds the deposit from the User.
-    fn do_create_dynamic_rate_payment_stream(
+    pub fn do_create_dynamic_rate_payment_stream(
         provider_id: &ProviderIdFor<T>,
         user_account: &T::AccountId,
         amount_provided: UnitsProvidedFor<T>,
+        current_price: BalanceOf<T>,
+        current_accumulated_price_index: BalanceOf<T>,
     ) -> DispatchResult {
-        // TODO: Implement this
+        // Check that the given ID belongs to an actual Provider
+        ensure!(
+            <T::ProvidersPallet as ProvidersInterface>::is_provider(*provider_id),
+            Error::<T>::NotAProvider
+        );
+
+        // Check that the given amount provided is not 0
+        ensure!(amount_provided != Zero::zero(), Error::<T>::RateCantBeZero);
+
+        // Check that a dynamic-rate payment stream between that Provider and User does not exist yet
+        ensure!(
+            !DynamicRatePaymentStreams::<T>::contains_key(provider_id, user_account),
+            Error::<T>::PaymentStreamAlreadyExists
+        );
+
+        // Check that the User is not flagged as without funds
+        ensure!(
+            !UsersWithoutFunds::<T>::contains_key(user_account),
+            Error::<T>::UserWithoutFunds
+        );
+
+        // Check that the user has enough balance to pay the deposit
+        // Deposit is: `amount_provided * current_price * NewStreamDeposit` where:
+        // - `amount_provided` is the amount of units of something (for example, storage) that are provided by the Provider to the User
+        // - `current_price` is the current price of the units of something (per unit per block)
+        // - `NewStreamDeposit` is a runtime constant that represents the number of blocks that the deposit should cover
+        let user_balance = T::NativeBalance::reducible_balance(
+            &user_account,
+            Preservation::Preserve,
+            Fortitude::Polite,
+        );
+        let deposit = current_price
+            .checked_mul(&amount_provided.into())
+            .ok_or(ArithmeticError::Overflow)?
+            .checked_mul(&T::BlockNumberToBalance::convert(T::NewStreamDeposit::get()))
+            .ok_or(ArithmeticError::Overflow)?;
+        ensure!(user_balance >= deposit, Error::<T>::CannotHoldDeposit);
+
+        // Check if we can hold the deposit from the User
+        ensure!(
+            T::NativeBalance::can_hold(
+                &HoldReason::PaymentStreamDeposit.into(),
+                &user_account,
+                deposit
+            ),
+            Error::<T>::CannotHoldDeposit
+        );
+
+        // Hold the deposit from the User
+        T::NativeBalance::hold(
+            &HoldReason::PaymentStreamDeposit.into(),
+            &user_account,
+            deposit,
+        )?;
+
+        // Add one to the user's payment streams count
+        RegisteredUsers::<T>::mutate(user_account, |user_payment_streams_count| {
+            *user_payment_streams_count = user_payment_streams_count
+                .checked_add(1)
+                .ok_or(ArithmeticError::Overflow)?;
+            Ok::<(), DispatchError>(())
+        })?;
+
+        // Store the new dynamic-rate payment stream in the DynamicRatePaymentStreams mapping
+        // We initiate the `price_index_when_last_charged` and `price_index_at_last_chargeable_block` with the current price index to be able to keep track of the
+        // price changes since the payment stream was originally created.
+        DynamicRatePaymentStreams::<T>::insert(
+            provider_id,
+            user_account,
+            DynamicRatePaymentStream {
+                amount_provided,
+                price_index_when_last_charged: current_accumulated_price_index,
+                price_index_at_last_chargeable_block: current_accumulated_price_index,
+            },
+        );
+
         Ok(())
     }
 
-    fn do_update_dynamic_rate_payment_stream(
+    /// This function holds the logic that checks if a dynamic-rate payment stream can be updated and, if so, updates it in the DynamicRatePaymentStreams mapping.
+    /// The function also takes care of releasing or holding the difference in deposit from the User depending on the new amount provided.
+    pub fn do_update_dynamic_rate_payment_stream(
         provider_id: &ProviderIdFor<T>,
         user_account: &T::AccountId,
         new_amount_provided: UnitsProvidedFor<T>,
+        current_price: BalanceOf<T>,
     ) -> DispatchResult {
-        // TODO: Implement this
+        // Check that the given ID belongs to an actual Provider
+        ensure!(
+            <T::ProvidersPallet as ProvidersInterface>::is_provider(*provider_id),
+            Error::<T>::NotAProvider
+        );
+
+        // Ensure that the new amount provided is not 0 (should use remove_dynamic_rate_payment_stream instead)
+        ensure!(
+            new_amount_provided != Zero::zero(),
+            Error::<T>::AmountProvidedCantBeZero
+        );
+
+        // Check that a dynamic-rate payment stream between the Provider and User exists
+        ensure!(
+            DynamicRatePaymentStreams::<T>::contains_key(provider_id, user_account),
+            Error::<T>::PaymentStreamNotFound
+        );
+
+        // Get the information of the payment stream
+        let payment_stream = DynamicRatePaymentStreams::<T>::get(provider_id, user_account)
+            .ok_or(Error::<T>::PaymentStreamNotFound)?;
+
+        // Verify that the new amount provided is different from the current one
+        ensure!(
+            payment_stream.amount_provided != new_amount_provided,
+            Error::<T>::UpdateAmountToSameAmount
+        );
+
+        // Check that the user is not flagged as without funds
+        ensure!(
+            !UsersWithoutFunds::<T>::contains_key(user_account),
+            Error::<T>::UserWithoutFunds
+        );
+
+        // Charge the payment stream with the old amount before updating it to prevent abuse
+        let amount_charged = Self::do_charge_payment_streams(&provider_id, user_account)?;
+        if amount_charged > Zero::zero() {
+            // We emit a payment charged event only if the user had to pay before the payment stream could be updated
+            Self::deposit_event(Event::<T>::PaymentStreamCharged {
+                user_account: user_account.clone(),
+                provider_id: *provider_id,
+                amount: amount_charged,
+            });
+        }
+
+        // Check if the new amount provided is lower or higher than the current one
+        // If the new amount is lower than the current one, we should release the difference in deposit
+        // If the new amount is higher than the current one, we should hold the difference in deposit
+        // TODO: we should probably keep track of user deposits since the runtime constant `NewStreamDeposit` could be changed in a runtime
+        // upgrade AND the current price (used for deposits) might also change. This is a potential security issue.
+        if new_amount_provided < payment_stream.amount_provided {
+            // Calculate the difference in deposit (`(amount_provided - new_amount_provided) * current_price * NewStreamDeposit`)
+            let difference_in_deposit = payment_stream
+                .amount_provided
+                .checked_sub(&new_amount_provided)
+                .ok_or(ArithmeticError::Underflow)?
+                .into()
+                .checked_mul(&current_price)
+                .ok_or(ArithmeticError::Overflow)?
+                .checked_mul(&T::BlockNumberToBalance::convert(T::NewStreamDeposit::get()))
+                .ok_or(ArithmeticError::Overflow)?;
+
+            // Release the difference in deposit from the user
+            T::NativeBalance::release(
+                &HoldReason::PaymentStreamDeposit.into(),
+                &user_account,
+                difference_in_deposit,
+                Precision::Exact,
+            )?;
+        } else if new_amount_provided > payment_stream.amount_provided {
+            // Calculate the difference in deposit (`(new_amount_provided - amount_provided) * current_price * NewStreamDeposit`)
+            let difference_in_deposit = new_amount_provided
+                .checked_sub(&payment_stream.amount_provided)
+                .ok_or(ArithmeticError::Underflow)?
+                .into()
+                .checked_mul(&current_price)
+                .ok_or(ArithmeticError::Overflow)?
+                .checked_mul(&T::BlockNumberToBalance::convert(T::NewStreamDeposit::get()))
+                .ok_or(ArithmeticError::Overflow)?;
+
+            // Check if we can hold the difference in deposit from the user
+            ensure!(
+                T::NativeBalance::can_hold(
+                    &HoldReason::PaymentStreamDeposit.into(),
+                    &user_account,
+                    difference_in_deposit
+                ),
+                Error::<T>::CannotHoldDeposit
+            );
+
+            // Hold the difference in deposit from the user
+            T::NativeBalance::hold(
+                &HoldReason::PaymentStreamDeposit.into(),
+                &user_account,
+                difference_in_deposit,
+            )?;
+        }
+
+        // Update the payment stream in the DynamicRatePaymentStreams mapping
+        DynamicRatePaymentStreams::<T>::mutate(provider_id, user_account, |payment_stream| {
+            let payment_stream = expect_or_err!(
+                payment_stream,
+                "Payment stream should exist if it was found before.",
+                Error::<T>::PaymentStreamNotFound
+            );
+            payment_stream.amount_provided = new_amount_provided;
+            Ok::<(), DispatchError>(())
+        })?;
+
         Ok(())
     }
 
-    fn do_delete_dynamic_rate_payment_stream(
+    /// This function holds the logic that checks if a dynamic-rate payment stream can be deleted and, if so, removes it from the DynamicRatePaymentStreams mapping,
+    /// decreases the user's payment streams count and releases the deposit of that payment stream.
+    pub fn do_delete_dynamic_rate_payment_stream(
         provider_id: &ProviderIdFor<T>,
         user_account: &T::AccountId,
+        current_price: BalanceOf<T>,
     ) -> DispatchResult {
-        // TODO: Implement this
+        // Check that the given ID belongs to an actual Provider
+        ensure!(
+            <T::ProvidersPallet as ProvidersInterface>::is_provider(*provider_id),
+            Error::<T>::NotAProvider
+        );
+
+        // Check that a dynamic-rate payment stream between that Provider and User exists
+        ensure!(
+            DynamicRatePaymentStreams::<T>::contains_key(provider_id, user_account),
+            Error::<T>::PaymentStreamNotFound
+        );
+
+        // TODO: What do we do when a user is flagged as without funds? Does the provider assume the loss and we remove the payment stream?
+        // Check that the user is not flagged as without funds
+        ensure!(
+            !UsersWithoutFunds::<T>::contains_key(user_account),
+            Error::<T>::UserWithoutFunds
+        );
+
+        // Charge the payment stream before deletion to make sure the services provided by the Provider is paid in full for its duration
+        let amount_charged = Self::do_charge_payment_streams(&provider_id, user_account)?;
+        if amount_charged > Zero::zero() {
+            // We emit a payment charged event only if the user had to pay before being able to delete the payment stream
+            Self::deposit_event(Event::<T>::PaymentStreamCharged {
+                user_account: user_account.clone(),
+                provider_id: *provider_id,
+                amount: amount_charged,
+            });
+        }
+
+        // Remove the payment stream from the DynamicRatePaymentStreams mapping
+        DynamicRatePaymentStreams::<T>::remove(provider_id, user_account);
+
+        // Decrease the user's payment streams count
+        let mut user_payment_streams_count = RegisteredUsers::<T>::get(user_account);
+        user_payment_streams_count = user_payment_streams_count
+            .checked_sub(1)
+            .ok_or(ArithmeticError::Underflow)?;
+        RegisteredUsers::<T>::insert(user_account, user_payment_streams_count);
+
+        // Release the deposit of this payment stream to the User
+        // TODO: The same as in the `update_dynamic_rate_payment_stream`: we should keep track of user deposits since the runtime constant `NewStreamDeposit`
+        // could be changed in a runtime upgrade and current price might change. This is a potential security issue.
+        let deposit = DynamicRatePaymentStreams::<T>::get(provider_id, user_account)
+            .ok_or(Error::<T>::PaymentStreamNotFound)?
+            .amount_provided
+            .into()
+            .checked_mul(&current_price)
+            .ok_or(ArithmeticError::Overflow)?
+            .checked_mul(&T::BlockNumberToBalance::convert(T::NewStreamDeposit::get()))
+            .ok_or(ArithmeticError::Overflow)?;
+        T::NativeBalance::release(
+            &HoldReason::PaymentStreamDeposit.into(),
+            &user_account,
+            deposit,
+            Precision::Exact,
+        )?;
+
         Ok(())
     }
 
@@ -453,7 +716,7 @@ impl<T: pallet::Config> PaymentStreamsInterface for pallet::Pallet<T> {
         user_account: &Self::AccountId,
         rate: <Self::Balance as Inspect<Self::AccountId>>::Balance,
     ) -> DispatchResult {
-        // Execute the logic to create a payment stream
+        // Execute the logic to create a fixed-rate payment stream
         Self::do_create_fixed_rate_payment_stream(provider_id, user_account, rate)?;
 
         // Emit the corresponding event
@@ -472,7 +735,7 @@ impl<T: pallet::Config> PaymentStreamsInterface for pallet::Pallet<T> {
         user_account: &Self::AccountId,
         new_rate: <Self::Balance as Inspect<Self::AccountId>>::Balance,
     ) -> DispatchResult {
-        // Execute the logic to update a payment stream
+        // Execute the logic to update a fixed-rate payment stream
         Self::do_update_fixed_rate_payment_stream(provider_id, user_account, new_rate)?;
 
         // Emit the corresponding event
@@ -490,7 +753,7 @@ impl<T: pallet::Config> PaymentStreamsInterface for pallet::Pallet<T> {
         provider_id: &Self::ProviderId,
         user_account: &Self::AccountId,
     ) -> DispatchResult {
-        // Execute the logic to delete a payment stream
+        // Execute the logic to delete a fixed-rate payment stream
         Self::do_delete_fixed_rate_payment_stream(provider_id, user_account)?;
 
         // Emit the corresponding event
@@ -515,8 +778,26 @@ impl<T: pallet::Config> PaymentStreamsInterface for pallet::Pallet<T> {
         provider_id: &Self::ProviderId,
         user_account: &Self::AccountId,
         amount_provided: &Self::Units,
+        current_price: <Self::Balance as Inspect<Self::AccountId>>::Balance,
+        current_accumulated_price_index: <Self::Balance as Inspect<Self::AccountId>>::Balance,
     ) -> DispatchResult {
-        // TODO: Implement the logic to create a dynamic-rate payment stream
+        // Execute the logic to create a dynamic-rate payment stream
+        Self::do_create_dynamic_rate_payment_stream(
+            provider_id,
+            user_account,
+            amount_provided.clone(),
+            current_price,
+            current_accumulated_price_index,
+        )?;
+
+        // Emit the corresponding event
+        Self::deposit_event(Event::<T>::DynamicRatePaymentStreamCreated {
+            user_account: user_account.clone(),
+            provider_id: *provider_id,
+            amount_provided: *amount_provided,
+        });
+
+        // Return a successful DispatchResult
         Ok(())
     }
 
@@ -524,16 +805,42 @@ impl<T: pallet::Config> PaymentStreamsInterface for pallet::Pallet<T> {
         provider_id: &Self::ProviderId,
         user_account: &Self::AccountId,
         new_amount_provided: &Self::Units,
+        current_price: <Self::Balance as Inspect<Self::AccountId>>::Balance,
     ) -> DispatchResult {
-        // TODO: Implement the logic to update a dynamic-rate payment stream
+        // Execute the logic to update a dynamic-rate payment stream
+        Self::do_update_dynamic_rate_payment_stream(
+            &provider_id,
+            &user_account,
+            new_amount_provided.clone(),
+            current_price,
+        )?;
+
+        // Emit the corresponding event
+        Self::deposit_event(Event::<T>::DynamicRatePaymentStreamUpdated {
+            user_account: user_account.clone(),
+            provider_id: *provider_id,
+            new_amount_provided: *new_amount_provided,
+        });
+
+        // Return a successful DispatchResult
         Ok(())
     }
 
     fn delete_dynamic_rate_payment_stream(
         provider_id: &Self::ProviderId,
         user_account: &Self::AccountId,
+        current_price: <Self::Balance as Inspect<Self::AccountId>>::Balance,
     ) -> DispatchResult {
-        // TODO: Implement the logic to delete a dynamic-rate payment stream
+        // Execute the logic to delete a dynamic-rate payment stream
+        Self::do_delete_dynamic_rate_payment_stream(&provider_id, &user_account, current_price)?;
+
+        // Emit the corresponding event
+        Self::deposit_event(Event::<T>::DynamicRatePaymentStreamDeleted {
+            user_account: user_account.clone(),
+            provider_id: *provider_id,
+        });
+
+        // Return a successful DispatchResult
         Ok(())
     }
 
@@ -607,7 +914,43 @@ impl<T: pallet::Config> PaymentManager for pallet::Pallet<T> {
         user_account: &Self::AccountId,
         new_last_chargeable_price_index: <Self::Balance as frame_support::traits::fungible::Inspect<Self::AccountId>>::Balance,
     ) -> DispatchResult {
-        // TODO: Implement this
+        // Check that the given ID belongs to an actual Provider
+        ensure!(
+            <T::ProvidersPallet as ProvidersInterface>::is_provider(*provider_id),
+            Error::<T>::NotAProvider
+        );
+
+        // Get the information of the payment stream to update
+        let payment_stream = DynamicRatePaymentStreams::<T>::get(provider_id, user_account)
+            .ok_or(Error::<T>::PaymentStreamNotFound)?;
+
+        // Ensure that the new last chargeable price index that is being set is greater than the previous last chargeable price index of the payment stream
+        // (it does not make sense to update it to the same or a lower value)
+        ensure!(
+            new_last_chargeable_price_index > payment_stream.price_index_at_last_chargeable_block,
+            Error::<T>::InvalidLastChargeablePriceIndex
+        );
+
+        // Ensure that the new last chargeable price index is greater than the last charged price index of the payment stream
+        expect_or_err!(
+            new_last_chargeable_price_index > payment_stream.price_index_when_last_charged,
+            "Last chargeable price index (which was checked previously) should always be greater than or equal to the last charged price index.",
+            Error::<T>::LastChargedGreaterThanLastChargeable,
+            bool
+        );
+
+        // Update the last chargeable price index of the payment stream
+        FixedRatePaymentStreams::<T>::mutate(provider_id, user_account, |payment_stream| {
+            let payment_stream = expect_or_err!(
+                payment_stream,
+                "Payment stream should exist if it was found before.",
+                Error::<T>::PaymentStreamNotFound
+            );
+            payment_stream.price_index_at_last_chargeable_block = new_last_chargeable_price_index;
+            Ok::<(), DispatchError>(())
+        })?;
+
+        // Return a successful DispatchResult
         Ok(())
     }
 }

--- a/pallets/payment-streams/src/utils.rs
+++ b/pallets/payment-streams/src/utils.rs
@@ -696,7 +696,10 @@ where
         }
 
         // If the dynamic-rate payment stream exists:
-        if let Some(dynamic_rate_payment_stream) = dynamic_rate_payment_stream {}
+        if let Some(_dynamic_rate_payment_stream) = dynamic_rate_payment_stream {
+            // TODO: Implement the logic to charge dynamic-rate payment streams
+            todo!();
+        }
 
         Ok(total_amount_charged)
     }
@@ -940,7 +943,7 @@ impl<T: pallet::Config> PaymentManager for pallet::Pallet<T> {
         );
 
         // Update the last chargeable price index of the payment stream
-        FixedRatePaymentStreams::<T>::mutate(provider_id, user_account, |payment_stream| {
+        DynamicRatePaymentStreams::<T>::mutate(provider_id, user_account, |payment_stream| {
             let payment_stream = expect_or_err!(
                 payment_stream,
                 "Payment stream should exist if it was found before.",

--- a/pallets/payment-streams/src/utils.rs
+++ b/pallets/payment-streams/src/utils.rs
@@ -478,16 +478,6 @@ where
             });
         }
 
-        // Remove the payment stream from the DynamicRatePaymentStreams mapping
-        DynamicRatePaymentStreams::<T>::remove(provider_id, user_account);
-
-        // Decrease the user's payment streams count
-        let mut user_payment_streams_count = RegisteredUsers::<T>::get(user_account);
-        user_payment_streams_count = user_payment_streams_count
-            .checked_sub(1)
-            .ok_or(ArithmeticError::Underflow)?;
-        RegisteredUsers::<T>::insert(user_account, user_payment_streams_count);
-
         // Release the deposit of this payment stream to the User
         let deposit = DynamicRatePaymentStreams::<T>::get(provider_id, user_account)
             .ok_or(Error::<T>::PaymentStreamNotFound)?
@@ -498,6 +488,16 @@ where
             deposit,
             Precision::Exact,
         )?;
+
+        // Remove the payment stream from the DynamicRatePaymentStreams mapping
+        DynamicRatePaymentStreams::<T>::remove(provider_id, user_account);
+
+        // Decrease the user's payment streams count
+        let mut user_payment_streams_count = RegisteredUsers::<T>::get(user_account);
+        user_payment_streams_count = user_payment_streams_count
+            .checked_sub(1)
+            .ok_or(ArithmeticError::Underflow)?;
+        RegisteredUsers::<T>::insert(user_account, user_payment_streams_count);
 
         Ok(())
     }

--- a/pallets/providers/src/lib.rs
+++ b/pallets/providers/src/lib.rs
@@ -8,7 +8,7 @@
 //! the network and get rewarded for it.
 #![cfg_attr(not(feature = "std"), no_std)]
 
-mod types;
+pub mod types;
 mod utils;
 
 #[cfg(feature = "runtime-benchmarks")]

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -399,7 +399,7 @@ impl pallet_storage_providers::Config for Runtime {
 }
 
 parameter_types! {
-    pub const PaymentStreamHoldReason: RuntimeHoldReason = RuntimeHoldReason::PaymentStreams(pallet_payment_streams::HoldReason::PaymentStreamStorageDeposit);
+    pub const PaymentStreamHoldReason: RuntimeHoldReason = RuntimeHoldReason::PaymentStreams(pallet_payment_streams::HoldReason::PaymentStreamDeposit);
 }
 
 // Converter from the BlockNumber type to the Balance type for math
@@ -416,7 +416,8 @@ impl pallet_payment_streams::Config for Runtime {
     type NativeBalance = Balances;
     type ProvidersPallet = Providers;
     type RuntimeHoldReason = RuntimeHoldReason;
-    type NewUserDeposit = ConstU128<10>;
+    type NewStreamDeposit = ConstU32<10>; // Amount of blocks that the deposit of a new stream should be able to pay for
+    type Units = u32; // Storage unit
     type BlockNumberToBalance = BlockNumberToBalance;
 }
 

--- a/support/traits/src/lib.rs
+++ b/support/traits/src/lib.rs
@@ -364,7 +364,6 @@ pub trait PaymentStreamsInterface {
     fn delete_dynamic_rate_payment_stream(
         provider_id: &Self::ProviderId,
         user_account: &Self::AccountId,
-        current_price: <Self::Balance as fungible::Inspect<Self::AccountId>>::Balance,
     ) -> DispatchResult;
 
     /// Get the dynamic-rate payment stream information between a User and a Provider

--- a/support/traits/src/lib.rs
+++ b/support/traits/src/lib.rs
@@ -348,6 +348,8 @@ pub trait PaymentStreamsInterface {
         provider_id: &Self::ProviderId,
         user_account: &Self::AccountId,
         amount_provided: &Self::Units,
+        current_price: <Self::Balance as fungible::Inspect<Self::AccountId>>::Balance,
+        current_accumulated_price_index: <Self::Balance as fungible::Inspect<Self::AccountId>>::Balance,
     ) -> DispatchResult;
 
     /// Update the amount provided of an existing dynamic-rate payment stream.
@@ -355,12 +357,14 @@ pub trait PaymentStreamsInterface {
         provider_id: &Self::ProviderId,
         user_account: &Self::AccountId,
         new_amount_provided: &Self::Units,
+        current_price: <Self::Balance as fungible::Inspect<Self::AccountId>>::Balance,
     ) -> DispatchResult;
 
     /// Delete a dynamic-rate payment stream.
     fn delete_dynamic_rate_payment_stream(
         provider_id: &Self::ProviderId,
         user_account: &Self::AccountId,
+        current_price: <Self::Balance as fungible::Inspect<Self::AccountId>>::Balance,
     ) -> DispatchResult;
 
     /// Get the dynamic-rate payment stream information between a User and a Provider


### PR DESCRIPTION
Huuuuge PR that completely revamps the `payment-streams` pallet logic to be generalized over a generic Provider instead of being tightly tied with specifically ___storage___ providers.

This PR:
- Makes the `payment-streams` pallet able to manage two different types of payment streams: fixed-rate (useful in our case for MSPs) and dynamic-rate (useful in our case for BSPs) payment streams.
    - Fixed-rate payment streams are the ones where there's a type of contract between the Provider and the User, where the Provider agrees to Provider X amount of units of something to the User for a fixed rate of tokens per unit per block. This payment stream CAN be updated (to update the rate, for example if the contract conditions change), it is fixed in the sense of a steady rate that only changes by external intervention.
    - Dynamic-rate payment streams are the ones where the price of the provided good is a global, common price, it is not controllable by either party and can change over time. For this streams, we use a price index to keep track of this variations of the global price, to always charge Users/pay Providers exactly what we should. You can think of the price index as the total price that a user would have paid until now to store one unit of data since genesis.
- Implements the correct deposit logic for new payment streams, to hold from users an amount that's enough to pay for `NewStreamDeposit` amount of blocks (being this a runtime constant). An off-chain worker or another maintenance tool should be run to periodically check users that haven't been charged in a long time, and this period should be at least equal to `NewStreamDeposit` blocks, if not less.
- Updates all traits and interfaces to handle this new flexibility.

TODOs:
- [x] Implement the functionality to charge dynamic-rate streams in `do_charge_payment_streams`
- [x] Implement keeping track of users deposit per-stream
- [x] Fix error in fixed-rate payment streams' tests
- [x] Write tests for dynamic-rate payment streams
