### PR TITLE
feat: create internal `RequestId` for FileTransferService

### DIFF
--- a/client/common/src/types.rs
+++ b/client/common/src/types.rs
@@ -110,10 +110,10 @@ impl FileProof {
 }
 
 #[derive(Clone, Eq, Hash, PartialEq)]
-pub struct RequestId(u64);
+pub struct DownloadRequestId(u64);
 
-impl RequestId {
+impl DownloadRequestId {
     pub fn new(id: u64) -> Self {
-        RequestId(id)
+        DownloadRequestId(id)
     }
 }

--- a/client/common/src/types.rs
+++ b/client/common/src/types.rs
@@ -108,3 +108,12 @@ impl FileProof {
         )
     }
 }
+
+#[derive(Clone, Eq, Hash, PartialEq)]
+pub struct RequestId(u64);
+
+impl RequestId {
+    pub fn new(id: u64) -> Self {
+        RequestId(id)
+    }
+}

--- a/client/file-transfer-service/src/events.rs
+++ b/client/file-transfer-service/src/events.rs
@@ -1,7 +1,6 @@
 use sc_network::PeerId;
-use shc_common::types::{ChunkId, FileKey, FileKeyProof};
-
 use shc_actors_framework::event_bus::{EventBus, EventBusMessage, ProvidesEventBus};
+use shc_common::types::{ChunkId, FileKey, FileKeyProof, RequestId};
 
 #[derive(Clone)]
 pub struct RemoteUploadRequest {
@@ -16,6 +15,7 @@ impl EventBusMessage for RemoteUploadRequest {}
 pub struct RemoteDownloadRequest {
     pub file_key: FileKey,
     pub chunk_id: ChunkId,
+    pub request_id: RequestId,
 }
 
 impl EventBusMessage for RemoteDownloadRequest {}

--- a/client/file-transfer-service/src/events.rs
+++ b/client/file-transfer-service/src/events.rs
@@ -1,6 +1,6 @@
 use sc_network::PeerId;
 use shc_actors_framework::event_bus::{EventBus, EventBusMessage, ProvidesEventBus};
-use shc_common::types::{ChunkId, FileKey, FileKeyProof, RequestId};
+use shc_common::types::{ChunkId, DownloadRequestId, FileKey, FileKeyProof};
 
 #[derive(Clone)]
 pub struct RemoteUploadRequest {
@@ -15,7 +15,7 @@ impl EventBusMessage for RemoteUploadRequest {}
 pub struct RemoteDownloadRequest {
     pub file_key: FileKey,
     pub chunk_id: ChunkId,
-    pub request_id: RequestId,
+    pub request_id: DownloadRequestId,
 }
 
 impl EventBusMessage for RemoteDownloadRequest {}


### PR DESCRIPTION
This PR adds a new mapping to the FileTransferService so upper layer tasks can respond back to download requests.