### PR TITLE
fix: :adhesive_bandage: panic when building block if the collator doesn't include randomness

### DIFF
--- a/pallets/randomness/src/mock.rs
+++ b/pallets/randomness/src/mock.rs
@@ -81,19 +81,17 @@ impl pallet_balances::Config for Test {
 }
 
 pub struct BabeDataGetter;
-impl crate::GetBabeData<u64, Option<H256>> for BabeDataGetter {
+impl crate::GetBabeData<u64, H256> for BabeDataGetter {
     fn get_epoch_index() -> u64 {
         frame_system::Pallet::<Test>::block_number()
     }
-    fn get_epoch_randomness() -> Option<H256> {
-        Some(H256::from_slice(&blake2_256(
-            &Self::get_epoch_index().to_le_bytes(),
-        )))
+    fn get_epoch_randomness() -> H256 {
+        H256::from_slice(&blake2_256(&Self::get_epoch_index().to_le_bytes()))
     }
-    fn get_parent_randomness() -> Option<H256> {
-        Some(H256::from_slice(&blake2_256(
+    fn get_parent_randomness() -> H256 {
+        H256::from_slice(&blake2_256(
             &Self::get_epoch_index().saturating_sub(1).to_le_bytes(),
-        )))
+        ))
     }
 }
 

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -383,7 +383,7 @@ fn relay_chain_state_proof() -> RelayChainStateProof {
 }
 
 pub struct BabeDataGetter;
-impl pallet_randomness::GetBabeData<u64, Option<Hash>> for BabeDataGetter {
+impl pallet_randomness::GetBabeData<u64, Hash> for BabeDataGetter {
     // Tolerate panic here because this is only ever called in an inherent (so can be omitted)
     fn get_epoch_index() -> u64 {
         if cfg!(feature = "runtime-benchmarks") {
@@ -399,26 +399,27 @@ impl pallet_randomness::GetBabeData<u64, Option<Hash>> for BabeDataGetter {
             .flatten()
             .expect("expected to be able to read epoch index from relay chain state proof")
     }
-    fn get_epoch_randomness() -> Option<Hash> {
+    fn get_epoch_randomness() -> Hash {
         if cfg!(feature = "runtime-benchmarks") {
             // storage reads as per actual reads
             let _relay_storage_root = ParachainSystem::validation_data();
             let _relay_chain_state = ParachainSystem::relay_state_proof();
             let benchmarking_babe_output = Hash::default();
-            return Some(benchmarking_babe_output);
+            return benchmarking_babe_output;
         }
         relay_chain_state_proof()
             .read_optional_entry(well_known_keys::ONE_EPOCH_AGO_RANDOMNESS)
             .ok()
             .flatten()
+            .expect("expected to be able to read epoch randomness from relay chain state proof")
     }
-    fn get_parent_randomness() -> Option<Hash> {
+    fn get_parent_randomness() -> Hash {
         if cfg!(feature = "runtime-benchmarks") {
             // storage reads as per actual reads
             let _relay_storage_root = ParachainSystem::validation_data();
             let _relay_chain_state = ParachainSystem::relay_state_proof();
             let benchmarking_babe_output = Hash::default();
-            return Some(benchmarking_babe_output);
+            return benchmarking_babe_output;
         }
         // Note: we use the `CURRENT_BLOCK_RANDOMNESS` key here as it also represents the parent randomness, the only difference
         // is the block since this randomness is valid, but we don't care about that because we are setting that directly in the `randomness` pallet.
@@ -426,6 +427,7 @@ impl pallet_randomness::GetBabeData<u64, Option<Hash>> for BabeDataGetter {
             .read_optional_entry(well_known_keys::CURRENT_BLOCK_RANDOMNESS)
             .ok()
             .flatten()
+            .expect("expected to be able to read parent randomness from relay chain state proof")
     }
 }
 

--- a/xcm-simulator/src/storagehub/configs/mod.rs
+++ b/xcm-simulator/src/storagehub/configs/mod.rs
@@ -389,7 +389,7 @@ fn relay_chain_state_proof() -> RelayChainStateProof {
 }
 
 pub struct BabeDataGetter;
-impl pallet_randomness::GetBabeData<u64, Option<Hash>> for BabeDataGetter {
+impl pallet_randomness::GetBabeData<u64, Hash> for BabeDataGetter {
     // Tolerate panic here because this is only ever called in an inherent (so can be omitted)
     fn get_epoch_index() -> u64 {
         if cfg!(feature = "runtime-benchmarks") {
@@ -405,26 +405,27 @@ impl pallet_randomness::GetBabeData<u64, Option<Hash>> for BabeDataGetter {
             .flatten()
             .expect("expected to be able to read epoch index from relay chain state proof")
     }
-    fn get_epoch_randomness() -> Option<Hash> {
+    fn get_epoch_randomness() -> Hash {
         if cfg!(feature = "runtime-benchmarks") {
             // storage reads as per actual reads
             let _relay_storage_root = ParachainSystem::validation_data();
             let _relay_chain_state = ParachainSystem::relay_state_proof();
             let benchmarking_babe_output = Hash::default();
-            return Some(benchmarking_babe_output);
+            return benchmarking_babe_output;
         }
         relay_chain_state_proof()
             .read_optional_entry(well_known_keys::ONE_EPOCH_AGO_RANDOMNESS)
             .ok()
             .flatten()
+            .expect("expected to be able to read epoch randomness from relay chain state proof")
     }
-    fn get_parent_randomness() -> Option<Hash> {
+    fn get_parent_randomness() -> Hash {
         if cfg!(feature = "runtime-benchmarks") {
             // storage reads as per actual reads
             let _relay_storage_root = ParachainSystem::validation_data();
             let _relay_chain_state = ParachainSystem::relay_state_proof();
             let benchmarking_babe_output = Hash::default();
-            return Some(benchmarking_babe_output);
+            return benchmarking_babe_output;
         }
         // Note: we use the `CURRENT_BLOCK_RANDOMNESS` key here as it also represents the parent randomness, the only difference
         // is the block since this randomness is valid, but we don't care about that because we are setting that directly in the `randomness` pallet.
@@ -432,6 +433,7 @@ impl pallet_randomness::GetBabeData<u64, Option<Hash>> for BabeDataGetter {
             .read_optional_entry(well_known_keys::CURRENT_BLOCK_RANDOMNESS)
             .ok()
             .flatten()
+            .expect("expected to be able to read parent randomness from relay chain state proof")
     }
 }
 


### PR DESCRIPTION
This PR solves issue [#13](https://github.com/Moonsong-Labs/internal-storage-hub-design-audit/issues/13) of the audit, by not allowing a collator to ignore adding the randomness from the relay chain into StorageHub.