### PR TITLE
refactor: Unify shared runtime and client types part 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12400,9 +12400,11 @@ name = "shc-file-manager"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "parity-scale-codec",
  "reference-trie",
  "shc-actors-framework",
  "shc-common",
+ "shp-traits",
  "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-v1.9.0)",
  "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git)",
  "trie-db 0.29.1",
@@ -14547,7 +14549,6 @@ dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
  "async-io 2.3.2",
- "bincode",
  "clap",
  "color-print",
  "cumulus-client-cli",

--- a/client/common/src/types.rs
+++ b/client/common/src/types.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use codec::{Decode, Encode};
-use serde::{Deserialize, Serialize};
+pub use shp_file_key_verifier::{Chunk, ChunkId, Leaf};
 use shp_traits::CommitmentVerifier;
 use sp_core::Hasher;
 use sp_trie::CompactProof;
@@ -13,81 +13,17 @@ use trie_db::TrieLayout;
 pub type HashT<T> = <T as TrieLayout>::Hash;
 pub type HasherOutT<T> = <<T as TrieLayout>::Hash as Hasher>::Out;
 
-/// FileKey is the identifier for a file.
-/// Computed as the hash of the FileMetadata.
-#[derive(
-    Encode, Decode, Clone, Copy, Debug, PartialEq, Eq, Default, Hash, Serialize, Deserialize,
-)]
-pub struct FileKey(Hash);
-
-impl From<Hash> for FileKey {
-    fn from(hash: Hash) -> Self {
-        Self(hash)
-    }
-}
-
-impl Into<Hash> for FileKey {
-    fn into(self) -> Hash {
-        self.0
-    }
-}
-
-impl From<&[u8]> for FileKey {
-    fn from(bytes: &[u8]) -> Self {
-        let mut hash = [0u8; 32];
-        hash.copy_from_slice(&bytes);
-        Self(hash)
-    }
-}
-
-impl AsRef<[u8]> for FileKey {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
-}
-
-impl From<&[u8; 32]> for FileKey {
-    fn from(bytes: &[u8; 32]) -> Self {
-        Self(*bytes)
-    }
-}
-
-impl AsRef<[u8; 32]> for FileKey {
-    fn as_ref(&self) -> &[u8; 32] {
-        &self.0
-    }
-}
-
 /// Following types are shared between the client and the runtime.
 /// They are defined as generic types in the runtime and made concrete using the runtime config
 /// here to be used by the node/client.
-pub type KeyVerifier = <Runtime as pallet_proofs_dealer::Config>::KeyVerifier;
-pub type FileKeyProof = <KeyVerifier as CommitmentVerifier>::Proof;
+pub type FileKeyVerifier = <Runtime as pallet_proofs_dealer::Config>::KeyVerifier;
+pub type FileKeyProof = <FileKeyVerifier as CommitmentVerifier>::Proof;
 
 pub type Hash = shp_file_key_verifier::Hash<H_LENGTH>;
 pub type Fingerprint = shp_file_key_verifier::Fingerprint<H_LENGTH>;
 pub type FileMetadata =
     shp_file_key_verifier::FileMetadata<H_LENGTH, FILE_CHUNK_SIZE, FILE_SIZE_TO_CHALLENGES>;
