### PR TITLE
feat: ✨  implement the `get_stake` function on the `Providers` pallet

### DIFF
--- a/pallets/proofs-dealer/src/tests.rs
+++ b/pallets/proofs-dealer/src/tests.rs
@@ -18,10 +18,14 @@ use codec::Encode;
 use frame_support::{
     assert_err, assert_noop, assert_ok,
     pallet_prelude::Weight,
-    traits::{fungible::Mutate, OnIdle, OnPoll},
+    traits::{
+        fungible::{Mutate, MutateHold},
+        OnIdle, OnPoll,
+    },
     weights::WeightMeter,
     BoundedBTreeSet,
 };
+use pallet_storage_providers::HoldReason;
 use shp_traits::{ProofsDealerInterface, ProvidersInterface, TrieRemoveMutation};
 use sp_core::{blake2_256, Get, Hasher, H256};
 use sp_runtime::{traits::BlakeTwo256, BoundedVec, DispatchError};
@@ -515,6 +519,18 @@ fn proofs_dealer_trait_initialise_challenge_cycle_success() {
             },
         );
 
+        // Add balance to that Provider and hold some so it has a stake.
+        let provider_balance = 1_000_000_000_000_000;
+        assert_ok!(<Test as crate::Config>::NativeBalance::mint_into(
+            &1,
+            provider_balance
+        ));
+        assert_ok!(<Test as crate::Config>::NativeBalance::hold(
+            &HoldReason::StorageProviderDeposit.into(),
+            &1,
+            provider_balance / 100
+        ));
+
         // Dispatch initialise provider extrinsic.
         assert_ok!(ProofsDealer::force_initialise_challenge_cycle(
             RuntimeOrigin::root(),
@@ -577,6 +593,18 @@ fn proofs_dealer_trait_initialise_challenge_cycle_already_initialised_success() 
                 payment_account: Default::default(),
             },
         );
+
+        // Add balance to that Provider and hold some so it has a stake.
+        let provider_balance = 1_000_000_000_000_000;
+        assert_ok!(<Test as crate::Config>::NativeBalance::mint_into(
+            &1,
+            provider_balance
+        ));
+        assert_ok!(<Test as crate::Config>::NativeBalance::hold(
+            &HoldReason::StorageProviderDeposit.into(),
+            &1,
+            provider_balance / 100
+        ));
 
         // Dispatch initialise provider extrinsic.
         assert_ok!(ProofsDealer::force_initialise_challenge_cycle(
@@ -683,6 +711,27 @@ fn proofs_dealer_trait_initialise_challenge_cycle_already_initialised_and_new_su
                 payment_account: Default::default(),
             },
         );
+
+        // Add balance to those Providers and hold some so they have a stake.
+        let provider_balance = 1_000_000_000_000_000;
+        assert_ok!(<Test as crate::Config>::NativeBalance::mint_into(
+            &1,
+            provider_balance
+        ));
+        assert_ok!(<Test as crate::Config>::NativeBalance::mint_into(
+            &2,
+            provider_balance
+        ));
+        assert_ok!(<Test as crate::Config>::NativeBalance::hold(
+            &HoldReason::StorageProviderDeposit.into(),
+            &1,
+            provider_balance / 100
+        ));
+        assert_ok!(<Test as crate::Config>::NativeBalance::hold(
+            &HoldReason::StorageProviderDeposit.into(),
+            &2,
+            provider_balance / 100
+        ));
 
         // Initialise providers
         assert_ok!(ProofsDealer::initialise_challenge_cycle(&provider_id_1));
@@ -794,6 +843,13 @@ fn submit_proof_success() {
                 payment_account: Default::default(),
             },
         );
+
+        // Hold some of the Provider's balance so it simulates it having a stake.
+        assert_ok!(<Test as crate::Config>::NativeBalance::hold(
+            &HoldReason::StorageProviderDeposit.into(),
+            &1,
+            user_balance / 100
+        ));
 
         // Set Provider's root to be an arbitrary value, different than the default root,
         // to simulate that it is actually providing a service.
@@ -923,6 +979,13 @@ fn submit_proof_adds_provider_to_valid_submitters_set() {
             },
         );
 
+        // Hold some of the Provider's balance so it simulates it having a stake.
+        assert_ok!(<Test as crate::Config>::NativeBalance::hold(
+            &HoldReason::StorageProviderDeposit.into(),
+            &1,
+            user_balance / 100
+        ));
+
         // Set Provider's root to be an arbitrary value, different than the default root,
         // to simulate that it is actually providing a service.
         let root = BlakeTwo256::hash(b"1234");
