### PR TITLE
Refactor TrieLayout trait bound in StorageHubHandler and tasks

### DIFF
--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -21,10 +21,9 @@ use polkadot_primitives::{BlakeTwo256, HashT, HeadData, ValidationCode};
 use sc_consensus_manual_seal::consensus::aura::AuraConsensusDataProvider;
 use shc_actors_framework::actor::TaskSpawner;
 use shc_blockchain_service::BlockchainService;
-use shc_common::types::{HasherOutT, StorageProofsMerkleTrieLayout, BCSV_KEY_TYPE};
+use shc_common::types::{StorageProofsMerkleTrieLayout, BCSV_KEY_TYPE};
 use sp_consensus_aura::Slot;
 use sp_core::H256;
-use sp_trie::TrieLayout;
 // Local Runtime Types
 use storage_hub_runtime::{
     opaque::{Block, Hash},
@@ -193,19 +192,17 @@ pub fn new_partial(
     })
 }
 
-async fn init_sh_builder<T, FL, FS>(
+async fn init_sh_builder<FL, FS>(
     provider_options: &Option<ProviderOptions>,
     task_manager: &TaskManager,
     file_transfer_request_protocol: Option<(ProtocolName, Receiver<IncomingRequest>)>,
     network: Arc<ParachainNetworkService>,
     keystore: KeystorePtr,
-) -> Option<StorageHubBuilder<T, FL, FS>>
+) -> Option<StorageHubBuilder<FL, FS>>
 where
