### PR TITLE
feat: Accrue failed proof submissions

### DIFF
--- a/pallets/file-system/src/tests.rs
+++ b/pallets/file-system/src/tests.rs
@@ -14,7 +14,7 @@ use frame_support::{
     weights::Weight,
 };
 use frame_system::pallet_prelude::BlockNumberFor;
-use pallet_proofs_dealer::{LastTickProviderSubmittedProofFor, PriorityChallengesQueue};
+use pallet_proofs_dealer::{LastTickProviderSubmissionInterval, PriorityChallengesQueue};
 use pallet_storage_providers::types::Bucket;
 use shp_traits::{ReadProvidersInterface, SubscribeProvidersInterface, TrieRemoveMutation};
 use sp_core::{ByteArray, Hasher, H256};
@@ -1481,7 +1481,7 @@ fn bsp_confirm_storing_success() {
 
         // Assert that the proving cycle was initialised for this BSP.
         let last_tick_provider_submitted_proof =
-            LastTickProviderSubmittedProofFor::<Test>::get(&bsp_id).unwrap();
+            LastTickProviderSubmissionInterval::<Test>::get(&bsp_id).unwrap();
         assert_eq!(last_tick_provider_submitted_proof, tick_when_confirming);
 
         // Assert that the correct event was deposited.

--- a/pallets/file-system/src/tests.rs
+++ b/pallets/file-system/src/tests.rs
@@ -14,7 +14,7 @@ use frame_support::{
     weights::Weight,
 };
 use frame_system::pallet_prelude::BlockNumberFor;
-use pallet_proofs_dealer::{LastTickProviderSubmissionInterval, PriorityChallengesQueue};
+use pallet_proofs_dealer::{LastTickProviderSubmittedAProofFor, PriorityChallengesQueue};
 use pallet_storage_providers::types::Bucket;
 use shp_traits::{ReadProvidersInterface, SubscribeProvidersInterface, TrieRemoveMutation};
 use sp_core::{ByteArray, Hasher, H256};
@@ -1481,7 +1481,7 @@ fn bsp_confirm_storing_success() {
 
         // Assert that the proving cycle was initialised for this BSP.
         let last_tick_provider_submitted_proof =
-            LastTickProviderSubmissionInterval::<Test>::get(&bsp_id).unwrap();
+            LastTickProviderSubmittedAProofFor::<Test>::get(&bsp_id).unwrap();
         assert_eq!(last_tick_provider_submitted_proof, tick_when_confirming);
 
         // Assert that the correct event was deposited.

--- a/pallets/proofs-dealer/src/lib.rs
+++ b/pallets/proofs-dealer/src/lib.rs
@@ -233,12 +233,18 @@ pub mod pallet {
         (),
     >;
 
-    /// A mapping from a Provider to the last tick interval for which they should have submitted a proof.
+    /// A mapping from a Provider to the last tick for which they SHOULD have submitted a proof.
     /// If for a Provider `p`, `LastTickProviderSubmittedProofFor[p]` is `n`, then the
     /// Provider should submit a proof for tick `n + stake_to_challenge_period(p)`.
+    ///
+    /// This gets updated when a Provider submits a proof successfully and is used to determine the
+    /// next tick for which the Provider should submit a proof, and it's deadline.
+    ///
+    /// If the Provider fails to submit a proof in time and is slashed, this will still get updated
+    /// to the tick it should have submitted a proof for.
     #[pallet::storage]
     #[pallet::getter(fn last_tick_provider_submitted_proof_for)]
-    pub type LastTickProviderSubmissionInterval<T: Config> =
+    pub type LastTickProviderSubmittedAProofFor<T: Config> =
         StorageMap<_, Blake2_128Concat, ProviderIdFor<T>, BlockNumberFor<T>>;
 
     /// A queue of keys that have been challenged manually.

--- a/pallets/proofs-dealer/src/lib.rs
+++ b/pallets/proofs-dealer/src/lib.rs
@@ -233,12 +233,12 @@ pub mod pallet {
         (),
     >;
 
-    /// A mapping from a Provider to the last challenge tick they submitted a proof for.
+    /// A mapping from a Provider to the last tick interval for which they should have submitted a proof.
     /// If for a Provider `p`, `LastTickProviderSubmittedProofFor[p]` is `n`, then the
     /// Provider should submit a proof for tick `n + stake_to_challenge_period(p)`.
     #[pallet::storage]
     #[pallet::getter(fn last_tick_provider_submitted_proof_for)]
-    pub type LastTickProviderSubmittedProofFor<T: Config> =
+    pub type LastTickProviderSubmissionInterval<T: Config> =
         StorageMap<_, Blake2_128Concat, ProviderIdFor<T>, BlockNumberFor<T>>;
 
     /// A queue of keys that have been challenged manually.

--- a/pallets/proofs-dealer/src/lib.rs
+++ b/pallets/proofs-dealer/src/lib.rs
@@ -162,9 +162,9 @@ pub mod pallet {
         #[pallet::constant]
         type TargetTicksStorageOfSubmitters: Get<u32>;
 
-        /// The maximum amount of Providers that can submit a proof in a single block.  
-        /// Although this can be seen as an arbitrary limit, if set to the already existing  
-        /// implicit limit that is "how many `submit_proof` extrinsics fit in the weight of  
+        /// The maximum amount of Providers that can submit a proof in a single block.
+        /// Although this can be seen as an arbitrary limit, if set to the already existing
+        /// implicit limit that is "how many `submit_proof` extrinsics fit in the weight of
         /// a block, this wouldn't add any additional artificial limit.
         #[pallet::constant]
         type MaxSubmittersPerTick: Get<u32>;
@@ -282,7 +282,7 @@ pub mod pallet {
 
     #[pallet::storage]
     #[pallet::getter(fn slashable_providers)]
-    pub type SlashableProviders<T: Config> = StorageMap<_, Blake2_128Concat, ProviderIdFor<T>, ()>;
+    pub type SlashableProviders<T: Config> = StorageMap<_, Blake2_128Concat, ProviderIdFor<T>, u32>;
 
     /// A mapping from tick to Providers, which is set if the Provider submitted a valid proof in that tick.
     ///

--- a/pallets/proofs-dealer/src/tests.rs
+++ b/pallets/proofs-dealer/src/tests.rs
@@ -11,7 +11,7 @@ use crate::types::{
 use crate::{mock::*, types::Proof};
 use crate::{
     ChallengeTickToChallengedProviders, ChallengesTicker, LastCheckpointTick, LastDeletedTick,
-    LastTickProviderSubmissionInterval, SlashableProviders, TickToChallengesSeed,
+    LastTickProviderSubmittedAProofFor, SlashableProviders, TickToChallengesSeed,
     TickToCheckpointChallenges, ValidProofSubmittersLastTicks,
 };
 use codec::Encode;
@@ -523,7 +523,7 @@ fn proofs_dealer_trait_initialise_challenge_cycle_success() {
 
         // Check that the Provider's last tick was set to 1.
         let last_tick_provider_submitted_proof =
-            LastTickProviderSubmissionInterval::<Test>::get(&provider_id).unwrap();
+            LastTickProviderSubmittedAProofFor::<Test>::get(&provider_id).unwrap();
         assert_eq!(last_tick_provider_submitted_proof, 1);
 
         // Check that the Provider's deadline was set to `challenge_period + challenge_ticks_tolerance`
@@ -586,7 +586,7 @@ fn proofs_dealer_trait_initialise_challenge_cycle_already_initialised_success() 
 
         // Check that the Provider's last tick was set to 1.
         let last_tick_provider_submitted_proof =
-            LastTickProviderSubmissionInterval::<Test>::get(&provider_id).unwrap();
+            LastTickProviderSubmittedAProofFor::<Test>::get(&provider_id).unwrap();
         assert_eq!(last_tick_provider_submitted_proof, 1);
 
         // Check that the Provider's deadline was set to `challenge_period + challenge_ticks_tolerance`
@@ -612,7 +612,7 @@ fn proofs_dealer_trait_initialise_challenge_cycle_already_initialised_success() 
 
         // Check that the Provider's last tick is the current now.
         let last_tick_provider_submitted_proof =
-            LastTickProviderSubmissionInterval::<Test>::get(&provider_id).unwrap();
+            LastTickProviderSubmittedAProofFor::<Test>::get(&provider_id).unwrap();
         let current_tick = ChallengesTicker::<Test>::get();
         assert_eq!(last_tick_provider_submitted_proof, current_tick);
 
@@ -690,10 +690,10 @@ fn proofs_dealer_trait_initialise_challenge_cycle_already_initialised_and_new_su
 
         // Check that the Providers' last tick was set to 1.
         let last_tick_provider_submitted_proof =
-            LastTickProviderSubmissionInterval::<Test>::get(&provider_id_1).unwrap();
+            LastTickProviderSubmittedAProofFor::<Test>::get(&provider_id_1).unwrap();
         assert_eq!(last_tick_provider_submitted_proof, 1);
         let last_tick_provider_submitted_proof =
-            LastTickProviderSubmissionInterval::<Test>::get(&provider_id_2).unwrap();
+            LastTickProviderSubmittedAProofFor::<Test>::get(&provider_id_2).unwrap();
         assert_eq!(last_tick_provider_submitted_proof, 1);
 
         // Check that Provider 1's deadline was set to `challenge_period + challenge_ticks_tolerance`
@@ -717,7 +717,7 @@ fn proofs_dealer_trait_initialise_challenge_cycle_already_initialised_and_new_su
 
         // Check that the Provider's last tick is the current now.
         let last_tick_provider_submitted_proof =
-            LastTickProviderSubmissionInterval::<Test>::get(&provider_id_1).unwrap();
+            LastTickProviderSubmittedAProofFor::<Test>::get(&provider_id_1).unwrap();
         let current_tick = ChallengesTicker::<Test>::get();
         assert_eq!(last_tick_provider_submitted_proof, current_tick);
 
@@ -808,7 +808,7 @@ fn submit_proof_success() {
         // Set Provider's last submitted proof block.
         let current_tick = ChallengesTicker::<Test>::get();
         let last_tick_provider_submitted_proof = current_tick;
-        LastTickProviderSubmissionInterval::<Test>::insert(
+        LastTickProviderSubmittedAProofFor::<Test>::insert(
             &provider_id,
             last_tick_provider_submitted_proof,
         );
@@ -874,7 +874,7 @@ fn submit_proof_success() {
         // Check the new last time this provider submitted a proof.
         let expected_new_tick = last_tick_provider_submitted_proof + challenge_period;
         let new_last_tick_provider_submitted_proof =
-            LastTickProviderSubmissionInterval::<Test>::get(provider_id).unwrap();
+            LastTickProviderSubmittedAProofFor::<Test>::get(provider_id).unwrap();
         assert_eq!(expected_new_tick, new_last_tick_provider_submitted_proof);
 
         // Check that the Provider's deadline was pushed forward.
@@ -936,7 +936,7 @@ fn submit_proof_adds_provider_to_valid_submitters_set() {
         // Set Provider's last submitted proof block.
         let current_tick = ChallengesTicker::<Test>::get();
         let last_tick_provider_submitted_proof = current_tick;
-        LastTickProviderSubmissionInterval::<Test>::insert(
+        LastTickProviderSubmittedAProofFor::<Test>::insert(
             &provider_id,
             last_tick_provider_submitted_proof,
         );
@@ -1045,7 +1045,7 @@ fn submit_proof_submitted_by_not_a_provider_success() {
         );
 
         // Set Provider's last submitted proof block.
-        LastTickProviderSubmissionInterval::<Test>::insert(&provider_id, System::block_number());
+        LastTickProviderSubmittedAProofFor::<Test>::insert(&provider_id, System::block_number());
 
         // Advance less than `ChallengeTicksTolerance` blocks.
         let challenge_ticks_tolerance: u64 = ChallengeTicksToleranceFor::<Test>::get();
@@ -1137,7 +1137,7 @@ fn submit_proof_with_checkpoint_challenges_success() {
 
         // Set Provider's last submitted proof tick.
         let last_tick_provider_submitted_proof = System::block_number();
-        LastTickProviderSubmissionInterval::<Test>::insert(&provider_id, System::block_number());
+        LastTickProviderSubmittedAProofFor::<Test>::insert(&provider_id, System::block_number());
 
         // Advance less than `ChallengeTicksTolerance` blocks.
         let challenge_ticks_tolerance: u64 = ChallengeTicksToleranceFor::<Test>::get();
@@ -1246,7 +1246,7 @@ fn submit_proof_with_checkpoint_challenges_mutations_success() {
 
         // Set Provider's last submitted proof tick.
         let last_tick_provider_submitted_proof = System::block_number();
-        LastTickProviderSubmissionInterval::<Test>::insert(&provider_id, System::block_number());
+        LastTickProviderSubmittedAProofFor::<Test>::insert(&provider_id, System::block_number());
 
         // Advance less than `ChallengeTicksTolerance` blocks.
         let challenge_ticks_tolerance: u64 = ChallengeTicksToleranceFor::<Test>::get();
@@ -1579,7 +1579,7 @@ fn submit_proof_challenges_block_not_reached_fail() {
         );
 
         // Set Provider's last submitted proof block.
-        LastTickProviderSubmissionInterval::<Test>::insert(&provider_id, 1);
+        LastTickProviderSubmittedAProofFor::<Test>::insert(&provider_id, 1);
 
         // Dispatch challenge extrinsic.
         assert_noop!(
@@ -1656,7 +1656,7 @@ fn submit_proof_challenges_block_too_old_fail() {
         );
 
         // Set Provider's last submitted proof block.
-        LastTickProviderSubmissionInterval::<Test>::insert(&provider_id, 1);
+        LastTickProviderSubmittedAProofFor::<Test>::insert(&provider_id, 1);
 
         // Advance more than `ChallengeHistoryLength` blocks.
         let challenge_history_length: u64 = ChallengeHistoryLengthFor::<Test>::get();
@@ -1733,7 +1733,7 @@ fn submit_proof_seed_not_found_fail() {
         );
 
         // Set Provider's last submitted proof block.
-        LastTickProviderSubmissionInterval::<Test>::insert(&provider_id, 1);
+        LastTickProviderSubmittedAProofFor::<Test>::insert(&provider_id, 1);
 
         // Advance less than `ChallengeTicksTolerance` blocks.
         let challenge_ticks_tolerance: u64 = ChallengeTicksToleranceFor::<Test>::get();
@@ -1813,7 +1813,7 @@ fn submit_proof_checkpoint_challenge_not_found_fail() {
         );
 
         // Set Provider's last submitted proof block.
-        LastTickProviderSubmissionInterval::<Test>::insert(&provider_id, System::block_number());
+        LastTickProviderSubmittedAProofFor::<Test>::insert(&provider_id, System::block_number());
 
         // Set random seed for this block challenges.
         let seed = BlakeTwo256::hash(b"seed");
@@ -1898,7 +1898,7 @@ fn submit_proof_forest_proof_verification_fail() {
         );
 
         // Set Provider's last submitted proof block.
-        LastTickProviderSubmissionInterval::<Test>::insert(&provider_id, System::block_number());
+        LastTickProviderSubmittedAProofFor::<Test>::insert(&provider_id, System::block_number());
 
         // Set random seed for this block challenges.
         let seed = BlakeTwo256::hash(b"seed");
@@ -1981,7 +1981,7 @@ fn submit_proof_no_key_proofs_for_keys_verified_in_forest_fail() {
         );
 
         // Set Provider's last submitted proof block.
-        LastTickProviderSubmissionInterval::<Test>::insert(&provider_id, System::block_number());
+        LastTickProviderSubmittedAProofFor::<Test>::insert(&provider_id, System::block_number());
 
         // Set random seed for this block challenges.
         let seed = BlakeTwo256::hash(b"seed");
@@ -2047,7 +2047,7 @@ fn submit_proof_out_checkpoint_challenges_fail() {
         );
 
         // Set Provider's last submitted proof block.
-        LastTickProviderSubmissionInterval::<Test>::insert(&provider_id, System::block_number());
+        LastTickProviderSubmittedAProofFor::<Test>::insert(&provider_id, System::block_number());
 
         // Set random seed for this block challenges.
         let seed = BlakeTwo256::hash(b"seed");
@@ -2160,7 +2160,7 @@ fn submit_proof_key_proof_verification_fail() {
         );
 
         // Set Provider's last submitted proof block.
-        LastTickProviderSubmissionInterval::<Test>::insert(&provider_id, System::block_number());
+        LastTickProviderSubmittedAProofFor::<Test>::insert(&provider_id, System::block_number());
 
         // Advance less than `ChallengeTicksTolerance` blocks.
         let challenge_ticks_tolerance: u64 = ChallengeTicksToleranceFor::<Test>::get();
@@ -2557,7 +2557,7 @@ fn new_challenges_round_provider_marked_as_slashable() {
         // Set Provider's last submitted proof block.
         let current_tick = ChallengesTicker::<Test>::get();
         let prev_tick_provider_submitted_proof = current_tick;
-        LastTickProviderSubmissionInterval::<Test>::insert(
+        LastTickProviderSubmittedAProofFor::<Test>::insert(
             &provider_id,
             prev_tick_provider_submitted_proof,
         );
@@ -2594,7 +2594,7 @@ fn new_challenges_round_provider_marked_as_slashable() {
         let current_tick_provider_submitted_proof =
             prev_tick_provider_submitted_proof + challenge_period;
         let new_last_tick_provider_submitted_proof =
-            LastTickProviderSubmissionInterval::<Test>::get(provider_id).unwrap();
+            LastTickProviderSubmittedAProofFor::<Test>::get(provider_id).unwrap();
         assert_eq!(
             current_tick_provider_submitted_proof,
             new_last_tick_provider_submitted_proof
@@ -2606,7 +2606,7 @@ fn new_challenges_round_provider_marked_as_slashable() {
             None
         );
         let new_deadline =
-            current_tick_provider_submitted_proof + challenge_period + challenge_ticks_tolerance;
+            new_last_tick_provider_submitted_proof + challenge_period + challenge_ticks_tolerance;
         assert_eq!(
             ChallengeTickToChallengedProviders::<Test>::get(new_deadline, provider_id),
             Some(()),
@@ -2651,7 +2651,7 @@ fn multiple_new_challenges_round_provider_accrued_many_failed_proof_submissions(
 
         // Set Provider's last submitted proof block.
         let prev_tick_provider_submitted_proof = ChallengesTicker::<Test>::get();
-        LastTickProviderSubmissionInterval::<Test>::insert(
+        LastTickProviderSubmittedAProofFor::<Test>::insert(
             &provider_id,
             prev_tick_provider_submitted_proof,
         );
@@ -2685,7 +2685,7 @@ fn multiple_new_challenges_round_provider_accrued_many_failed_proof_submissions(
 
         // New challenges round
         let current_tick = ChallengesTicker::<Test>::get();
-        let prev_deadline = current_tick + challenge_period_plus_tolerance;
+        let prev_deadline = current_tick + challenge_period;
         ChallengeTickToChallengedProviders::<Test>::insert(prev_deadline, provider_id, ());
 
         // Advance to the deadline block for this Provider.
@@ -2767,14 +2767,14 @@ fn new_challenges_round_bad_provider_marked_as_slashable_but_good_no() {
 
         // Set Alice and Bob's last submitted proof block.
         let current_tick = ChallengesTicker::<Test>::get();
-        let last_tick_provider_submitted_proof = current_tick;
-        LastTickProviderSubmissionInterval::<Test>::insert(
+        let last_interval_tick = current_tick;
+        LastTickProviderSubmittedAProofFor::<Test>::insert(
             &alice_provider_id,
-            last_tick_provider_submitted_proof,
+            last_interval_tick,
         );
-        LastTickProviderSubmissionInterval::<Test>::insert(
+        LastTickProviderSubmittedAProofFor::<Test>::insert(
             &bob_provider_id,
-            last_tick_provider_submitted_proof,
+            last_interval_tick,
         );
 
         // Set Alice and Bob's deadline for submitting a proof.
@@ -2849,13 +2849,12 @@ fn new_challenges_round_bad_provider_marked_as_slashable_but_good_no() {
         // Advance to the deadline block for this Provider.
         run_to_block(prev_deadline);
 
-        // // Check event of Bob being marked as slashable.
-        // System::assert_has_event(
-        //     Event::SlashableProvider {
-        //         provider: bob_provider_id,
-        //     }
-        //     .into(),
-        // );
+        System::assert_has_event(
+            Event::SlashableProvider {
+                provider: bob_provider_id,
+            }
+            .into(),
+        );
 
         // Check that Bob is in the SlashableProviders storage map and that Alice is not.
         assert!(!SlashableProviders::<Test>::contains_key(
@@ -2864,14 +2863,14 @@ fn new_challenges_round_bad_provider_marked_as_slashable_but_good_no() {
         assert!(SlashableProviders::<Test>::contains_key(&bob_provider_id));
         assert_eq!(SlashableProviders::<Test>::get(&bob_provider_id), Some(1));
 
-        // Check the new last time Bob and Alice submitted a proof.
-        let expected_new_tick = last_tick_provider_submitted_proof + challenge_period;
-        let new_last_tick_alice_submitted_proof =
-            LastTickProviderSubmissionInterval::<Test>::get(alice_provider_id).unwrap();
-        assert_eq!(expected_new_tick, new_last_tick_alice_submitted_proof);
-        let new_last_tick_bob_submitted_proof =
-            LastTickProviderSubmissionInterval::<Test>::get(bob_provider_id).unwrap();
-        assert_eq!(expected_new_tick, new_last_tick_bob_submitted_proof);
+        // Check the new last tick interval for Alice and Bob.
+        let expected_new_tick = last_interval_tick + challenge_period;
+        let new_last_interval_tick_alice =
+            LastTickProviderSubmittedAProofFor::<Test>::get(alice_provider_id).unwrap();
+        assert_eq!(expected_new_tick, new_last_interval_tick_alice);
+        let new_last_interval_tick_bob =
+            LastTickProviderSubmittedAProofFor::<Test>::get(bob_provider_id).unwrap();
+        assert_eq!(expected_new_tick, new_last_interval_tick_bob);
 
         assert_eq!(
             ChallengeTickToChallengedProviders::<Test>::get(prev_deadline, alice_provider_id),
@@ -2883,7 +2882,7 @@ fn new_challenges_round_bad_provider_marked_as_slashable_but_good_no() {
         );
 
         // Check that the both Alice and Bob's deadlines were pushed forward.
-        let new_deadline = expected_new_tick + challenge_period + challenge_ticks_tolerance;
+        let new_deadline = expected_new_tick + challenge_period_plus_tolerance;
         assert_eq!(
             ChallengeTickToChallengedProviders::<Test>::get(new_deadline, alice_provider_id),
             Some(()),

--- a/pallets/proofs-dealer/src/tests.rs
+++ b/pallets/proofs-dealer/src/tests.rs
@@ -2768,14 +2768,8 @@ fn new_challenges_round_bad_provider_marked_as_slashable_but_good_no() {
         // Set Alice and Bob's last submitted proof block.
         let current_tick = ChallengesTicker::<Test>::get();
         let last_interval_tick = current_tick;
-        LastTickProviderSubmittedAProofFor::<Test>::insert(
-            &alice_provider_id,
-            last_interval_tick,
-        );
-        LastTickProviderSubmittedAProofFor::<Test>::insert(
-            &bob_provider_id,
-            last_interval_tick,
-        );
+        LastTickProviderSubmittedAProofFor::<Test>::insert(&alice_provider_id, last_interval_tick);
+        LastTickProviderSubmittedAProofFor::<Test>::insert(&bob_provider_id, last_interval_tick);
 
         // Set Alice and Bob's deadline for submitting a proof.
         // It is the sum of this Provider's challenge period and the `ChallengesTicksTolerance`.

--- a/pallets/proofs-dealer/src/tests.rs
+++ b/pallets/proofs-dealer/src/tests.rs
@@ -11,7 +11,7 @@ use crate::types::{
 use crate::{mock::*, types::Proof};
 use crate::{
     ChallengeTickToChallengedProviders, ChallengesTicker, LastCheckpointTick, LastDeletedTick,
-    LastTickProviderSubmittedProofFor, SlashableProviders, TickToChallengesSeed,
+    LastTickProviderSubmissionInterval, SlashableProviders, TickToChallengesSeed,
     TickToCheckpointChallenges, ValidProofSubmittersLastTicks,
 };
 use codec::Encode;
@@ -523,7 +523,7 @@ fn proofs_dealer_trait_initialise_challenge_cycle_success() {
 
         // Check that the Provider's last tick was set to 1.
         let last_tick_provider_submitted_proof =
-            LastTickProviderSubmittedProofFor::<Test>::get(&provider_id).unwrap();
+            LastTickProviderSubmissionInterval::<Test>::get(&provider_id).unwrap();
         assert_eq!(last_tick_provider_submitted_proof, 1);
 
         // Check that the Provider's deadline was set to `challenge_period + challenge_ticks_tolerance`
@@ -586,7 +586,7 @@ fn proofs_dealer_trait_initialise_challenge_cycle_already_initialised_success() 
 
         // Check that the Provider's last tick was set to 1.
         let last_tick_provider_submitted_proof =
-            LastTickProviderSubmittedProofFor::<Test>::get(&provider_id).unwrap();
+            LastTickProviderSubmissionInterval::<Test>::get(&provider_id).unwrap();
         assert_eq!(last_tick_provider_submitted_proof, 1);
 
         // Check that the Provider's deadline was set to `challenge_period + challenge_ticks_tolerance`
@@ -612,7 +612,7 @@ fn proofs_dealer_trait_initialise_challenge_cycle_already_initialised_success() 
 
         // Check that the Provider's last tick is the current now.
         let last_tick_provider_submitted_proof =
-            LastTickProviderSubmittedProofFor::<Test>::get(&provider_id).unwrap();
+            LastTickProviderSubmissionInterval::<Test>::get(&provider_id).unwrap();
         let current_tick = ChallengesTicker::<Test>::get();
         assert_eq!(last_tick_provider_submitted_proof, current_tick);
 
@@ -690,10 +690,10 @@ fn proofs_dealer_trait_initialise_challenge_cycle_already_initialised_and_new_su
 
         // Check that the Providers' last tick was set to 1.
         let last_tick_provider_submitted_proof =
-            LastTickProviderSubmittedProofFor::<Test>::get(&provider_id_1).unwrap();
+            LastTickProviderSubmissionInterval::<Test>::get(&provider_id_1).unwrap();
         assert_eq!(last_tick_provider_submitted_proof, 1);
         let last_tick_provider_submitted_proof =
-            LastTickProviderSubmittedProofFor::<Test>::get(&provider_id_2).unwrap();
+            LastTickProviderSubmissionInterval::<Test>::get(&provider_id_2).unwrap();
         assert_eq!(last_tick_provider_submitted_proof, 1);
 
         // Check that Provider 1's deadline was set to `challenge_period + challenge_ticks_tolerance`
@@ -717,7 +717,7 @@ fn proofs_dealer_trait_initialise_challenge_cycle_already_initialised_and_new_su
 
         // Check that the Provider's last tick is the current now.
         let last_tick_provider_submitted_proof =
-            LastTickProviderSubmittedProofFor::<Test>::get(&provider_id_1).unwrap();
+            LastTickProviderSubmissionInterval::<Test>::get(&provider_id_1).unwrap();
         let current_tick = ChallengesTicker::<Test>::get();
         assert_eq!(last_tick_provider_submitted_proof, current_tick);
 
@@ -808,7 +808,7 @@ fn submit_proof_success() {
         // Set Provider's last submitted proof block.
         let current_tick = ChallengesTicker::<Test>::get();
         let last_tick_provider_submitted_proof = current_tick;
-        LastTickProviderSubmittedProofFor::<Test>::insert(
+        LastTickProviderSubmissionInterval::<Test>::insert(
             &provider_id,
             last_tick_provider_submitted_proof,
         );
@@ -874,7 +874,7 @@ fn submit_proof_success() {
         // Check the new last time this provider submitted a proof.
         let expected_new_tick = last_tick_provider_submitted_proof + challenge_period;
         let new_last_tick_provider_submitted_proof =
-            LastTickProviderSubmittedProofFor::<Test>::get(provider_id).unwrap();
+            LastTickProviderSubmissionInterval::<Test>::get(provider_id).unwrap();
         assert_eq!(expected_new_tick, new_last_tick_provider_submitted_proof);
 
         // Check that the Provider's deadline was pushed forward.
@@ -936,7 +936,7 @@ fn submit_proof_adds_provider_to_valid_submitters_set() {
         // Set Provider's last submitted proof block.
         let current_tick = ChallengesTicker::<Test>::get();
         let last_tick_provider_submitted_proof = current_tick;
-        LastTickProviderSubmittedProofFor::<Test>::insert(
+        LastTickProviderSubmissionInterval::<Test>::insert(
             &provider_id,
             last_tick_provider_submitted_proof,
         );
@@ -1045,7 +1045,7 @@ fn submit_proof_submitted_by_not_a_provider_success() {
         );
 
         // Set Provider's last submitted proof block.
-        LastTickProviderSubmittedProofFor::<Test>::insert(&provider_id, System::block_number());
+        LastTickProviderSubmissionInterval::<Test>::insert(&provider_id, System::block_number());
 
         // Advance less than `ChallengeTicksTolerance` blocks.
         let challenge_ticks_tolerance: u64 = ChallengeTicksToleranceFor::<Test>::get();
@@ -1137,7 +1137,7 @@ fn submit_proof_with_checkpoint_challenges_success() {
 
         // Set Provider's last submitted proof tick.
         let last_tick_provider_submitted_proof = System::block_number();
-        LastTickProviderSubmittedProofFor::<Test>::insert(&provider_id, System::block_number());
+        LastTickProviderSubmissionInterval::<Test>::insert(&provider_id, System::block_number());
 
         // Advance less than `ChallengeTicksTolerance` blocks.
         let challenge_ticks_tolerance: u64 = ChallengeTicksToleranceFor::<Test>::get();
@@ -1246,7 +1246,7 @@ fn submit_proof_with_checkpoint_challenges_mutations_success() {
 
         // Set Provider's last submitted proof tick.
         let last_tick_provider_submitted_proof = System::block_number();
-        LastTickProviderSubmittedProofFor::<Test>::insert(&provider_id, System::block_number());
+        LastTickProviderSubmissionInterval::<Test>::insert(&provider_id, System::block_number());
 
         // Advance less than `ChallengeTicksTolerance` blocks.
         let challenge_ticks_tolerance: u64 = ChallengeTicksToleranceFor::<Test>::get();
@@ -1579,7 +1579,7 @@ fn submit_proof_challenges_block_not_reached_fail() {
         );
 
         // Set Provider's last submitted proof block.
-        LastTickProviderSubmittedProofFor::<Test>::insert(&provider_id, 1);
+        LastTickProviderSubmissionInterval::<Test>::insert(&provider_id, 1);
 
         // Dispatch challenge extrinsic.
         assert_noop!(
@@ -1656,7 +1656,7 @@ fn submit_proof_challenges_block_too_old_fail() {
         );
 
         // Set Provider's last submitted proof block.
-        LastTickProviderSubmittedProofFor::<Test>::insert(&provider_id, 1);
+        LastTickProviderSubmissionInterval::<Test>::insert(&provider_id, 1);
 
         // Advance more than `ChallengeHistoryLength` blocks.
         let challenge_history_length: u64 = ChallengeHistoryLengthFor::<Test>::get();
@@ -1733,7 +1733,7 @@ fn submit_proof_seed_not_found_fail() {
         );
 
         // Set Provider's last submitted proof block.
-        LastTickProviderSubmittedProofFor::<Test>::insert(&provider_id, 1);
+        LastTickProviderSubmissionInterval::<Test>::insert(&provider_id, 1);
 
         // Advance less than `ChallengeTicksTolerance` blocks.
         let challenge_ticks_tolerance: u64 = ChallengeTicksToleranceFor::<Test>::get();
@@ -1813,7 +1813,7 @@ fn submit_proof_checkpoint_challenge_not_found_fail() {
         );
 
         // Set Provider's last submitted proof block.
-        LastTickProviderSubmittedProofFor::<Test>::insert(&provider_id, System::block_number());
+        LastTickProviderSubmissionInterval::<Test>::insert(&provider_id, System::block_number());
 
         // Set random seed for this block challenges.
         let seed = BlakeTwo256::hash(b"seed");
@@ -1898,7 +1898,7 @@ fn submit_proof_forest_proof_verification_fail() {
         );
 
         // Set Provider's last submitted proof block.
-        LastTickProviderSubmittedProofFor::<Test>::insert(&provider_id, System::block_number());
+        LastTickProviderSubmissionInterval::<Test>::insert(&provider_id, System::block_number());
 
         // Set random seed for this block challenges.
         let seed = BlakeTwo256::hash(b"seed");
@@ -1981,7 +1981,7 @@ fn submit_proof_no_key_proofs_for_keys_verified_in_forest_fail() {
         );
 
         // Set Provider's last submitted proof block.
-        LastTickProviderSubmittedProofFor::<Test>::insert(&provider_id, System::block_number());
+        LastTickProviderSubmissionInterval::<Test>::insert(&provider_id, System::block_number());
 
         // Set random seed for this block challenges.
         let seed = BlakeTwo256::hash(b"seed");
@@ -2047,7 +2047,7 @@ fn submit_proof_out_checkpoint_challenges_fail() {
         );
 
         // Set Provider's last submitted proof block.
-        LastTickProviderSubmittedProofFor::<Test>::insert(&provider_id, System::block_number());
+        LastTickProviderSubmissionInterval::<Test>::insert(&provider_id, System::block_number());
 
         // Set random seed for this block challenges.
         let seed = BlakeTwo256::hash(b"seed");
@@ -2160,7 +2160,7 @@ fn submit_proof_key_proof_verification_fail() {
         );
 
         // Set Provider's last submitted proof block.
-        LastTickProviderSubmittedProofFor::<Test>::insert(&provider_id, System::block_number());
+        LastTickProviderSubmissionInterval::<Test>::insert(&provider_id, System::block_number());
 
         // Advance less than `ChallengeTicksTolerance` blocks.
         let challenge_ticks_tolerance: u64 = ChallengeTicksToleranceFor::<Test>::get();
@@ -2557,7 +2557,7 @@ fn new_challenges_round_provider_marked_as_slashable() {
         // Set Provider's last submitted proof block.
         let current_tick = ChallengesTicker::<Test>::get();
         let prev_tick_provider_submitted_proof = current_tick;
-        LastTickProviderSubmittedProofFor::<Test>::insert(
+        LastTickProviderSubmissionInterval::<Test>::insert(
             &provider_id,
             prev_tick_provider_submitted_proof,
         );
@@ -2594,7 +2594,7 @@ fn new_challenges_round_provider_marked_as_slashable() {
         let current_tick_provider_submitted_proof =
             prev_tick_provider_submitted_proof + challenge_period;
         let new_last_tick_provider_submitted_proof =
-            LastTickProviderSubmittedProofFor::<Test>::get(provider_id).unwrap();
+            LastTickProviderSubmissionInterval::<Test>::get(provider_id).unwrap();
         assert_eq!(
             current_tick_provider_submitted_proof,
             new_last_tick_provider_submitted_proof
@@ -2651,7 +2651,7 @@ fn multiple_new_challenges_round_provider_accrued_many_failed_proof_submissions(
 
         // Set Provider's last submitted proof block.
         let prev_tick_provider_submitted_proof = ChallengesTicker::<Test>::get();
-        LastTickProviderSubmittedProofFor::<Test>::insert(
+        LastTickProviderSubmissionInterval::<Test>::insert(
             &provider_id,
             prev_tick_provider_submitted_proof,
         );
@@ -2768,11 +2768,11 @@ fn new_challenges_round_bad_provider_marked_as_slashable_but_good_no() {
         // Set Alice and Bob's last submitted proof block.
         let current_tick = ChallengesTicker::<Test>::get();
         let last_tick_provider_submitted_proof = current_tick;
-        LastTickProviderSubmittedProofFor::<Test>::insert(
+        LastTickProviderSubmissionInterval::<Test>::insert(
             &alice_provider_id,
             last_tick_provider_submitted_proof,
         );
-        LastTickProviderSubmittedProofFor::<Test>::insert(
+        LastTickProviderSubmissionInterval::<Test>::insert(
             &bob_provider_id,
             last_tick_provider_submitted_proof,
         );
@@ -2867,27 +2867,27 @@ fn new_challenges_round_bad_provider_marked_as_slashable_but_good_no() {
         // Check the new last time Bob and Alice submitted a proof.
         let expected_new_tick = last_tick_provider_submitted_proof + challenge_period;
         let new_last_tick_alice_submitted_proof =
-            LastTickProviderSubmittedProofFor::<Test>::get(alice_provider_id).unwrap();
+            LastTickProviderSubmissionInterval::<Test>::get(alice_provider_id).unwrap();
         assert_eq!(expected_new_tick, new_last_tick_alice_submitted_proof);
         let new_last_tick_bob_submitted_proof =
-            LastTickProviderSubmittedProofFor::<Test>::get(bob_provider_id).unwrap();
+            LastTickProviderSubmissionInterval::<Test>::get(bob_provider_id).unwrap();
         assert_eq!(expected_new_tick, new_last_tick_bob_submitted_proof);
 
-        // Check that the both Alice and Bob's deadlines were pushed forward.
         assert_eq!(
             ChallengeTickToChallengedProviders::<Test>::get(prev_deadline, alice_provider_id),
             None
-        );
-        let new_deadline = expected_new_tick + challenge_period + challenge_ticks_tolerance;
-        assert_eq!(
-            ChallengeTickToChallengedProviders::<Test>::get(new_deadline, alice_provider_id),
-            Some(()),
         );
         assert_eq!(
             ChallengeTickToChallengedProviders::<Test>::get(prev_deadline, bob_provider_id),
             None
         );
+
+        // Check that the both Alice and Bob's deadlines were pushed forward.
         let new_deadline = expected_new_tick + challenge_period + challenge_ticks_tolerance;
+        assert_eq!(
+            ChallengeTickToChallengedProviders::<Test>::get(new_deadline, alice_provider_id),
+            Some(()),
+        );
         assert_eq!(
             ChallengeTickToChallengedProviders::<Test>::get(new_deadline, bob_provider_id),
             Some(()),

--- a/pallets/proofs-dealer/src/utils.rs
+++ b/pallets/proofs-dealer/src/utils.rs
@@ -847,7 +847,7 @@ impl<T: pallet::Config> ProofsDealerInterface for Pallet<T> {
             );
         }
 
-        // Set `LastTickProviderSubmissionInterval` to the current tick.
+        // Set `LastTickProviderSubmittedAProofFor` to the current tick.
         let current_tick = ChallengesTicker::<T>::get();
         LastTickProviderSubmittedAProofFor::<T>::set(*provider_id, Some(current_tick));
 

--- a/pallets/proofs-dealer/src/utils.rs
+++ b/pallets/proofs-dealer/src/utils.rs
@@ -454,8 +454,8 @@ where
             //
             // Therefore, the next deadline is one period from now:
             // next_challenge_deadline = challenge_ticker + provider_period
-            let next_challenge_deadline = challenges_ticker
-                .saturating_add(Self::stake_to_challenge_period(stake));
+            let next_challenge_deadline =
+                challenges_ticker.saturating_add(Self::stake_to_challenge_period(stake));
 
             // Update this Provider's next challenge deadline.
             ChallengeTickToChallengedProviders::<T>::set(


### PR DESCRIPTION
This PR:

- Accrues number of failed proof submissions for slashable providers.
- Adds documentation explaining the `LastTickProviderSubmittedProofFor` storage and how it is utilized as part of the challenging protocol.