### PR TITLE
refactor: :recycle: refactor implementation for default merkle trie root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6707,6 +6707,7 @@ dependencies = [
  "sp-keyring",
  "sp-runtime 31.0.1",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-v1.9.0)",
+ "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git)",
 ]
 
 [[package]]
@@ -7299,6 +7300,7 @@ dependencies = [
  "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-v1.9.0)",
  "sp-io 30.0.0",
  "sp-runtime 31.0.1",
+ "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk.git)",
 ]
 
 [[package]]

--- a/pallets/bucket-nfts/Cargo.toml
+++ b/pallets/bucket-nfts/Cargo.toml
@@ -41,6 +41,7 @@ pallet-storage-providers = { workspace = true }
 # Substrate
 sp-io = { workspace = true }
 sp-keyring = { workspace = true }
+sp-trie = { workspace = true }
 
 # Frame
 pallet-balances = { workspace = true, features = ["std"] }

--- a/pallets/bucket-nfts/src/mock.rs
+++ b/pallets/bucket-nfts/src/mock.rs
@@ -1,3 +1,4 @@
+use core::marker::PhantomData;
 use frame_support::{
     construct_runtime, derive_impl, parameter_types,
     traits::{AsEnsureOriginWithArg, Everything, Randomness},
@@ -8,13 +9,14 @@ use pallet_nfts::PalletFeatures;
 use shp_traits::{
     ProofsDealerInterface, SubscribeProvidersInterface, TrieMutation, TrieRemoveMutation,
 };
-use sp_core::{hashing::blake2_256, ConstU128, ConstU32, ConstU64, Get, H256};
+use sp_core::{hashing::blake2_256, ConstU128, ConstU32, ConstU64, Get, H256, Hasher};
 use sp_keyring::sr25519::Keyring;
 use sp_runtime::{
     traits::{BlakeTwo256, Convert, IdentifyAccount, IdentityLookup, Verify},
     BuildStorage, DispatchResult, FixedPointNumber, FixedU128, MultiSignature, SaturatedConversion,
 };
 use sp_std::collections::btree_set::BTreeSet;
+use sp_trie::{LayoutV1, TrieConfiguration, TrieLayout};
 use system::pallet_prelude::BlockNumberFor;
 
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -234,7 +236,13 @@ parameter_types! {
     pub const MaxMultiAddressSize: u32 = 100;
     pub const MaxMultiAddressAmount: u32 = 5;
 }
-
+pub type HasherOutT<T> = <<T as TrieLayout>::Hash as Hasher>::Out;
+pub struct DefaultMerkleRoot<T>(PhantomData<T>);
+impl<T: TrieConfiguration> Get<HasherOutT<T>> for DefaultMerkleRoot<T> {
+    fn get() -> HasherOutT<T> {
+        sp_trie::empty_trie_root::<T>()
+    }
+}
 impl pallet_storage_providers::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type NativeBalance = Balances;
@@ -242,7 +250,7 @@ impl pallet_storage_providers::Config for Test {
     type StorageData = u32;
     type SpCount = u32;
     type MerklePatriciaRoot = H256;
-    type MerkleTrieHashing = BlakeTwo256;
+    type DefaultMerkleRoot = DefaultMerkleRoot<LayoutV1<BlakeTwo256>>;
     type ValuePropId = H256;
     type ReadAccessGroupId = <Self as pallet_nfts::Config>::CollectionId;
     type MaxMultiAddressSize = MaxMultiAddressSize;

--- a/pallets/bucket-nfts/src/mock.rs
+++ b/pallets/bucket-nfts/src/mock.rs
@@ -9,7 +9,7 @@ use pallet_nfts::PalletFeatures;
 use shp_traits::{
     ProofsDealerInterface, SubscribeProvidersInterface, TrieMutation, TrieRemoveMutation,
 };
-use sp_core::{hashing::blake2_256, ConstU128, ConstU32, ConstU64, Get, H256, Hasher};
+use sp_core::{hashing::blake2_256, ConstU128, ConstU32, ConstU64, Get, Hasher, H256};
 use sp_keyring::sr25519::Keyring;
 use sp_runtime::{
     traits::{BlakeTwo256, Convert, IdentifyAccount, IdentityLookup, Verify},

--- a/pallets/payment-streams/Cargo.toml
+++ b/pallets/payment-streams/Cargo.toml
@@ -37,6 +37,7 @@ pallet-storage-providers = { workspace = true }
 # Substrate
 sp-core = { workspace = true }
 sp-io = { workspace = true }
+sp-trie = { workspace = true }
 
 # Frame
 pallet-balances = { workspace = true, features = ["std"] }

--- a/pallets/payment-streams/src/mock.rs
+++ b/pallets/payment-streams/src/mock.rs
@@ -1,19 +1,22 @@
 use crate as pallet_payment_streams;
+use core::marker::PhantomData;
 use frame_support::{
     construct_runtime, derive_impl, parameter_types,
     traits::{AsEnsureOriginWithArg, Everything, Randomness},
     weights::constants::RocksDbWeight,
+	pallet_prelude::Get
 };
 use frame_system as system;
 use pallet_nfts::PalletFeatures;
 use shp_traits::SubscribeProvidersInterface;
-use sp_core::{hashing::blake2_256, ConstU128, ConstU32, ConstU64, H256};
+use sp_core::{hashing::blake2_256, ConstU128, ConstU32, ConstU64, H256, Hasher};
 use sp_runtime::traits::Convert;
 use sp_runtime::{
     testing::TestSignature,
     traits::{BlakeTwo256, IdentityLookup},
     BuildStorage, DispatchResult,
 };
+use sp_trie::{LayoutV1, TrieConfiguration, TrieLayout};
 use system::pallet_prelude::BlockNumberFor;
 
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -111,6 +114,13 @@ impl pallet_balances::Config for Test {
 parameter_types! {
     pub const StorageProvidersHoldReason: RuntimeHoldReason = RuntimeHoldReason::StorageProviders(pallet_storage_providers::HoldReason::StorageProviderDeposit);
 }
+pub type HasherOutT<T> = <<T as TrieLayout>::Hash as Hasher>::Out;
+pub struct DefaultMerkleRoot<T>(PhantomData<T>);
+impl<T: TrieConfiguration> Get<HasherOutT<T>> for DefaultMerkleRoot<T> {
+    fn get() -> HasherOutT<T> {
+        sp_trie::empty_trie_root::<T>()
+    }
+}
 impl pallet_storage_providers::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type NativeBalance = Balances;
@@ -118,7 +128,7 @@ impl pallet_storage_providers::Config for Test {
     type StorageData = StorageUnit;
     type SpCount = u32;
     type MerklePatriciaRoot = H256;
-    type MerkleTrieHashing = BlakeTwo256;
+    type DefaultMerkleRoot = DefaultMerkleRoot<LayoutV1<BlakeTwo256>>;
     type ValuePropId = H256;
     type ReadAccessGroupId = <Self as pallet_nfts::Config>::CollectionId;
     type MaxMultiAddressSize = ConstU32<100>;

--- a/pallets/payment-streams/src/mock.rs
+++ b/pallets/payment-streams/src/mock.rs
@@ -1,15 +1,16 @@
 use crate as pallet_payment_streams;
 use core::marker::PhantomData;
 use frame_support::{
-    construct_runtime, derive_impl, parameter_types,
+    construct_runtime, derive_impl,
+    pallet_prelude::Get,
+    parameter_types,
     traits::{AsEnsureOriginWithArg, Everything, Randomness},
     weights::constants::RocksDbWeight,
-	pallet_prelude::Get
 };
 use frame_system as system;
 use pallet_nfts::PalletFeatures;
 use shp_traits::SubscribeProvidersInterface;
-use sp_core::{hashing::blake2_256, ConstU128, ConstU32, ConstU64, H256, Hasher};
+use sp_core::{hashing::blake2_256, ConstU128, ConstU32, ConstU64, Hasher, H256};
 use sp_runtime::traits::Convert;
 use sp_runtime::{
     testing::TestSignature,

--- a/pallets/proofs-dealer/src/mock.rs
+++ b/pallets/proofs-dealer/src/mock.rs
@@ -2,10 +2,11 @@
 
 use core::marker::PhantomData;
 use frame_support::{
-    derive_impl, parameter_types,
+    derive_impl,
+    pallet_prelude::Get,
+    parameter_types,
     traits::{Everything, Randomness},
     weights::constants::RocksDbWeight,
-	pallet_prelude::Get
 };
 use frame_system as system;
 use shp_traits::{
@@ -18,7 +19,7 @@ use sp_runtime::{
     BuildStorage, DispatchError, DispatchResult, SaturatedConversion,
 };
 use sp_std::collections::btree_set::BTreeSet;
-use sp_trie::{CompactProof, LayoutV1, MemoryDB, TrieLayout, TrieConfiguration};
+use sp_trie::{CompactProof, LayoutV1, MemoryDB, TrieConfiguration, TrieLayout};
 use system::pallet_prelude::BlockNumberFor;
 
 type Block = frame_system::mocking::MockBlock<Test>;

--- a/pallets/proofs-dealer/src/tests.rs
+++ b/pallets/proofs-dealer/src/tests.rs
@@ -19,7 +19,6 @@ use frame_support::{
     traits::{fungible::Mutate, OnPoll},
     weights::WeightMeter,
 };
-use pallet_storage_providers::types::MerklePatriciaRootDefault;
 use shp_traits::{ProofsDealerInterface, ProvidersInterface, TrieRemoveMutation};
 use sp_core::{blake2_256, Get, Hasher, H256};
 use sp_runtime::{traits::BlakeTwo256, BoundedVec, DispatchError};
@@ -297,8 +296,7 @@ fn challenge_submit_by_registered_provider_with_no_funds_succeed() {
         pallet_storage_providers::BackupStorageProviders::<Test>::mutate(
             &provider_id,
             |provider| {
-                provider.as_mut().expect("Provider should exist").root =
-                    MerklePatriciaRootDefault(root);
+                provider.as_mut().expect("Provider should exist").root = root;
             },
         );
 
@@ -818,8 +816,7 @@ fn submit_proof_success() {
         pallet_storage_providers::BackupStorageProviders::<Test>::mutate(
             &provider_id,
             |provider| {
-                provider.as_mut().expect("Provider should exist").root =
-                    MerklePatriciaRootDefault(root);
+                provider.as_mut().expect("Provider should exist").root = root;
             },
         );
 
@@ -951,8 +948,7 @@ fn submit_proof_submitted_by_not_a_provider_success() {
         pallet_storage_providers::BackupStorageProviders::<Test>::mutate(
             &provider_id,
             |provider| {
-                provider.as_mut().expect("Provider should exist").root =
-                    MerklePatriciaRootDefault(root);
+                provider.as_mut().expect("Provider should exist").root = root;
             },
         );
 
@@ -1042,8 +1038,7 @@ fn submit_proof_with_checkpoint_challenges_success() {
         pallet_storage_providers::BackupStorageProviders::<Test>::mutate(
             &provider_id,
             |provider| {
-                provider.as_mut().expect("Provider should exist").root =
-                    MerklePatriciaRootDefault(root);
+                provider.as_mut().expect("Provider should exist").root = root;
             },
         );
 
@@ -1155,8 +1150,7 @@ fn submit_proof_with_checkpoint_challenges_mutations_success() {
         pallet_storage_providers::BackupStorageProviders::<Test>::mutate(
             &provider_id,
             |provider| {
-                provider.as_mut().expect("Provider should exist").root =
-                    MerklePatriciaRootDefault(root);
+                provider.as_mut().expect("Provider should exist").root = root;
             },
         );
 
@@ -1353,8 +1347,7 @@ fn submit_proof_empty_key_proofs_fail() {
         pallet_storage_providers::BackupStorageProviders::<Test>::mutate(
             &provider_id,
             |provider| {
-                provider.as_mut().expect("Provider should exist").root =
-                    MerklePatriciaRootDefault(root);
+                provider.as_mut().expect("Provider should exist").root = root;
             },
         );
 
@@ -1423,8 +1416,7 @@ fn submit_proof_no_record_of_last_proof_fail() {
         pallet_storage_providers::BackupStorageProviders::<Test>::mutate(
             &provider_id,
             |provider| {
-                provider.as_mut().expect("Provider should exist").root =
-                    MerklePatriciaRootDefault(root);
+                provider.as_mut().expect("Provider should exist").root = root;
             },
         );
 
@@ -1493,8 +1485,7 @@ fn submit_proof_challenges_block_not_reached_fail() {
         pallet_storage_providers::BackupStorageProviders::<Test>::mutate(
             &provider_id,
             |provider| {
-                provider.as_mut().expect("Provider should exist").root =
-                    MerklePatriciaRootDefault(root);
+                provider.as_mut().expect("Provider should exist").root = root;
             },
         );
 
@@ -1570,8 +1561,7 @@ fn submit_proof_challenges_block_too_old_fail() {
         pallet_storage_providers::BackupStorageProviders::<Test>::mutate(
             &provider_id,
             |provider| {
-                provider.as_mut().expect("Provider should exist").root =
-                    MerklePatriciaRootDefault(root);
+                provider.as_mut().expect("Provider should exist").root = root;
             },
         );
 
@@ -1647,8 +1637,7 @@ fn submit_proof_seed_not_found_fail() {
         pallet_storage_providers::BackupStorageProviders::<Test>::mutate(
             &provider_id,
             |provider| {
-                provider.as_mut().expect("Provider should exist").root =
-                    MerklePatriciaRootDefault(root);
+                provider.as_mut().expect("Provider should exist").root = root;
             },
         );
 
@@ -1727,8 +1716,7 @@ fn submit_proof_checkpoint_challenge_not_found_fail() {
         pallet_storage_providers::BackupStorageProviders::<Test>::mutate(
             &provider_id,
             |provider| {
-                provider.as_mut().expect("Provider should exist").root =
-                    MerklePatriciaRootDefault(root);
+                provider.as_mut().expect("Provider should exist").root = root;
             },
         );
 
@@ -1812,8 +1800,7 @@ fn submit_proof_forest_proof_verification_fail() {
         pallet_storage_providers::BackupStorageProviders::<Test>::mutate(
             &provider_id,
             |provider| {
-                provider.as_mut().expect("Provider should exist").root =
-                    MerklePatriciaRootDefault(root);
+                provider.as_mut().expect("Provider should exist").root = root;
             },
         );
 
@@ -1895,8 +1882,7 @@ fn submit_proof_no_key_proofs_for_keys_verified_in_forest_fail() {
         pallet_storage_providers::BackupStorageProviders::<Test>::mutate(
             &provider_id,
             |provider| {
-                provider.as_mut().expect("Provider should exist").root =
-                    MerklePatriciaRootDefault(root);
+                provider.as_mut().expect("Provider should exist").root = root;
             },
         );
 
@@ -1961,8 +1947,7 @@ fn submit_proof_out_checkpoint_challenges_fail() {
         pallet_storage_providers::BackupStorageProviders::<Test>::mutate(
             &provider_id,
             |provider| {
-                provider.as_mut().expect("Provider should exist").root =
-                    MerklePatriciaRootDefault(root);
+                provider.as_mut().expect("Provider should exist").root = root;
             },
         );
 
@@ -2074,8 +2059,7 @@ fn submit_proof_key_proof_verification_fail() {
         pallet_storage_providers::BackupStorageProviders::<Test>::mutate(
             &provider_id,
             |provider| {
-                provider.as_mut().expect("Provider should exist").root =
-                    MerklePatriciaRootDefault(root);
+                provider.as_mut().expect("Provider should exist").root = root;
             },
         );
 
@@ -2477,8 +2461,7 @@ fn new_challenges_round_provider_marked_as_slashable() {
         pallet_storage_providers::BackupStorageProviders::<Test>::mutate(
             &provider_id,
             |provider| {
-                provider.as_mut().expect("Provider should exist").root =
-                    MerklePatriciaRootDefault(root);
+                provider.as_mut().expect("Provider should exist").root = root;
             },
         );
 
@@ -2605,15 +2588,13 @@ fn new_challenges_round_bad_provider_marked_as_slashable_but_good_no() {
         pallet_storage_providers::BackupStorageProviders::<Test>::mutate(
             &alice_provider_id,
             |provider| {
-                provider.as_mut().expect("Provider should exist").root =
-                    MerklePatriciaRootDefault(root);
+                provider.as_mut().expect("Provider should exist").root = root;
             },
         );
         pallet_storage_providers::BackupStorageProviders::<Test>::mutate(
             &bob_provider_id,
             |provider| {
-                provider.as_mut().expect("Provider should exist").root =
-                    MerklePatriciaRootDefault(root);
+                provider.as_mut().expect("Provider should exist").root = root;
             },
         );
 

--- a/pallets/providers/src/lib.rs
+++ b/pallets/providers/src/lib.rs
@@ -37,7 +37,7 @@ pub mod pallet {
         dispatch::DispatchResultWithPostInfo,
         pallet_prelude::*,
         sp_runtime::traits::{
-            AtLeast32BitUnsigned, CheckEqual, Hash, MaybeDisplay, Saturating, SimpleBitOps,
+            AtLeast32BitUnsigned, CheckEqual, MaybeDisplay, Saturating, SimpleBitOps,
         },
         traits::{fungible::*, Incrementable},
         Blake2_128Concat,
@@ -110,9 +110,6 @@ pub mod pallet {
             + MaxEncodedLen
             + FullCodec;
 
-        /// The hashing system (algorithm) being used for the Merkle Patricia Forests (e.g. Blake2).
-        type MerkleTrieHashing: Hash<Output = Self::MerklePatriciaRoot> + TypeInfo;
-
         /// The type of the identifier of the value proposition of a MSP (probably a hash of that value proposition)
         type ValuePropId: Parameter
             + Member
@@ -184,6 +181,10 @@ pub mod pallet {
         /// The minimum amount of blocks between capacity changes for a SP
         #[pallet::constant]
         type MinBlocksBetweenCapacityChanges: Get<BlockNumberFor<Self>>;
+
+        /// The default value of the root of the Merkle Patricia Trie of the runtime
+        #[pallet::constant]
+        type DefaultMerkleRoot: Get<Self::MerklePatriciaRoot>;
     }
 
     #[pallet::pallet]
@@ -547,7 +548,7 @@ pub mod pallet {
                 capacity,
                 data_used: StorageData::<T>::default(),
                 multiaddresses: multiaddresses.clone(),
-                root: MerklePatriciaRootDefault::<T>::default(),
+                root: T::DefaultMerkleRoot::get(),
                 last_capacity_change: frame_system::Pallet::<T>::block_number(),
                 payment_account,
             };
@@ -881,7 +882,7 @@ pub mod pallet {
                 capacity,
                 data_used: StorageData::<T>::default(),
                 multiaddresses: multiaddresses.clone(),
-                root: MerklePatriciaRootDefault::<T>::default(),
+                root: T::DefaultMerkleRoot::get(),
                 last_capacity_change: frame_system::Pallet::<T>::block_number(),
                 payment_account,
             };

--- a/pallets/providers/src/mock.rs
+++ b/pallets/providers/src/mock.rs
@@ -1,3 +1,5 @@
+use core::marker::PhantomData;
+
 use crate as pallet_storage_providers;
 use codec::Encode;
 use frame_support::{
@@ -7,11 +9,12 @@ use frame_support::{
 };
 use frame_system as system;
 use shp_traits::SubscribeProvidersInterface;
-use sp_core::{hashing::blake2_256, ConstU128, ConstU32, ConstU64, H256};
+use sp_core::{hashing::blake2_256, ConstU128, ConstU32, ConstU64, Get, Hasher, H256};
 use sp_runtime::{
     traits::{BlakeTwo256, IdentityLookup},
     BuildStorage, DispatchResult,
 };
+use sp_trie::{LayoutV1, TrieConfiguration, TrieLayout};
 use system::pallet_prelude::BlockNumberFor;
 
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -108,6 +111,14 @@ impl pallet_balances::Config for Test {
     type MaxFreezes = ConstU32<10>;
 }
 
+pub type HasherOutT<T> = <<T as TrieLayout>::Hash as Hasher>::Out;
+pub struct DefaultMerkleRoot<T>(PhantomData<T>);
+impl<T: TrieConfiguration> Get<HasherOutT<T>> for DefaultMerkleRoot<T> {
+    fn get() -> HasherOutT<T> {
+        sp_trie::empty_trie_root::<T>()
+    }
+}
+
 impl crate::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type NativeBalance = Balances;
@@ -115,7 +126,7 @@ impl crate::Config for Test {
     type StorageData = u32;
     type SpCount = u32;
     type MerklePatriciaRoot = H256;
-    type MerkleTrieHashing = BlakeTwo256;
+    type DefaultMerkleRoot = DefaultMerkleRoot<LayoutV1<BlakeTwo256>>;
     type ValuePropId = H256;
     type ReadAccessGroupId = u32;
     type MaxMultiAddressSize = ConstU32<100>;

--- a/pallets/providers/src/tests.rs
+++ b/pallets/providers/src/tests.rs
@@ -28,6 +28,7 @@ type DepositPerData = <Test as crate::Config>::DepositPerData;
 type MaxMsps = <Test as crate::Config>::MaxMsps;
 type MaxBsps = <Test as crate::Config>::MaxBsps;
 type MinBlocksBetweenCapacityChanges = <Test as crate::Config>::MinBlocksBetweenCapacityChanges;
+type DefaultMerkleRoot = <Test as crate::Config>::DefaultMerkleRoot;
 
 // Runtime constants:
 // This is the duration of an epoch in blocks, a constant from the runtime configuration that we mock here
@@ -615,7 +616,7 @@ mod sign_up {
                         alice_sign_up_request.unwrap(),
                         (
                             StorageProvider::BackupStorageProvider(BackupStorageProvider {
-                                root: Default::default(),
+                                root: DefaultMerkleRoot::get(),
                                 capacity: storage_amount,
                                 data_used: 0,
                                 multiaddresses,
@@ -984,7 +985,7 @@ mod sign_up {
                             capacity: storage_amount,
                             data_used: 0,
                             multiaddresses: multiaddresses.clone(),
-                            root: Default::default(),
+                            root: DefaultMerkleRoot::get(),
                             last_capacity_change: current_block,
                             payment_account: alice
                         })));
@@ -4125,7 +4126,7 @@ fn register_account_as_bsp(
             capacity: storage_amount,
             data_used: 0,
             multiaddresses,
-            root: Default::default(),
+            root: DefaultMerkleRoot::get(),
             last_capacity_change: frame_system::Pallet::<Test>::block_number(),
             payment_account: account,
         },

--- a/pallets/providers/src/types.rs
+++ b/pallets/providers/src/types.rs
@@ -40,7 +40,7 @@ pub struct BackupStorageProvider<T: Config> {
     pub capacity: StorageData<T>,
     pub data_used: StorageData<T>,
     pub multiaddresses: BoundedVec<MultiAddress<T>, MaxMultiAddressAmount<T>>,
-    pub root: MerklePatriciaRootDefault<T>,
+    pub root: MerklePatriciaRoot<T>,
     pub last_capacity_change: BlockNumberFor<T>,
     pub payment_account: T::AccountId,
 }
@@ -50,7 +50,7 @@ pub struct BackupStorageProvider<T: Config> {
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, RuntimeDebugNoBound, PartialEq, Eq, Clone)]
 #[scale_info(skip_type_params(T))]
 pub struct Bucket<T: Config> {
-    pub root: MerklePatriciaRootDefault<T>,
+    pub root: MerklePatriciaRoot<T>,
     pub user_id: T::AccountId,
     pub msp_id: MainStorageProviderId<T>,
     pub private: bool,
@@ -87,21 +87,7 @@ pub type MultiAddress<T> = BoundedVec<u8, MaxMultiAddressSize<T>>;
 
 /// MerklePatriciaRoot is the type of the root of a Merkle Patricia Trie, either the root of a BSP or a bucket from an MSP.
 pub type MerklePatriciaRoot<T> = <T as crate::Config>::MerklePatriciaRoot;
-/// Wrapper for MerklePatriciaRoot<T> that implements a custom Default which returns the root of an empty trie.
-/// Note that it uses the LayoutV1 struct from sp_trie. Will need to be changed if the trie layout changes.
-#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, RuntimeDebugNoBound, PartialEq, Eq, Clone)]
-#[scale_info(skip_type_params(T))]
-pub struct MerklePatriciaRootDefault<T: Config>(pub MerklePatriciaRoot<T>);
-impl<T> Default for MerklePatriciaRootDefault<T>
-where
-    T: Config,
-{
-    fn default() -> Self {
-        MerklePatriciaRootDefault(sp_trie::empty_trie_root::<
-            sp_trie::LayoutV1<T::MerkleTrieHashing>,
-        >())
-    }
-}
+
 /// HashId is the type that uniquely identifies either a Storage Provider (MSP or BSP) or a Bucket.
 pub type HashId<T> = <T as frame_system::Config>::Hash;
 

--- a/pallets/providers/src/utils.rs
+++ b/pallets/providers/src/utils.rs
@@ -1,6 +1,4 @@
-use crate::types::{
-    Bucket, MainStorageProvider, MerklePatriciaRootDefault, MultiAddress, StorageProvider,
-};
+use crate::types::{Bucket, MainStorageProvider, MultiAddress, StorageProvider};
 use codec::Encode;
 use frame_support::ensure;
 use frame_support::pallet_prelude::DispatchResult;
@@ -775,7 +773,7 @@ impl<T: Config> From<MainStorageProvider<T>> for BackupStorageProvider<T> {
             capacity: msp.capacity,
             data_used: msp.data_used,
             multiaddresses: msp.multiaddresses,
-            root: MerklePatriciaRootDefault::<T>::default(),
+            root: T::DefaultMerkleRoot::get(),
             last_capacity_change: msp.last_capacity_change,
             payment_account: msp.payment_account,
         }
@@ -844,7 +842,7 @@ impl<T: pallet::Config> MutateProvidersInterface for pallet::Pallet<T> {
         );
 
         let bucket = Bucket {
-            root: MerklePatriciaRootDefault::<T>::default(),
+            root: T::DefaultMerkleRoot::get(),
             user_id,
             msp_id,
             private,
@@ -886,7 +884,7 @@ impl<T: pallet::Config> MutateProvidersInterface for pallet::Pallet<T> {
             Buckets::<T>::insert(
                 &bucket_id,
                 Bucket {
-                    root: MerklePatriciaRootDefault(new_root),
+                    root: new_root,
                     ..bucket
                 },
             );
@@ -1007,9 +1005,9 @@ impl<T: pallet::Config> ProvidersInterface for pallet::Pallet<T> {
 
     fn get_root(who: Self::ProviderId) -> Option<Self::MerkleHash> {
         if let Some(bucket) = Buckets::<T>::get(&who) {
-            Some(bucket.root.0)
+            Some(bucket.root)
         } else if let Some(bsp) = BackupStorageProviders::<T>::get(&who) {
-            Some(bsp.root.0)
+            Some(bsp.root)
         } else {
             None
         }
@@ -1032,7 +1030,7 @@ impl<T: pallet::Config> ProvidersInterface for pallet::Pallet<T> {
             Buckets::<T>::insert(
                 &who,
                 Bucket {
-                    root: MerklePatriciaRootDefault(new_root),
+                    root: new_root,
                     ..bucket
                 },
             );
@@ -1040,7 +1038,7 @@ impl<T: pallet::Config> ProvidersInterface for pallet::Pallet<T> {
             BackupStorageProviders::<T>::insert(
                 &who,
                 BackupStorageProvider {
-                    root: MerklePatriciaRootDefault(new_root),
+                    root: new_root,
                     ..bsp
                 },
             );
@@ -1051,6 +1049,6 @@ impl<T: pallet::Config> ProvidersInterface for pallet::Pallet<T> {
     }
 
     fn get_default_root() -> Self::MerkleHash {
-        MerklePatriciaRootDefault::<T>::default().0
+        T::DefaultMerkleRoot::get()
     }
 }

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -439,13 +439,20 @@ impl pallet_randomness::Config for Runtime {
     type WeightInfo = ();
 }
 
+pub type HasherOutT<T> = <<T as TrieLayout>::Hash as Hasher>::Out;
+pub struct DefaultMerkleRoot<T>(PhantomData<T>);
+impl<T: TrieConfiguration> Get<HasherOutT<T>> for DefaultMerkleRoot<T> {
+    fn get() -> HasherOutT<T> {
+        sp_trie::empty_trie_root::<T>()
+    }
+}
 impl pallet_storage_providers::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type NativeBalance = Balances;
     type StorageData = u32;
     type SpCount = u32;
     type MerklePatriciaRoot = Hash;
-    type MerkleTrieHashing = BlakeTwo256;
+    type DefaultMerkleRoot = DefaultMerkleRoot<LayoutV1<BlakeTwo256>>;
     type ValuePropId = Hash;
     type ReadAccessGroupId = <Self as pallet_nfts::Config>::CollectionId;
     type MaxMultiAddressSize = ConstU32<100>;

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -26,6 +26,7 @@
 mod xcm_config;
 
 // Substrate and Polkadot dependencies
+use core::marker::PhantomData;
 use cumulus_pallet_parachain_system::{RelayChainStateProof, RelayNumberMonotonicallyIncreases};
 use cumulus_primitives_core::{relay_chain::well_known_keys, AggregateMessageOrigin, ParaId};
 use frame_support::{
@@ -60,8 +61,7 @@ use sp_runtime::{
     AccountId32, DispatchError, FixedPointNumber, FixedU128, Perbill, SaturatedConversion,
 };
 use sp_std::collections::btree_set::BTreeSet;
-use sp_trie::CompactProof;
-use sp_trie::LayoutV1;
+use sp_trie::{CompactProof, LayoutV1, TrieConfiguration, TrieLayout};
 use sp_version::RuntimeVersion;
 use xcm::latest::prelude::BodyId;
 


### PR DESCRIPTION
This PR refactors the previous logic used to get the default BSP and Bucket root. It still uses the root of an empty Merkle trie, but in a more generic and configurable way using a configuration constant and a Get implementation