@@ -1034,6 +1097,18 @@ fn submit_proof_submitted_by_not_a_provider_success() {
             },
         );
 
+        // Add balance to that Provider and hold some so it has a stake.
+        let provider_balance = 1_000_000_000_000_000;
+        assert_ok!(<Test as crate::Config>::NativeBalance::mint_into(
+            &1,
+            provider_balance
+        ));
+        assert_ok!(<Test as crate::Config>::NativeBalance::hold(
+            &HoldReason::StorageProviderDeposit.into(),
+            &1,
+            provider_balance / 100
+        ));
+
         // Set Provider's root to be an arbitrary value, different than the default root,
         // to simulate that it is actually providing a service.
         let root = BlakeTwo256::hash(b"1234");
@@ -1124,6 +1199,13 @@ fn submit_proof_with_checkpoint_challenges_success() {
                 payment_account: Default::default(),
             },
         );
+
+        // Hold some of the Provider's balance so it simulates it having a stake.
+        assert_ok!(<Test as crate::Config>::NativeBalance::hold(
+            &HoldReason::StorageProviderDeposit.into(),
+            &1,
+            user_balance / 100
+        ));
 
         // Set Provider's root to be an arbitrary value, different than the default root,
         // to simulate that it is actually providing a service.
@@ -1233,6 +1315,13 @@ fn submit_proof_with_checkpoint_challenges_mutations_success() {
                 payment_account: Default::default(),
             },
         );
+
+        // Hold some of the Provider's balance so it simulates it having a stake.
+        assert_ok!(<Test as crate::Config>::NativeBalance::hold(
+            &HoldReason::StorageProviderDeposit.into(),
+            &1,
+            user_balance / 100
+        ));
 
         // Set Provider's root to be an arbitrary value, different than the default root,
         // to simulate that it is actually providing a service.
@@ -1568,6 +1657,13 @@ fn submit_proof_challenges_block_not_reached_fail() {
             },
         );
 
+        // Hold some of the Provider's balance so it simulates it having a stake.
+        assert_ok!(<Test as crate::Config>::NativeBalance::hold(
+            &HoldReason::StorageProviderDeposit.into(),
+            &1,
+            user_balance / 100
+        ));
+
         // Set Provider's root to be an arbitrary value, different than the default root,
         // to simulate that it is actually providing a service.
         let root = BlakeTwo256::hash(b"1234");
@@ -1645,6 +1741,13 @@ fn submit_proof_challenges_block_too_old_fail() {
             },
         );
 
+        // Hold some of the Provider's balance so it simulates it having a stake.
+        assert_ok!(<Test as crate::Config>::NativeBalance::hold(
+            &HoldReason::StorageProviderDeposit.into(),
+            &1,
+            user_balance / 100
+        ));
+
         // Set Provider's root to be an arbitrary value, different than the default root,
         // to simulate that it is actually providing a service.
         let root = BlakeTwo256::hash(b"1234");
@@ -1721,6 +1824,13 @@ fn submit_proof_seed_not_found_fail() {
                 payment_account: Default::default(),
             },
         );
+
+        // Hold some of the Provider's balance so it simulates it having a stake.
+        assert_ok!(<Test as crate::Config>::NativeBalance::hold(
+            &HoldReason::StorageProviderDeposit.into(),
+            &1,
+            user_balance / 100
+        ));
 
         // Set Provider's root to be an arbitrary value, different than the default root,
         // to simulate that it is actually providing a service.
@@ -1801,6 +1911,13 @@ fn submit_proof_checkpoint_challenge_not_found_fail() {
                 payment_account: Default::default(),
             },
         );
+
+        // Hold some of the Provider's balance so it simulates it having a stake.
+        assert_ok!(<Test as crate::Config>::NativeBalance::hold(
+            &HoldReason::StorageProviderDeposit.into(),
+            &1,
+            user_balance / 100
+        ));
 
         // Set Provider's root to be an arbitrary value, different than the default root,
         // to simulate that it is actually providing a service.
@@ -1887,6 +2004,13 @@ fn submit_proof_forest_proof_verification_fail() {
             },
         );
 
+        // Hold some of the Provider's balance so it simulates it having a stake.
+        assert_ok!(<Test as crate::Config>::NativeBalance::hold(
+            &HoldReason::StorageProviderDeposit.into(),
+            &1,
+            user_balance / 100
+        ));
+
         // Set Provider's root to be an arbitrary value, different than the default root,
         // to simulate that it is actually providing a service.
         let root = BlakeTwo256::hash(b"1234");
@@ -1970,6 +2094,13 @@ fn submit_proof_no_key_proofs_for_keys_verified_in_forest_fail() {
             },
         );
 