-
-/// Typed u64 representing the index of a file [`Chunk`]. Indexed from 0.
-pub type ChunkId = u64;
-
-// TODO: this is currently a placeholder in order to define Storage interface.
-/// Typed chunk of a file. This is what is stored in the leaf of the stored Merkle tree.
-pub type Chunk = Vec<u8>;
-
-/// Leaf in the Forest or File trie.
-#[derive(Clone, Serialize, Deserialize)]
-pub struct Leaf<K, D: Debug> {
-    pub key: K,
-    pub data: D,
-}
-
-impl<K, D: Debug> Leaf<K, D> {
-    pub fn new(key: K, data: D) -> Self {
-        Self { key, data }
-    }
-}
+pub type FileKey = shp_file_key_verifier::FileKey<H_LENGTH>;
 
 /// Proving either the exact key or the neighbour keys of the challenged key.
 pub enum Proven<K, D: Debug> {
@@ -121,41 +57,19 @@ pub struct ForestProof<T: TrieLayout> {
     pub root: HasherOutT<T>,
 }
 
-/// Storage proof in compact form.
-#[derive(Clone, Serialize, Deserialize)]
-pub struct SerializableCompactProof {
-    pub encoded_nodes: Vec<Vec<u8>>,
-}
-
-impl From<CompactProof> for SerializableCompactProof {
-    fn from(proof: CompactProof) -> Self {
-        Self {
-            encoded_nodes: proof.encoded_nodes,
-        }
-    }
-}
-
-impl Into<CompactProof> for SerializableCompactProof {
-    fn into(self) -> CompactProof {
-        CompactProof {
-            encoded_nodes: self.encoded_nodes,
-        }
-    }
-}
-
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Encode, Decode)]
 pub struct FileProof {
-    /// The file chunk (and id) that was proven.
-    pub proven: Vec<Leaf<ChunkId, Chunk>>,
     /// The compact proof.
-    pub proof: SerializableCompactProof,
+    pub proof: CompactProof,
     /// The root hash of the trie, also known as the fingerprint of the file.
-    pub root: Fingerprint,
+    pub fingerprint: Fingerprint,
 }
 
 impl FileProof {
-    pub fn verify(&self) -> bool {
-        // TODO: implement this using the verifier from runtime after we have it.
-        true
+    pub fn to_file_key_proof(&self, file_metadata: FileMetadata) -> FileKeyProof {
+        FileKeyProof {
+            proof: self.proof.clone(),
+            file_metadata,
+        }
     }
 }

--- a/client/file-manager/Cargo.toml
+++ b/client/file-manager/Cargo.toml
@@ -15,6 +15,7 @@ publish = false
 workspace = true
 
 [dependencies]
+codec = { workspace = true }
 bincode = { workspace = true }
 reference-trie = { workspace = true }
 trie-db = { workspace = true }
@@ -22,5 +23,6 @@ trie-db = { workspace = true }
 sp-core = { workspace = true }
 sp-trie = { workspace = true, default-features = true }
 
+shp-traits = { workspace = true }
 shc-actors-framework = { workspace = true }
 shc-common = { workspace = true }

--- a/client/file-manager/src/traits.rs
+++ b/client/file-manager/src/traits.rs
@@ -1,4 +1,4 @@
-use shc_common::types::{Chunk, ChunkId, FileMetadata, FileProof, HasherOutT};
+use shc_common::types::{Chunk, ChunkId, FileKeyProof, FileMetadata, FileProof, HasherOutT};
 use trie_db::TrieLayout;
 
 #[derive(Debug)]
@@ -77,7 +77,7 @@ pub trait FileStorage<T: TrieLayout>: 'static {
         &self,
         key: &HasherOutT<T>,
         chunk_id: &Vec<ChunkId>,
-    ) -> Result<FileProof, FileStorageError>;
+    ) -> Result<FileKeyProof, FileStorageError>;
 
     /// Remove a file from storage.
     fn delete_file(&mut self, key: &HasherOutT<T>);

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -6,6 +6,7 @@ use jsonrpsee::types::error::INTERNAL_ERROR_CODE;
 use jsonrpsee::types::error::INTERNAL_ERROR_MSG;
 use jsonrpsee::types::ErrorObjectOwned;
 
+use shc_common::types::ChunkId;
 use shc_common::types::FileMetadata;
 use shc_common::types::FILE_CHUNK_SIZE;
 use sp_runtime::AccountId32;
@@ -101,7 +102,7 @@ where
 
                     // Build the actual [`FileDataTrie`] by inserting each chunk into it.
                     file_data_trie
-                        .write_chunk(&chunk_id, &chunk)
+                        .write_chunk(&ChunkId::new(chunk_id), &chunk)
                         .map_err(into_rpc_error)?;
                     chunk_id += 1;
                 }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -18,7 +18,6 @@ anyhow = { workspace = true }
 array-bytes = { workspace = true }
 async-channel = { workspace = true }
 async-io = { workspace = true }
-bincode = { workspace = true }
 color-print = { workspace = true }
 futures-timer = { workspace = true }
 hex = { workspace = true }

--- a/node/src/services/file_transfer/commands.rs
+++ b/node/src/services/file_transfer/commands.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use sc_network::{Multiaddr, PeerId, ProtocolName, RequestFailure};
 
 use shc_actors_framework::actor::ActorHandle;
-use shc_common::types::{ChunkId, FileKey, FileProof};
+use shc_common::types::{ChunkId, FileKey, FileKeyProof};
 
 use super::{schema, FileTransferService};
 