-    StorageHubBuilder<T, FL, FS>: StorageLayerBuilder,
-    T: TrieLayout + Send + Sync + 'static,
-    FL: FileStorage<T> + Send + Sync,
-    FS: ForestStorage<T> + Send + Sync + 'static,
-    HasherOutT<T>: TryFrom<[u8; 32]>,
+    StorageHubBuilder<FL, FS>: StorageLayerBuilder,
+    FL: FileStorage<StorageProofsMerkleTrieLayout> + Send + Sync,
+    FS: ForestStorage<StorageProofsMerkleTrieLayout> + Send + Sync + 'static,
 {
     match provider_options {
         Some(ProviderOptions { storage_path, .. }) => {
@@ -213,7 +210,7 @@ where
             let task_spawner = TaskSpawner::new(task_manager.spawn_handle(), "generic");
 
             // Create builder for the StorageHubHandler.
-            let mut storage_hub_builder = StorageHubBuilder::<T, FL, FS>::new(task_spawner);
+            let mut storage_hub_builder = StorageHubBuilder::new(task_spawner);
 
             // Add FileTransfer Service to the StorageHubHandler.
             let (file_transfer_request_protocol_name, file_transfer_request_receiver) =
@@ -239,18 +236,16 @@ where
     }
 }
 
-async fn finish_sh_builder_and_build<T, FL, FS>(
-    mut sh_builder: StorageHubBuilder<T, FL, FS>,
+async fn finish_sh_builder_and_build<FL, FS>(
+    mut sh_builder: StorageHubBuilder<FL, FS>,
     client: Arc<ParachainClient>,
     rpc_handlers: RpcHandlers,
     keystore: KeystorePtr,
     provider_options: ProviderOptions,
 ) where
-    StorageHubBuilder<T, FL, FS>: StorageLayerBuilder,
-    T: TrieLayout + Send + Sync + 'static,
-    FL: FileStorage<T> + Send + Sync,
-    FS: ForestStorage<T> + Send + Sync + 'static,
-    HasherOutT<T>: TryFrom<[u8; 32]>,
+    StorageHubBuilder<FL, FS>: StorageLayerBuilder,
+    FL: FileStorage<StorageProofsMerkleTrieLayout> + Send + Sync,
+    FS: ForestStorage<StorageProofsMerkleTrieLayout> + Send + Sync + 'static,
 {
     // Spawn the Blockchain Service if node is running as a Storage Provider, now that
     // the rpc handlers has been created.
@@ -263,14 +258,12 @@ async fn finish_sh_builder_and_build<T, FL, FS>(
     start_provider_tasks(provider_options, sh_handler);
 }
 
-fn start_provider_tasks<T, FL, FS>(
+fn start_provider_tasks<FL, FS>(
     provider_options: ProviderOptions,
-    sh_handler: StorageHubHandler<T, FL, FS>,
+    sh_handler: StorageHubHandler<FL, FS>,
 ) where
-    T: TrieLayout + Send + Sync + 'static,
-    FL: FileStorage<T> + Send + Sync,
-    FS: ForestStorage<T> + Send + Sync + 'static,
-    HasherOutT<T>: TryFrom<[u8; 32]>,
+    FL: FileStorage<StorageProofsMerkleTrieLayout> + Send + Sync,
+    FS: ForestStorage<StorageProofsMerkleTrieLayout> + Send + Sync + 'static,
 {
     // Starting the tasks according to the provider type.
     match provider_options.provider_type {
@@ -282,7 +275,7 @@ fn start_provider_tasks<T, FL, FS>(
 
 /// Start a development node with the given solo chain `Configuration`.
 #[sc_tracing::logging::prefix_logs_with("Solo chain 💾")]
-async fn start_dev_impl<T, FL, FS>(
+async fn start_dev_impl<FL, FS>(
     config: Configuration,
     provider_options: Option<ProviderOptions>,
     hwbench: Option<sc_sysinfo::HwBench>,
@@ -290,11 +283,9 @@ async fn start_dev_impl<T, FL, FS>(
     sealing: cli::Sealing,
 ) -> sc_service::error::Result<TaskManager>
 where
-    T: TrieLayout + Send + Sync + 'static,
-    StorageHubBuilder<T, FL, FS>: StorageLayerBuilder,
-    FL: FileStorage<T> + Send + Sync,
-    FS: ForestStorage<T> + Send + Sync + 'static,
-    HasherOutT<T>: TryFrom<[u8; 32]>,
+    StorageHubBuilder<FL, FS>: StorageLayerBuilder,
+    FL: FileStorage<StorageProofsMerkleTrieLayout> + Send + Sync,
+    FS: ForestStorage<StorageProofsMerkleTrieLayout> + Send + Sync + 'static,
 {
     use async_io::Timer;
     use sc_consensus_manual_seal::{run_manual_seal, EngineCommand, ManualSealParams};
@@ -640,7 +631,7 @@ where
 ///
 /// This is the actual implementation that is abstract over the executor and the runtime api.
 #[sc_tracing::logging::prefix_logs_with("StorageHub 💾")]
-async fn start_node_impl<T, FL, FS>(
+async fn start_node_impl<FL, FS>(
     parachain_config: Configuration,
     polkadot_config: Configuration,
     collator_options: CollatorOptions,
@@ -649,11 +640,9 @@ async fn start_node_impl<T, FL, FS>(
     hwbench: Option<sc_sysinfo::HwBench>,
 ) -> sc_service::error::Result<(TaskManager, Arc<ParachainClient>)>
 where
-    StorageHubBuilder<T, FL, FS>: StorageLayerBuilder,
-    T: TrieLayout + Send + Sync + 'static,
-    FL: FileStorage<T> + Send + Sync,
-    FS: ForestStorage<T> + Send + Sync + 'static,
-    HasherOutT<T>: TryFrom<[u8; 32]>,
+    StorageHubBuilder<FL, FS>: StorageLayerBuilder,
+    FL: FileStorage<StorageProofsMerkleTrieLayout> + Send + Sync,
+    FS: ForestStorage<StorageProofsMerkleTrieLayout> + Send + Sync + 'static,
 {
     let parachain_config = prepare_node_config(parachain_config);
 
@@ -991,16 +980,17 @@ pub async fn start_dev_node(
     match provider_options {
         Some(provider_options) => match provider_options.storage_layer {
             StorageLayer::Memory => {
-                start_dev_impl::<
-                    StorageProofsMerkleTrieLayout,
-                    InMemoryFileStorage<_>,
-                    InMemoryForestStorage<_>,
-                >(config, Some(provider_options), hwbench, para_id, sealing)
+                start_dev_impl::<InMemoryFileStorage<_>, InMemoryForestStorage<_>>(
+                    config,
+                    Some(provider_options),
+                    hwbench,
+                    para_id,
+                    sealing,
+                )
                 .await
             }
             StorageLayer::RocksDB => {
                 start_dev_impl::<
-                    StorageProofsMerkleTrieLayout,
                     RocksDbFileStorage<_, kvdb_rocksdb::Database>,
                     RocksDBForestStorage<_, kvdb_rocksdb::Database>,
                 >(config, Some(provider_options), hwbench, para_id, sealing)
@@ -1010,11 +1000,9 @@ pub async fn start_dev_node(
         // In this case, it is not really important the types used for the storage layer, as
         // the node will not run as a provider.
         None => {
-            start_dev_impl::<
-                StorageProofsMerkleTrieLayout,
-                InMemoryFileStorage<_>,
-                InMemoryForestStorage<_>,
-            >(config, None, hwbench, para_id, sealing)
+            start_dev_impl::<InMemoryFileStorage<_>, InMemoryForestStorage<_>>(
+                config, None, hwbench, para_id, sealing,
+            )
             .await
         }
     }
@@ -1032,11 +1020,7 @@ pub async fn start_parachain_node(
     match provider_options {
         Some(provider_options) => match provider_options.storage_layer {
             StorageLayer::Memory => {
-                start_node_impl::<
-                    StorageProofsMerkleTrieLayout,
-                    InMemoryFileStorage<_>,
-                    InMemoryForestStorage<_>,
-                >(
+                start_node_impl::<InMemoryFileStorage<_>, InMemoryForestStorage<_>>(
                     parachain_config,
                     polkadot_config,
                     collator_options,
@@ -1048,7 +1032,6 @@ pub async fn start_parachain_node(
             }
             StorageLayer::RocksDB => {
                 start_node_impl::<
-                    StorageProofsMerkleTrieLayout,
                     RocksDbFileStorage<_, kvdb_rocksdb::Database>,
                     RocksDBForestStorage<_, kvdb_rocksdb::Database>,
                 >(
@@ -1065,11 +1048,7 @@ pub async fn start_parachain_node(
         None => {
             // In this case, it is not really important the types used for the storage layer, as
             // the node will not run as a provider.
-            start_node_impl::<
-                StorageProofsMerkleTrieLayout,
-                InMemoryFileStorage<_>,
-                InMemoryForestStorage<_>,
-            >(
+            start_node_impl::<InMemoryFileStorage<_>, InMemoryForestStorage<_>>(
                 parachain_config,
                 polkadot_config,
                 collator_options,

--- a/node/src/services/handler.rs
+++ b/node/src/services/handler.rs
@@ -1,6 +1,4 @@
-use shc_common::types::HasherOutT;
-use sp_trie::TrieLayout;
-use std::{marker::PhantomData, sync::Arc};
+use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use shc_actors_framework::{
@@ -18,6 +16,7 @@ use shc_file_transfer_service::{
     FileTransferService,
 };
 use shc_forest_manager::traits::ForestStorage;
+use storage_hub_runtime::StorageProofsMerkleTrieLayout;
 
 use crate::tasks::slash_provider::SlashProviderTask;
 use crate::tasks::{
@@ -26,11 +25,10 @@ use crate::tasks::{
 };
 
 /// Represents the handler for the Storage Hub service.
-pub struct StorageHubHandler<T, FL, FS>
+pub struct StorageHubHandler<FL, FS>
 where
-    T: TrieLayout,
-    FL: FileStorage<T> + Send + Sync,
-    FS: ForestStorage<T> + Send + Sync,
+    FL: FileStorage<StorageProofsMerkleTrieLayout> + Send + Sync,
+    FS: ForestStorage<StorageProofsMerkleTrieLayout> + Send + Sync,
 {
     /// The task spawner for spawning asynchronous tasks.
     pub task_spawner: TaskSpawner,
@@ -42,34 +40,28 @@ where
     pub file_storage: Arc<RwLock<FL>>,
     /// The forest storage layer which tracks all complete files stored in the file storage layer.
     pub forest_storage: Arc<RwLock<FS>>,
-
-    _marker: PhantomData<T>,
 }
 
-impl<T, FL, FS> Clone for StorageHubHandler<T, FL, FS>
+impl<FL, FS> Clone for StorageHubHandler<FL, FS>
 where
-    T: TrieLayout,
-    FL: FileStorage<T> + Send + Sync,
-    FS: ForestStorage<T> + Send + Sync,
+    FL: FileStorage<StorageProofsMerkleTrieLayout> + Send + Sync,
+    FS: ForestStorage<StorageProofsMerkleTrieLayout> + Send + Sync,
 {
-    fn clone(&self) -> StorageHubHandler<T, FL, FS> {
+    fn clone(&self) -> StorageHubHandler<FL, FS> {
         Self {
             task_spawner: self.task_spawner.clone(),
             file_transfer: self.file_transfer.clone(),
             blockchain: self.blockchain.clone(),
             file_storage: self.file_storage.clone(),
             forest_storage: self.forest_storage.clone(),
-            _marker: self._marker,
         }
     }
 }
 
-impl<T, FL, FS> StorageHubHandler<T, FL, FS>
+impl<FL, FS> StorageHubHandler<FL, FS>
 where
-    T: TrieLayout + Send + Sync + 'static,
-    FL: FileStorage<T> + Send + Sync,
-    FS: ForestStorage<T> + Send + Sync + 'static,
-    HasherOutT<T>: TryFrom<[u8; 32]>,
+    FL: FileStorage<StorageProofsMerkleTrieLayout> + Send + Sync,
+    FS: ForestStorage<StorageProofsMerkleTrieLayout> + Send + Sync + 'static,
 {
     pub fn new(
         task_spawner: TaskSpawner,
@@ -84,7 +76,6 @@ where
             blockchain,
             file_storage,
             forest_storage,
-            _marker: Default::default(),
         }
     }
 

--- a/node/src/tasks/bsp_download_file.rs
+++ b/node/src/tasks/bsp_download_file.rs
@@ -1,75 +1,62 @@
 use sc_tracing::tracing::{error, info};
 use shc_actors_framework::event_bus::EventHandler;
-use shc_common::types::HasherOutT;
+use shc_common::types::StorageProofsMerkleTrieLayout;
 use shc_file_manager::traits::FileStorage;
 use shc_file_transfer_service::{
     commands::FileTransferServiceInterface, events::RemoteDownloadRequest,
 };
 use shc_forest_manager::traits::ForestStorage;
-use shp_constants::H_LENGTH;
-use sp_trie::TrieLayout;
 
 use crate::services::handler::StorageHubHandler;
 
 const LOG_TARGET: &str = "bsp-download-file-task";
 
-pub struct BspDownloadFileTask<T, FL, FS>
+pub struct BspDownloadFileTask<FL, FS>
 where
-    T: TrieLayout,
-    FL: Send + Sync + FileStorage<T>,
-    FS: Send + Sync + ForestStorage<T>,
-    HasherOutT<T>: TryFrom<[u8; H_LENGTH]>,
+    FL: Send + Sync + FileStorage<StorageProofsMerkleTrieLayout>,
+    FS: Send + Sync + ForestStorage<StorageProofsMerkleTrieLayout>,
 {
-    storage_hub_handler: StorageHubHandler<T, FL, FS>,
+    storage_hub_handler: StorageHubHandler<FL, FS>,
 }
 
-impl<T, FL, FS> Clone for BspDownloadFileTask<T, FL, FS>
+impl<FL, FS> Clone for BspDownloadFileTask<FL, FS>
 where
-    T: TrieLayout,
-    FL: Send + Sync + FileStorage<T>,
-    FS: Send + Sync + ForestStorage<T>,
-    HasherOutT<T>: TryFrom<[u8; H_LENGTH]>,
+    FL: Send + Sync + FileStorage<StorageProofsMerkleTrieLayout>,
+    FS: Send + Sync + ForestStorage<StorageProofsMerkleTrieLayout>,
 {
-    fn clone(&self) -> BspDownloadFileTask<T, FL, FS> {
+    fn clone(&self) -> BspDownloadFileTask<FL, FS> {
         Self {
             storage_hub_handler: self.storage_hub_handler.clone(),
         }
     }
 }
 
-impl<T, FL, FS> BspDownloadFileTask<T, FL, FS>
+impl<FL, FS> BspDownloadFileTask<FL, FS>
 where
-    T: TrieLayout,
-    FL: Send + Sync + FileStorage<T>,
-    FS: Send + Sync + ForestStorage<T>,
-    HasherOutT<T>: TryFrom<[u8; H_LENGTH]>,
+    FL: Send + Sync + FileStorage<StorageProofsMerkleTrieLayout>,
+    FS: Send + Sync + ForestStorage<StorageProofsMerkleTrieLayout>,
 {
-    pub fn new(storage_hub_handler: StorageHubHandler<T, FL, FS>) -> Self {
+    pub fn new(storage_hub_handler: StorageHubHandler<FL, FS>) -> Self {
         Self {
             storage_hub_handler,
         }
     }
 }
 
-impl<T, FL, FS> EventHandler<RemoteDownloadRequest> for BspDownloadFileTask<T, FL, FS>
+impl<FL, FS> EventHandler<RemoteDownloadRequest> for BspDownloadFileTask<FL, FS>
 where
-    T: TrieLayout + Send + Sync + 'static,
-    FL: FileStorage<T> + Send + Sync,
-    FS: ForestStorage<T> + Send + Sync + 'static,
-    HasherOutT<T>: TryFrom<[u8; H_LENGTH]>,
+    FL: FileStorage<StorageProofsMerkleTrieLayout> + Send + Sync,
+    FS: ForestStorage<StorageProofsMerkleTrieLayout> + Send + Sync + 'static,
 {
     async fn handle_event(&mut self, event: RemoteDownloadRequest) -> anyhow::Result<()> {
         info!(target: LOG_TARGET, "Received remote download request with id {:?} for file {:?}", event.request_id, event.file_key);
 
         let chunk_id = event.chunk_id;
         let request_id = event.request_id;
-        // TODO: use helper method defined in RocksDbFileStorage
-        let file_key: HasherOutT<T> = TryFrom::try_from(*event.file_key.as_ref())
-            .map_err(|_| anyhow::anyhow!("File key and HasherOutT mismatch!"))?;
 
         let file_storage_read_lock = self.storage_hub_handler.file_storage.read().await;
         let generate_proof_result =
-            file_storage_read_lock.generate_proof(&file_key, &vec![chunk_id]);
+            file_storage_read_lock.generate_proof(&event.file_key.into(), &vec![chunk_id]);
 
         match generate_proof_result {
             Ok(file_key_proof) => {
@@ -79,7 +66,7 @@ where
                     .await?;
             }
             Err(error) => {
-                error!(target: LOG_TARGET, "Failed to generate proof for chunk id {:?} of file {:?}", chunk_id, file_key);
+                error!(target: LOG_TARGET, "Failed to generate proof for chunk id {:?} of file {:?}", chunk_id, event.file_key);
                 return Err(anyhow::anyhow!("{:?}", error));
             }
         }

--- a/node/src/tasks/mock_bsp_volunteer.rs
+++ b/node/src/tasks/mock_bsp_volunteer.rs
@@ -3,55 +3,51 @@ use std::time::Duration;
 use log::*;
 use shc_actors_framework::event_bus::EventHandler;
 use shc_blockchain_service::{commands::BlockchainServiceInterface, events::NewStorageRequest};
+use shc_common::types::StorageProofsMerkleTrieLayout;
 use shc_file_manager::traits::FileStorage;
 use shc_forest_manager::traits::ForestStorage;
 use sp_core::H256;
-use sp_trie::TrieLayout;
 
 use crate::services::handler::StorageHubHandler;
 
 const LOG_TARGET: &str = "bsp-volunteer-mock-task";
 
-pub struct BspVolunteerMockTask<T, FL, FS>
+pub struct BspVolunteerMockTask<FL, FS>
 where
-    T: Send + Sync + TrieLayout + 'static,
-    FL: Send + Sync + FileStorage<T>,
-    FS: Send + Sync + ForestStorage<T> + 'static,
+    FL: Send + Sync + FileStorage<StorageProofsMerkleTrieLayout>,
+    FS: Send + Sync + ForestStorage<StorageProofsMerkleTrieLayout> + 'static,
 {
-    storage_hub_handler: StorageHubHandler<T, FL, FS>,
+    storage_hub_handler: StorageHubHandler<FL, FS>,
 }
 
-impl<T, FL, FS> Clone for BspVolunteerMockTask<T, FL, FS>
+impl<FL, FS> Clone for BspVolunteerMockTask<FL, FS>
 where
-    T: Send + Sync + TrieLayout + 'static,
-    FL: Send + Sync + FileStorage<T>,
-    FS: Send + Sync + ForestStorage<T> + 'static,
+    FL: Send + Sync + FileStorage<StorageProofsMerkleTrieLayout>,
+    FS: Send + Sync + ForestStorage<StorageProofsMerkleTrieLayout> + 'static,
 {
-    fn clone(&self) -> BspVolunteerMockTask<T, FL, FS> {
+    fn clone(&self) -> BspVolunteerMockTask<FL, FS> {
         Self {
             storage_hub_handler: self.storage_hub_handler.clone(),
         }
     }
 }
 
-impl<T, FL, FS> BspVolunteerMockTask<T, FL, FS>
+impl<FL, FS> BspVolunteerMockTask<FL, FS>
 where
-    T: Send + Sync + TrieLayout + 'static,
-    FL: Send + Sync + FileStorage<T>,
-    FS: Send + Sync + ForestStorage<T> + 'static,
+    FL: Send + Sync + FileStorage<StorageProofsMerkleTrieLayout>,
+    FS: Send + Sync + ForestStorage<StorageProofsMerkleTrieLayout> + 'static,
 {
-    pub fn new(storage_hub_handler: StorageHubHandler<T, FL, FS>) -> Self {
+    pub fn new(storage_hub_handler: StorageHubHandler<FL, FS>) -> Self {
         Self {
             storage_hub_handler,
         }
     }
 }
 
-impl<T, FL, FS> EventHandler<NewStorageRequest> for BspVolunteerMockTask<T, FL, FS>
+impl<FL, FS> EventHandler<NewStorageRequest> for BspVolunteerMockTask<FL, FS>
 where
-    T: Send + Sync + TrieLayout + 'static,
-    FL: Send + Sync + FileStorage<T>,
-    FS: Send + Sync + ForestStorage<T> + 'static,
+    FL: Send + Sync + FileStorage<StorageProofsMerkleTrieLayout>,
+    FS: Send + Sync + ForestStorage<StorageProofsMerkleTrieLayout> + 'static,
 {
     async fn handle_event(&mut self, event: NewStorageRequest) -> anyhow::Result<()> {
         info!(

--- a/node/src/tasks/mock_sp_react_to_event.rs
+++ b/node/src/tasks/mock_sp_react_to_event.rs
@@ -3,9 +3,9 @@ use std::time::Duration;
 use log::*;
 use shc_actors_framework::event_bus::EventHandler;
 use shc_blockchain_service::{commands::BlockchainServiceInterface, events::NewChallengeSeed};
+use shc_common::types::StorageProofsMerkleTrieLayout;
 use shc_file_manager::traits::FileStorage;
 use shc_forest_manager::traits::ForestStorage;
-use sp_trie::TrieLayout;
 
 use crate::services::handler::StorageHubHandler;
 
@@ -18,46 +18,42 @@ pub type EventToReactTo = NewChallengeSeed;
 ///
 /// This can be used for debugging purposes.
 /// The event to react to can be configured by setting the [`EventToReactTo`] type.
-pub struct SpReactToEventMockTask<T, FL, FS>
+pub struct SpReactToEventMockTask<FL, FS>
 where
-    T: Send + Sync + TrieLayout + 'static,
-    FL: Send + Sync + FileStorage<T>,
-    FS: Send + Sync + ForestStorage<T> + 'static,
+    FL: Send + Sync + FileStorage<StorageProofsMerkleTrieLayout>,
+    FS: Send + Sync + ForestStorage<StorageProofsMerkleTrieLayout> + 'static,
 {
-    storage_hub_handler: StorageHubHandler<T, FL, FS>,
+    storage_hub_handler: StorageHubHandler<FL, FS>,
 }
 
-impl<T, FL, FS> Clone for SpReactToEventMockTask<T, FL, FS>
+impl<FL, FS> Clone for SpReactToEventMockTask<FL, FS>
 where
-    T: Send + Sync + TrieLayout + 'static,
-    FL: Send + Sync + FileStorage<T>,
-    FS: Send + Sync + ForestStorage<T> + 'static,
+    FL: Send + Sync + FileStorage<StorageProofsMerkleTrieLayout>,
+    FS: Send + Sync + ForestStorage<StorageProofsMerkleTrieLayout> + 'static,
 {
-    fn clone(&self) -> SpReactToEventMockTask<T, FL, FS> {
+    fn clone(&self) -> SpReactToEventMockTask<FL, FS> {
         Self {
             storage_hub_handler: self.storage_hub_handler.clone(),
         }
     }
 }
 
-impl<T, FL, FS> SpReactToEventMockTask<T, FL, FS>
+impl<FL, FS> SpReactToEventMockTask<FL, FS>
 where
-    T: Send + Sync + TrieLayout + 'static,
-    FL: Send + Sync + FileStorage<T>,
-    FS: Send + Sync + ForestStorage<T> + 'static,
+    FL: Send + Sync + FileStorage<StorageProofsMerkleTrieLayout>,
+    FS: Send + Sync + ForestStorage<StorageProofsMerkleTrieLayout> + 'static,
 {
-    pub fn new(storage_hub_handler: StorageHubHandler<T, FL, FS>) -> Self {
+    pub fn new(storage_hub_handler: StorageHubHandler<FL, FS>) -> Self {
         Self {
             storage_hub_handler,
         }
     }
 }
 
-impl<T, FL, FS> EventHandler<EventToReactTo> for SpReactToEventMockTask<T, FL, FS>
+impl<FL, FS> EventHandler<EventToReactTo> for SpReactToEventMockTask<FL, FS>
 where
-    T: Send + Sync + TrieLayout + 'static,
-    FL: Send + Sync + FileStorage<T>,
-    FS: Send + Sync + ForestStorage<T> + 'static,
+    FL: Send + Sync + FileStorage<StorageProofsMerkleTrieLayout>,
+    FS: Send + Sync + ForestStorage<StorageProofsMerkleTrieLayout> + 'static,
 {
     async fn handle_event(&mut self, event: EventToReactTo) -> anyhow::Result<()> {
         info!(

--- a/node/src/tasks/mod.rs
+++ b/node/src/tasks/mod.rs
@@ -12,59 +12,50 @@ pub mod user_sends_file;
 use sc_tracing::tracing::info;
 use shc_actors_framework::event_bus::EventHandler;
 use shc_blockchain_service::events::{AcceptedBspVolunteer, NewStorageRequest};
-use shc_common::types::HasherOutT;
+use shc_common::types::StorageProofsMerkleTrieLayout;
 use shc_file_manager::traits::FileStorage;
 use shc_file_transfer_service::events::RemoteUploadRequest;
 use shc_forest_manager::traits::ForestStorage;
-use sp_trie::TrieLayout;
 
 use crate::services::handler::StorageHubHandler;
 
 // ! The following are examples of task definitions.
-pub struct ResolveRemoteUploadRequest<T, FL, FS>
+pub struct ResolveRemoteUploadRequest<FL, FS>
 where
-    T: TrieLayout,
-    FL: Send + Sync + FileStorage<T>,
-    FS: Send + Sync + ForestStorage<T>,
-    HasherOutT<T>: TryFrom<[u8; 32]>,
+    FL: Send + Sync + FileStorage<StorageProofsMerkleTrieLayout>,
+    FS: Send + Sync + ForestStorage<StorageProofsMerkleTrieLayout>,
 {
-    _storage_hub_handler: StorageHubHandler<T, FL, FS>,
+    _storage_hub_handler: StorageHubHandler<FL, FS>,
 }
 
-impl<T, FL, FS> Clone for ResolveRemoteUploadRequest<T, FL, FS>
+impl<FL, FS> Clone for ResolveRemoteUploadRequest<FL, FS>
 where
-    T: TrieLayout,
-    FL: Send + Sync + FileStorage<T>,
-    FS: Send + Sync + ForestStorage<T>,
-    HasherOutT<T>: TryFrom<[u8; 32]>,
+    FL: Send + Sync + FileStorage<StorageProofsMerkleTrieLayout>,
+    FS: Send + Sync + ForestStorage<StorageProofsMerkleTrieLayout>,
 {
-    fn clone(&self) -> ResolveRemoteUploadRequest<T, FL, FS> {
+    fn clone(&self) -> ResolveRemoteUploadRequest<FL, FS> {
         Self {
             _storage_hub_handler: self._storage_hub_handler.clone(),
         }
     }
 }
 
-impl<T, FL, FS> ResolveRemoteUploadRequest<T, FL, FS>
+impl<FL, FS> ResolveRemoteUploadRequest<FL, FS>
 where
-    T: TrieLayout,
-    FL: Send + Sync + FileStorage<T>,
-    FS: Send + Sync + ForestStorage<T>,
-    HasherOutT<T>: TryFrom<[u8; 32]>,
+    FL: Send + Sync + FileStorage<StorageProofsMerkleTrieLayout>,
+    FS: Send + Sync + ForestStorage<StorageProofsMerkleTrieLayout>,
 {
-    pub fn new(storage_hub_handler: StorageHubHandler<T, FL, FS>) -> Self {
+    pub fn new(storage_hub_handler: StorageHubHandler<FL, FS>) -> Self {
         Self {
             _storage_hub_handler: storage_hub_handler,
         }
     }
 }
 
-impl<T, FL, FS> EventHandler<RemoteUploadRequest> for ResolveRemoteUploadRequest<T, FL, FS>
+impl<FL, FS> EventHandler<RemoteUploadRequest> for ResolveRemoteUploadRequest<FL, FS>
 where
-    T: Send + Sync + TrieLayout + 'static,
-    FL: Send + Sync + FileStorage<T>,
-    FS: Send + Sync + ForestStorage<T> + 'static,
-    HasherOutT<T>: TryFrom<[u8; 32]>,
+    FL: Send + Sync + FileStorage<StorageProofsMerkleTrieLayout>,
+    FS: Send + Sync + ForestStorage<StorageProofsMerkleTrieLayout> + 'static,
 {
     async fn handle_event(&mut self, event: RemoteUploadRequest) -> anyhow::Result<()> {
         info!(
@@ -78,50 +69,42 @@ where
     }
 }
 
-pub struct NewStorageRequestHandler<T, FL, FS>
+pub struct NewStorageRequestHandler<FL, FS>
 where
-    T: TrieLayout,
-    FL: Send + Sync + FileStorage<T>,
-    FS: Send + Sync + ForestStorage<T>,
-    HasherOutT<T>: TryFrom<[u8; 32]>,
+    FL: Send + Sync + FileStorage<StorageProofsMerkleTrieLayout>,
+    FS: Send + Sync + ForestStorage<StorageProofsMerkleTrieLayout>,
 {
-    _storage_hub_handler: StorageHubHandler<T, FL, FS>,
+    _storage_hub_handler: StorageHubHandler<FL, FS>,
 }
 
-impl<T, FL, FS> NewStorageRequestHandler<T, FL, FS>
+impl<FL, FS> NewStorageRequestHandler<FL, FS>
 where
-    T: TrieLayout,
-    FL: Send + Sync + FileStorage<T>,
-    FS: Send + Sync + ForestStorage<T>,
-    HasherOutT<T>: TryFrom<[u8; 32]>,
+    FL: Send + Sync + FileStorage<StorageProofsMerkleTrieLayout>,
+    FS: Send + Sync + ForestStorage<StorageProofsMerkleTrieLayout>,
 {
-    pub fn new(storage_hub_handler: StorageHubHandler<T, FL, FS>) -> Self {
+    pub fn new(storage_hub_handler: StorageHubHandler<FL, FS>) -> Self {
         Self {
             _storage_hub_handler: storage_hub_handler,
         }
     }
 }
 
-impl<T, FL, FS> Clone for NewStorageRequestHandler<T, FL, FS>
+impl<FL, FS> Clone for NewStorageRequestHandler<FL, FS>
 where
-    T: TrieLayout,
-    FL: Send + Sync + FileStorage<T>,
-    FS: Send + Sync + ForestStorage<T>,
-    HasherOutT<T>: TryFrom<[u8; 32]>,
+    FL: Send + Sync + FileStorage<StorageProofsMerkleTrieLayout>,
+    FS: Send + Sync + ForestStorage<StorageProofsMerkleTrieLayout>,
 {
-    fn clone(&self) -> NewStorageRequestHandler<T, FL, FS> {
+    fn clone(&self) -> NewStorageRequestHandler<FL, FS> {
         Self {
             _storage_hub_handler: self._storage_hub_handler.clone(),
         }
     }
 }
 
-impl<T, FL, FS> EventHandler<NewStorageRequest> for NewStorageRequestHandler<T, FL, FS>
+impl<FL, FS> EventHandler<NewStorageRequest> for NewStorageRequestHandler<FL, FS>
 where
-    T: Send + Sync + TrieLayout + 'static,
-    FL: Send + Sync + FileStorage<T>,
-    FS: Send + Sync + ForestStorage<T> + 'static,
-    HasherOutT<T>: TryFrom<[u8; 32]>,
+    FL: Send + Sync + FileStorage<StorageProofsMerkleTrieLayout>,
+    FS: Send + Sync + ForestStorage<StorageProofsMerkleTrieLayout> + 'static,
 {
     async fn handle_event(&mut self, event: NewStorageRequest) -> anyhow::Result<()> {
         info!("[NewStorageRequestHandler] - received event: {:?}", event);
@@ -132,50 +115,42 @@ where
     }
 }
 
-pub struct AcceptedBspVolunteerHandler<T, FL, FS>
+pub struct AcceptedBspVolunteerHandler<FL, FS>
 where
-    T: TrieLayout,
-    FL: Send + Sync + FileStorage<T>,
-    FS: Send + Sync + ForestStorage<T>,
-    HasherOutT<T>: TryFrom<[u8; 32]>,
+    FL: Send + Sync + FileStorage<StorageProofsMerkleTrieLayout>,
+    FS: Send + Sync + ForestStorage<StorageProofsMerkleTrieLayout>,
 {
-    _storage_hub_handler: StorageHubHandler<T, FL, FS>,
+    _storage_hub_handler: StorageHubHandler<FL, FS>,
 }
 
-impl<T, FL, FS> Clone for AcceptedBspVolunteerHandler<T, FL, FS>
+impl<FL, FS> Clone for AcceptedBspVolunteerHandler<FL, FS>
 where
-    T: TrieLayout,
-    FL: Send + Sync + FileStorage<T>,
-    FS: Send + Sync + ForestStorage<T>,
-    HasherOutT<T>: TryFrom<[u8; 32]>,
+    FL: Send + Sync + FileStorage<StorageProofsMerkleTrieLayout>,
+    FS: Send + Sync + ForestStorage<StorageProofsMerkleTrieLayout>,
 {
-    fn clone(&self) -> AcceptedBspVolunteerHandler<T, FL, FS> {
+    fn clone(&self) -> AcceptedBspVolunteerHandler<FL, FS> {
         Self {
             _storage_hub_handler: self._storage_hub_handler.clone(),
         }
     }
 }
 
-impl<T, FL, FS> AcceptedBspVolunteerHandler<T, FL, FS>
+impl<FL, FS> AcceptedBspVolunteerHandler<FL, FS>
 where
-    T: TrieLayout,
-    FL: Send + Sync + FileStorage<T>,
-    FS: Send + Sync + ForestStorage<T>,
-    HasherOutT<T>: TryFrom<[u8; 32]>,
+    FL: Send + Sync + FileStorage<StorageProofsMerkleTrieLayout>,
+    FS: Send + Sync + ForestStorage<StorageProofsMerkleTrieLayout>,
 {
-    pub fn new(storage_hub_handler: StorageHubHandler<T, FL, FS>) -> Self {
+    pub fn new(storage_hub_handler: StorageHubHandler<FL, FS>) -> Self {
         Self {
             _storage_hub_handler: storage_hub_handler,
         }
     }
 }
 
-impl<T, FL, FS> EventHandler<AcceptedBspVolunteer> for AcceptedBspVolunteerHandler<T, FL, FS>
+impl<FL, FS> EventHandler<AcceptedBspVolunteer> for AcceptedBspVolunteerHandler<FL, FS>
 where
-    T: Send + Sync + TrieLayout + 'static,
-    FL: Send + Sync + FileStorage<T>,
-    FS: Send + Sync + ForestStorage<T> + 'static,
-    HasherOutT<T>: TryFrom<[u8; 32]>,
+    FL: Send + Sync + FileStorage<StorageProofsMerkleTrieLayout>,
+    FS: Send + Sync + ForestStorage<StorageProofsMerkleTrieLayout> + 'static,
 {
     async fn handle_event(&mut self, event: AcceptedBspVolunteer) -> anyhow::Result<()> {
         info!("[NewStorageRequestHandler] - received event: {:?}", event);

--- a/primitives/file-metadata/src/lib.rs
+++ b/primitives/file-metadata/src/lib.rs
@@ -7,6 +7,7 @@ use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use shp_traits::AsCompact;
 use sp_arithmetic::traits::SaturatedConversion;
+use sp_core::H256;
 use sp_std::vec::Vec;
 
 /// A struct containing all the information about a file in StorageHub.
@@ -77,6 +78,20 @@ impl<const H_LENGTH: usize> From<Hash<H_LENGTH>> for FileKey<H_LENGTH> {
 impl<const H_LENGTH: usize> Into<Hash<H_LENGTH>> for FileKey<H_LENGTH> {
     fn into(self) -> Hash<H_LENGTH> {
         self.0
+    }
+}
+
+impl From<H256> for FileKey<32> {
+    fn from(hash: H256) -> Self {
+        let mut file_key = [0u8; 32];
+        file_key.copy_from_slice(hash.as_bytes());
+        Self(file_key)
+    }
+}
+
+impl Into<H256> for FileKey<32> {
+    fn into(self) -> H256 {
+        H256::from_slice(&self.0)
     }
 }
 


### PR DESCRIPTION
This PR removes generic `T` and `T: TrieLayout` and `HasherOutT<T>` trait bounds from `StorageHubHandler` and tasks by making it concrete. This makes working with storage and the client side easier by removing the need for awkward conversion between `HasherOutT<T>` and `H256`. 