+        // Hold some of the Provider's balance so it simulates it having a stake.
+        assert_ok!(<Test as crate::Config>::NativeBalance::hold(
+            &HoldReason::StorageProviderDeposit.into(),
+            &1,
+            user_balance / 100
+        ));
+
         // Set Provider's root to be an arbitrary value, different than the default root,
         // to simulate that it is actually providing a service.
         let root = BlakeTwo256::hash(b"1234");
@@ -2035,6 +2166,13 @@ fn submit_proof_out_checkpoint_challenges_fail() {
                 payment_account: Default::default(),
             },
         );
+
+        // Hold some of the Provider's balance so it simulates it having a stake.
+        assert_ok!(<Test as crate::Config>::NativeBalance::hold(
+            &HoldReason::StorageProviderDeposit.into(),
+            &1,
+            user_balance / 100
+        ));
 
         // Set Provider's root to be an arbitrary value, different than the default root,
         // to simulate that it is actually providing a service.
@@ -2148,6 +2286,13 @@ fn submit_proof_key_proof_verification_fail() {
                 payment_account: Default::default(),
             },
         );
+
+        // Hold some of the Provider's balance so it simulates it having a stake.
+        assert_ok!(<Test as crate::Config>::NativeBalance::hold(
+            &HoldReason::StorageProviderDeposit.into(),
+            &1,
+            user_balance / 100
+        ));
 
         // Set Provider's root to be an arbitrary value, different than the default root,
         // to simulate that it is actually providing a service.
@@ -2544,6 +2689,18 @@ fn new_challenges_round_provider_marked_as_slashable() {
             },
         );
 
+        // Add balance to that Provider and hold some so it has a stake.
+        let provider_balance = 1_000_000_000_000_000;
+        assert_ok!(<Test as crate::Config>::NativeBalance::mint_into(
+            &1,
+            provider_balance
+        ));
+        assert_ok!(<Test as crate::Config>::NativeBalance::hold(
+            &HoldReason::StorageProviderDeposit.into(),
+            &1,
+            provider_balance / 100
+        ));
+
         // Set Provider's root to be an arbitrary value, different than the default root,
         // to simulate that it is actually providing a service.
         let root = BlakeTwo256::hash(b"1234");
@@ -2730,6 +2887,18 @@ fn new_challenges_round_bad_provider_marked_as_slashable_but_good_no() {
             },
         );
 
+        // Add balance to Alice and hold some so it has a stake.
+        let alice_balance = 1_000_000_000_000_000;
+        assert_ok!(<Test as crate::Config>::NativeBalance::mint_into(
+            &1,
+            alice_balance
+        ));
+        assert_ok!(<Test as crate::Config>::NativeBalance::hold(
+            &HoldReason::StorageProviderDeposit.into(),
+            &1,
+            alice_balance / 100
+        ));
+
         // Register Bob as a Provider in Providers pallet.
         let bob_provider_id = BlakeTwo256::hash(b"bob_id");
         pallet_storage_providers::AccountIdToBackupStorageProviderId::<Test>::insert(
@@ -2748,6 +2917,18 @@ fn new_challenges_round_bad_provider_marked_as_slashable_but_good_no() {
                 payment_account: Default::default(),
             },
         );
+
+        // Add balance to Bob and hold some so it has a stake.
+        let bob_balance = 1_000_000_000_000_000;
+        assert_ok!(<Test as crate::Config>::NativeBalance::mint_into(
+            &2,
+            bob_balance
+        ));
+        assert_ok!(<Test as crate::Config>::NativeBalance::hold(
+            &HoldReason::StorageProviderDeposit.into(),
+            &2,
+            bob_balance / 100
+        ));
 
         // Set Alice and Bob's root to be an arbitrary value, different than the default root,
         // to simulate that they are actually providing a service.

--- a/pallets/providers/src/utils.rs
+++ b/pallets/providers/src/utils.rs
@@ -1144,7 +1144,7 @@ impl<T: pallet::Config> ProvidersInterface for pallet::Pallet<T> {
         if let Some(bucket) = Buckets::<T>::get(&who) {
             match MainStorageProviders::<T>::get(bucket.msp_id) {
                 Some(related_msp) => Some(T::NativeBalance::balance_on_hold(
-                    &HoldReason::StorageProviderDeposit.into(),
+                    &HoldReason::BucketDeposit.into(),
                     &related_msp.owner_account,
                 )),
                 None => None,


### PR DESCRIPTION
This PR implements the actual funcionality of getting the stake of a Provider from the `Providers` pallet, and updates `ProofsDealer` tests to work with this new functionality.