@@ -14,7 +14,7 @@ pub enum FileTransferServiceCommand {
     UploadRequest {
         peer_id: PeerId,
         file_key: FileKey,
-        chunk_with_proof: FileProof,
+        file_key_proof: FileKeyProof,
         callback: tokio::sync::oneshot::Sender<
             futures::channel::oneshot::Receiver<Result<(Vec<u8>, ProtocolName), RequestFailure>>,
         >,
@@ -69,7 +69,7 @@ pub trait FileTransferServiceInterface {
         &self,
         peer_id: PeerId,
         file_key: FileKey,
-        data: FileProof,
+        file_key_proof: FileKeyProof,
     ) -> Result<schema::v1::provider::RemoteUploadDataResponse, RequestError>;
 
     async fn download_request(
@@ -101,13 +101,13 @@ impl FileTransferServiceInterface for ActorHandle<FileTransferService> {
         &self,
         peer_id: PeerId,
         file_key: FileKey,
-        chunk_with_proof: FileProof,
+        file_key_proof: FileKeyProof,
     ) -> Result<schema::v1::provider::RemoteUploadDataResponse, RequestError> {
         let (callback, file_transfer_rx) = tokio::sync::oneshot::channel();
         let command = FileTransferServiceCommand::UploadRequest {
             peer_id,
             file_key,
-            chunk_with_proof,
+            file_key_proof,
             callback,
         };
         self.send(command).await;

--- a/node/src/services/file_transfer/events.rs
+++ b/node/src/services/file_transfer/events.rs
@@ -1,5 +1,5 @@
 use sc_network::PeerId;
-use shc_common::types::{ChunkId, FileKey, FileProof};
+use shc_common::types::{ChunkId, FileKey, FileKeyProof};
 
 use shc_actors_framework::event_bus::{EventBus, EventBusMessage, ProvidesEventBus};
 
@@ -7,7 +7,7 @@ use shc_actors_framework::event_bus::{EventBus, EventBusMessage, ProvidesEventBu
 pub struct RemoteUploadRequest {
     pub peer: PeerId,
     pub file_key: FileKey,
-    pub chunk_with_proof: FileProof,
+    pub file_key_proof: FileKeyProof,
 }
 
 impl EventBusMessage for RemoteUploadRequest {}

--- a/node/src/services/file_transfer/schema/provider.v1.proto
+++ b/node/src/services/file_transfer/schema/provider.v1.proto
@@ -25,7 +25,7 @@ message RemoteUploadDataRequest {
 	// Location to store data.
 	bytes file_key = 1;
 	// Data to store.
-	bytes file_chunk_with_proof = 2;
+	bytes file_key_proof = 2;
 }
 
 // Remote data upload response.
@@ -45,5 +45,5 @@ message RemoteDownloadDataRequest {
 message RemoteDownloadDataResponse {
 	// Read data stored in provider. No data means that the provider
 	// couldn't retrieve the data at the requested locations.
-	bytes file_chunk_with_proof = 1;
+	bytes file_key_proof = 1;
 }

--- a/node/src/tasks/user_sends_file.rs
+++ b/node/src/tasks/user_sends_file.rs
@@ -7,6 +7,7 @@ use shc_actors_framework::event_bus::EventHandler;
 use shc_common::types::FileMetadata;
 use shc_file_manager::traits::FileStorage;
 use shc_forest_manager::traits::ForestStorage;
+use shp_file_key_verifier::ChunkId;
 use sp_runtime::AccountId32;
 use sp_trie::TrieLayout;
 
@@ -114,7 +115,7 @@ where
                     .file_storage
                     .read()
                     .await
-                    .generate_proof(&file_key, &vec![chunk_id])
+                    .generate_proof(&file_key, &vec![ChunkId::new(chunk_id)])
                     .expect("File is not in storage, or proof does not exist.");
 
                 let upload_response = self

--- a/primitives/file-key-verifier/src/tests.rs
+++ b/primitives/file-key-verifier/src/tests.rs
@@ -10,6 +10,7 @@ use sp_trie::{
 };
 use trie_db::{Hasher, Trie, TrieIterator};
 
+use crate::ChunkId;
 use crate::{FileKeyProof, FileKeyVerifier, FileMetadata, Fingerprint};
 
 /// The hash type of trie node keys
@@ -1038,4 +1039,12 @@ fn commitment_verifier_challenge_with_none_value_failure() {
         >::verify_proof(&file_key, &challenges, &file_key_proof),
         Err("The proof is invalid. The challenged chunk was not found in the trie, possibly because the challenged chunk has an index higher than the amount of chunks in the file. This should not be possible, provided that the size of the file (and therefore number of chunks) is correct.".into())
     );
+}
+
+#[test]
+fn chunk_id_convert_to_and_from_trie_key() {
+    let chunk_id = ChunkId::new(0x12345678u64);
+    let chunk_id_bytes = chunk_id.as_trie_key();
+    let chunk_id_decoded = ChunkId::from_trie_key(&chunk_id_bytes).unwrap();
+    assert_eq!(chunk_id, chunk_id_decoded);
 }


### PR DESCRIPTION
In this PR:
- Move `FileKey`, `Leaf`, `ChunkId`, and `Chunk` to runtime.
- `ChunkId` implements `as_trie_key` and `from_trie_key`.
- `FileStorage` interface now generates proofs for `FileKeyProof` (from runtime) instead of `FileProof`. Note: `FileProof` is kept for `FileDataTrie` still needed for the first steps of uploading a file.
- `FileProof` can be built into a `FileKeyProof` by adding the associated `FileMetadata`.
- `FileStorage` now uses `ChunkId` to/from trie keys, compatible with the runtime (`AsCompact` instead of `be_bytes`).
- Ditch `bincode` for serialize/deserialize of protobuf fields in favor of SCALE.
- Add `verify()` and `proven()` to `FileKeyProof`.
- Received file chunks proofs are now being verified.