### PR TITLE
test: 🧪 Add BSP testshelper

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,10 +13,10 @@ importers:
         version: 1.8.3
       '@types/node':
         specifier: 20.14.9
-        version: 22.4.1
+        version: 20.14.9
       typescript:
         specifier: 5.5.3
-        version: 5.5.4
+        version: 5.5.3
 
   api-augment:
     dependencies:
@@ -81,8 +81,8 @@ importers:
         specifier: workspace:*
         version: link:../types-bundle
       '@zombienet/cli':
-        specifier: 1.3.108
-        version: 1.3.108(@polkadot/util@13.0.2)(@types/node@22.4.1)(chokidar@3.6.0)
+        specifier: 1.3.109
+        version: 1.3.109(@polkadot/util@13.0.2)(@types/node@22.4.1)(chokidar@3.6.0)
       '@zombienet/utils':
         specifier: 0.0.25
         version: 0.0.25(@types/node@22.4.1)(chokidar@3.6.0)(typescript@5.5.4)
@@ -731,6 +731,9 @@ packages:
   '@types/node@18.19.45':
     resolution: {integrity: sha512-VZxPKNNhjKmaC1SUYowuXSRSMGyQGmQjvvA1xE4QZ0xce2kLtEhPDS+kqpCPBZYgqblCLQ2DAjSzmgCM5auvhA==}
 
+  '@types/node@20.14.9':
+    resolution: {integrity: sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==}
+
   '@types/node@22.4.1':
     resolution: {integrity: sha512-1tbpb9325+gPnKK0dMm+/LMriX0vKxf6RnB0SZUqfyVkQ4fMgUSySqhxE/y8Jvs4NyF1yHzTfG9KlnkIODxPKg==}
 
@@ -749,16 +752,16 @@ packages:
   '@types/wrap-ansi@3.0.0':
     resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
 
-  '@zombienet/cli@1.3.108':
-    resolution: {integrity: sha512-c5pUb8P3vl3k1/HUE1b4GHgGoOjcC8e27zFwRV9zHSpl3kKUQrL922R1BxGkz7E5WhLubCm9RCpKaS1/66doWQ==}
+  '@zombienet/cli@1.3.109':
+    resolution: {integrity: sha512-JxvXP4zpfMgbWLFn4gDohsSsGtlCLQfjxq91UAwEqth0mL81cg2qplT+exjvG4FQnCuWWM6JxfNWkrVWGlJkMQ==}
     engines: {node: '>=18'}
     hasBin: true
 
   '@zombienet/dsl-parser-wrapper@0.1.10':
     resolution: {integrity: sha512-2r2SjanMcNTQiiwTtj/TRO89ek4KoIKGKhgcdHm8+uXPVWuU3tIh/unN8+m51Jnm2jhCLkQQwa5aidvSC02wOg==}
 
-  '@zombienet/orchestrator@0.0.89':
-    resolution: {integrity: sha512-E9KftxZPrLH0+ULTqFRxpxLvO+snmkBJZGb35AZmL8wqRjwz3V6/ZU/hv6LMKi1Id9vylyu6K4aeYlE7moqQIA==}
+  '@zombienet/orchestrator@0.0.90':
+    resolution: {integrity: sha512-2LPrg0+zSwznaPkKfY6u76/88LWmSUen7R13tLNUoagGRIPZVdQ72bRduYTW/oFBI9S9ei906OkRP2OzyxWz/Q==}
     engines: {node: '>=18'}
 
   '@zombienet/utils@0.0.25':
@@ -1848,6 +1851,11 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
+  typescript@5.5.3:
+    resolution: {integrity: sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@5.5.4:
     resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
     engines: {node: '>=14.17'}
@@ -2712,6 +2720,10 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
+  '@types/node@20.14.9':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@22.4.1':
     dependencies:
       undici-types: 6.19.6
@@ -2735,10 +2747,10 @@ snapshots:
 
   '@types/wrap-ansi@3.0.0': {}
 
-  '@zombienet/cli@1.3.108(@polkadot/util@13.0.2)(@types/node@22.4.1)(chokidar@3.6.0)':
+  '@zombienet/cli@1.3.109(@polkadot/util@13.0.2)(@types/node@22.4.1)(chokidar@3.6.0)':
     dependencies:
       '@zombienet/dsl-parser-wrapper': 0.1.10
-      '@zombienet/orchestrator': 0.0.89(@polkadot/util@13.0.2)(@types/node@22.4.1)(chokidar@3.6.0)
+      '@zombienet/orchestrator': 0.0.90(@polkadot/util@13.0.2)(@types/node@22.4.1)(chokidar@3.6.0)
       '@zombienet/utils': 0.0.25(@types/node@22.4.1)(chokidar@3.6.0)(typescript@5.5.4)
       cli-progress: 3.12.0
       commander: 11.1.0
@@ -2758,7 +2770,7 @@ snapshots:
 
   '@zombienet/dsl-parser-wrapper@0.1.10': {}
 
-  '@zombienet/orchestrator@0.0.89(@polkadot/util@13.0.2)(@types/node@22.4.1)(chokidar@3.6.0)':
+  '@zombienet/orchestrator@0.0.90(@polkadot/util@13.0.2)(@types/node@22.4.1)(chokidar@3.6.0)':
     dependencies:
       '@polkadot/api': 12.3.1
       '@polkadot/keyring': 13.0.2(@polkadot/util-crypto@13.0.2(@polkadot/util@13.0.2))(@polkadot/util@13.0.2)
@@ -3995,6 +4007,8 @@ snapshots:
   type-detect@4.1.0: {}
 
   type-fest@0.21.3: {}
+
+  typescript@5.5.3: {}
 
   typescript@5.5.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: workspace:*
         version: link:../types-bundle
       '@zombienet/cli':
-        specifier: 1.3.109
-        version: 1.3.109(@polkadot/util@13.0.2)(@types/node@22.4.1)(chokidar@3.6.0)
+        specifier: 1.3.108
+        version: 1.3.108(@polkadot/util@13.0.2)(@types/node@22.4.1)(chokidar@3.6.0)
       '@zombienet/utils':
         specifier: 0.0.25
         version: 0.0.25(@types/node@22.4.1)(chokidar@3.6.0)(typescript@5.5.4)
@@ -752,16 +752,16 @@ packages:
   '@types/wrap-ansi@3.0.0':
     resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
 
-  '@zombienet/cli@1.3.109':
-    resolution: {integrity: sha512-JxvXP4zpfMgbWLFn4gDohsSsGtlCLQfjxq91UAwEqth0mL81cg2qplT+exjvG4FQnCuWWM6JxfNWkrVWGlJkMQ==}
+  '@zombienet/cli@1.3.108':
+    resolution: {integrity: sha512-c5pUb8P3vl3k1/HUE1b4GHgGoOjcC8e27zFwRV9zHSpl3kKUQrL922R1BxGkz7E5WhLubCm9RCpKaS1/66doWQ==}
     engines: {node: '>=18'}
     hasBin: true
 
   '@zombienet/dsl-parser-wrapper@0.1.10':
     resolution: {integrity: sha512-2r2SjanMcNTQiiwTtj/TRO89ek4KoIKGKhgcdHm8+uXPVWuU3tIh/unN8+m51Jnm2jhCLkQQwa5aidvSC02wOg==}
 
-  '@zombienet/orchestrator@0.0.90':
-    resolution: {integrity: sha512-2LPrg0+zSwznaPkKfY6u76/88LWmSUen7R13tLNUoagGRIPZVdQ72bRduYTW/oFBI9S9ei906OkRP2OzyxWz/Q==}
+  '@zombienet/orchestrator@0.0.89':
+    resolution: {integrity: sha512-E9KftxZPrLH0+ULTqFRxpxLvO+snmkBJZGb35AZmL8wqRjwz3V6/ZU/hv6LMKi1Id9vylyu6K4aeYlE7moqQIA==}
     engines: {node: '>=18'}
 
   '@zombienet/utils@0.0.25':
@@ -2747,10 +2747,10 @@ snapshots:
 
   '@types/wrap-ansi@3.0.0': {}
 
-  '@zombienet/cli@1.3.109(@polkadot/util@13.0.2)(@types/node@22.4.1)(chokidar@3.6.0)':
+  '@zombienet/cli@1.3.108(@polkadot/util@13.0.2)(@types/node@22.4.1)(chokidar@3.6.0)':
     dependencies:
       '@zombienet/dsl-parser-wrapper': 0.1.10
-      '@zombienet/orchestrator': 0.0.90(@polkadot/util@13.0.2)(@types/node@22.4.1)(chokidar@3.6.0)
+      '@zombienet/orchestrator': 0.0.89(@polkadot/util@13.0.2)(@types/node@22.4.1)(chokidar@3.6.0)
       '@zombienet/utils': 0.0.25(@types/node@22.4.1)(chokidar@3.6.0)(typescript@5.5.4)
       cli-progress: 3.12.0
       commander: 11.1.0
@@ -2770,7 +2770,7 @@ snapshots:
 
   '@zombienet/dsl-parser-wrapper@0.1.10': {}
 
-  '@zombienet/orchestrator@0.0.90(@polkadot/util@13.0.2)(@types/node@22.4.1)(chokidar@3.6.0)':
+  '@zombienet/orchestrator@0.0.89(@polkadot/util@13.0.2)(@types/node@22.4.1)(chokidar@3.6.0)':
     dependencies:
       '@polkadot/api': 12.3.1
       '@polkadot/keyring': 13.0.2(@polkadot/util-crypto@13.0.2(@polkadot/util@13.0.2))(@polkadot/util@13.0.2)

--- a/test/package.json
+++ b/test/package.json
@@ -57,7 +57,7 @@
     "@reporters/github": "1.7.0",
     "@storagehub/api-augment": "workspace:*",
     "@storagehub/types-bundle": "workspace:*",
-    "@zombienet/cli": "1.3.108",
+    "@zombienet/cli": "1.3.109",
     "@zombienet/utils": "0.0.25",
     "docker-compose": "0.24.8",
     "dockerode": "4.0.2",

--- a/test/package.json
+++ b/test/package.json
@@ -57,7 +57,7 @@
     "@reporters/github": "1.7.0",
     "@storagehub/api-augment": "workspace:*",
     "@storagehub/types-bundle": "workspace:*",
-    "@zombienet/cli": "1.3.109",
+    "@zombienet/cli": "1.3.108",
     "@zombienet/utils": "0.0.25",
     "docker-compose": "0.24.8",
     "dockerode": "4.0.2",

--- a/test/suites/integration/bsp/onboard.test.ts
+++ b/test/suites/integration/bsp/onboard.test.ts
@@ -28,7 +28,7 @@ for (const bspNetConfig of bspNetConfigCases) {
     });
 
     after(async () => {
-      await cleardownTest(api);
+      await cleardownTest({ api });
     });
 
     it("New BSP can be created", async () => {

--- a/test/suites/integration/bsp/slash-provider.test.ts
+++ b/test/suites/integration/bsp/slash-provider.test.ts
@@ -21,7 +21,7 @@ describe("BSPNet: Slash Provider", () => {
   });
 
   after(async () => {
-    await cleardownTest(api);
+    await cleardownTest({ api });
   });
 
   it("Network launches and can be queried", async () => {

--- a/test/util/asserts.ts
+++ b/test/util/asserts.ts
@@ -5,28 +5,6 @@ import type { AugmentedEvent } from "@polkadot/api/types";
 import type { BspNetApi } from "./bspNet";
 
 //TODO: add ability to search nested extrinsics e.g. sudo.sudo(balance.forceTransfer(...))
-/**
- * Asserts that an extrinsic is present in a block or transaction pool.
- * 
- * @param api - The connected API instance for interacting with a running BspNet.
- * @param options - Configuration options for the extrinsic assertion.
- * @param options.blockHeight - The block height to check. If not provided, checks the latest block.
- * @param options.enforceSuccess - If true, also checks for a successful extrinsic execution.
- * @param options.checkTxPool - If true, checks the transaction pool instead of a specific block.
- * @param options.module - The module name of the extrinsic to search for.
- * @param options.method - The method name of the extrinsic to search for.
- * @param options.ignoreParamCheck - If true, skips the check for module and method existence in the API metadata.
- * @returns A promise that resolves to an array of matching extrinsics, each containing module, method, and index.
- * @throws Throws an error if the specified extrinsic is not found or if the metadata check fails.
- * 
- * @example
- * const matches = await assertExtrinsicPresent(api, {
- *   module: 'balances',
- *   method: 'transfer',
- *   blockHeight: '1000000',
- *   enforceSuccess: true
- * });
- */
 export const assertExtrinsicPresent = async (
   api: BspNetApi,
   options: {
@@ -44,12 +22,19 @@ export const assertExtrinsicPresent = async (
     extIndex: number;
   }[]
 > => {
-  
-  if (options.ignoreParamCheck !== true){
-    strictEqual(options.module in api.tx, true, `Module ${options.module} not found in API metadata. Turn off this check with "ignoreParamCheck: true" if you are sure this exists`)
-    strictEqual(options.method in api.tx[options.module], true, `Method ${options.module}.${options.method} not found in metadata. Turn off this check with "ignoreParamCheck: true" if you are sure this exists`)
+  if (options.ignoreParamCheck !== true) {
+    strictEqual(
+      options.module in api.tx,
+      true,
+      `Module ${options.module} not found in API metadata. Turn off this check with "ignoreParamCheck: true" if you are sure this exists`
+    );
+    strictEqual(
+      options.method in api.tx[options.module],
+      true,
+      `Method ${options.module}.${options.method} not found in metadata. Turn off this check with "ignoreParamCheck: true" if you are sure this exists`
+    );
   }
-  
+
   const blockHash = await api.rpc.chain.getBlockHash(options?.blockHeight);
   const extrinsics = !options.checkTxPool
     ? await (async () => {
@@ -68,7 +53,7 @@ export const assertExtrinsicPresent = async (
   strictEqual(
     matches.length > 0,
     true,
-    `No extrinsics matching ${options?.module}.${options?.method} found. \n Extrinsics in block ${options.blockHeight || blockHash}: ${(extrinsics.map(({ method: { method, section } }) => `${section}.${method}`).join(" | "))}`
+    `No extrinsics matching ${options?.module}.${options?.method} found. \n Extrinsics in block ${options.blockHeight || blockHash}: ${extrinsics.map(({ method: { method, section } }) => `${section}.${method}`).join(" | ")}`
   );
 
   if (options?.enforceSuccess) {

--- a/test/util/asserts.ts
+++ b/test/util/asserts.ts
@@ -4,7 +4,24 @@ import type { ApiPromise } from "@polkadot/api";
 import type { AugmentedEvent } from "@polkadot/api/types";
 import type { BspNetApi } from "./bspNet";
 
-//TODO: add ability to search nested extrinsics e.g. sudo.sudo(balance.forceTransfer(...))
+/**
+ * Asserts that a specific extrinsic (module.method) is present in a blockchain block or transaction pool.
+ *
+ * @param {BspNetApi} api - The API instance connected to the blockchain network.
+ * @param {Object} options - Configuration options for the extrinsic check.
+ * @param {string} [options.blockHeight] - The block height to check. If not provided, the latest block will be used.
+ * @param {string} [options.blockHash] - The block hash to check. Takes precedence over blockHeight if provided.
+ * @param {boolean} [options.skipSuccessCheck=false] - If true, skips the check for an associated `ExtrinsicSuccess` event.
+ * @param {boolean} [options.checkTxPool=false] - If true, checks the pending transaction pool instead of a finalized block.
+ * @param {string} options.module - The module name of the extrinsic to check (e.g., "balances").
+ * @param {string} options.method - The method name of the extrinsic to check (e.g., "transfer").
+ * @param {boolean} [options.ignoreParamCheck=false] - If true, skips the validation check for the module.method existence in the API metadata.
+ *
+ * @returns {Promise<Object[]>} - Returns a list of objects representing the extrinsics that match the module.method criteria.
+ * @throws {Error} - Throws an error if no matching extrinsic is found, or if the success check fails (unless skipped).
+ *
+ * TODO: add ability to search nested extrinsics e.g. sudo.sudo(balance.forceTransfer(...))
+ */
 export const assertExtrinsicPresent = async (
   api: BspNetApi,
   options: {
@@ -76,6 +93,17 @@ export const assertExtrinsicPresent = async (
   return matches;
 };
 
+/**
+ * Asserts that a specific event (module.method) is present in the provided list of events.
+ *
+ * @param {ApiPromise} api - The API instance connected to the blockchain network.
+ * @param {string} module - The module name of the event to check (e.g., "system").
+ * @param {string} method - The method name of the event to check (e.g., "ExtrinsicSuccess").
+ * @param {EventRecord[]} [events] - The list of events to search through. If not provided or empty, an error is thrown.
+ *
+ * @returns {Object} - Returns an object containing the matching event and its data.
+ * @throws {Error} - Throws an error if no matching event is found, or if the event does not match the expected structure.
+ */
 export const assertEventPresent = (
   api: ApiPromise,
   module: string,
@@ -100,6 +128,17 @@ export const assertEventPresent = (
   return { event: event.event, data: event.event.data };
 };
 
+/**
+ * Asserts that multiple instances of a specific event (module.method) are present in the provided list of events.
+ *
+ * @param {ApiPromise} api - The API instance connected to the blockchain network.
+ * @param {string} module - The module name of the event to check (e.g., "system").
+ * @param {string} method - The method name of the event to check (e.g., "ExtrinsicSuccess").
+ * @param {EventRecord[]} [events] - The list of events to search through. If not provided or empty, an error is thrown.
+ *
+ * @returns {EventRecord[]} - Returns an array of matching events.
+ * @throws {Error} - Throws an error if no matching events are found.
+ */
 export const assertEventMany = (
   api: ApiPromise,
   module: string,

--- a/test/util/bspNet/helpers.ts
+++ b/test/util/bspNet/helpers.ts
@@ -1,3 +1,4 @@
+import "@storagehub/api-augment";
 import type { ApiPromise } from "@polkadot/api";
 import type { SubmittableExtrinsic } from "@polkadot/api/types";
 import type { KeyringPair } from "@polkadot/keyring/types";
@@ -717,9 +718,12 @@ export const createBucket = async (api: ApiPromise, bucketName: string) => {
   return event;
 };
 
-export const cleardownTest = async (api: BspNetApi) => {
-  await api.disconnect();
-  await closeSimpleBspNet();
+export const cleardownTest = async (cleardownOptions: {
+  api: BspNetApi;
+  keepNetworkAlive?: boolean;
+}) => {
+  await cleardownOptions.api.disconnect();
+  !cleardownOptions.keepNetworkAlive && (await closeSimpleBspNet());
 };
 
 export const createCheckBucket = async (api: BspNetApi, bucketName: string) => {

--- a/test/util/bspNet/helpers.ts
+++ b/test/util/bspNet/helpers.ts
@@ -723,7 +723,7 @@ export const cleardownTest = async (cleardownOptions: {
   keepNetworkAlive?: boolean;
 }) => {
   await cleardownOptions.api.disconnect();
-  !cleardownOptions.keepNetworkAlive && (await closeSimpleBspNet());
+  cleardownOptions.keepNetworkAlive === true ? null : await closeSimpleBspNet();
 };
 
 export const createCheckBucket = async (api: BspNetApi, bucketName: string) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,8 @@
 		// Bundler mode
 		"moduleResolution": "bundler",
 		"allowImportingTsExtensions": true,
+		"removeComments": false,
+		"sourceMap": true,
 		"verbatimModuleSyntax": true,
 		"noEmit": true,
 


### PR DESCRIPTION
## Added

- New helper: `assertExtrinsicPresent()`
```ts
async function assertExtrinsicPresent(
  api: BspNetApi,
  options: {
    blockHeight?: string;
    blockHash?: string;
    skipSuccessCheck?: boolean;
    checkTxPool?: boolean;
    module: string;
    method: string;
    ignoreParamCheck?: boolean;
  }
): Promise<
  {
    module: string;
    method: string;
    extIndex: number;
  }[]
> 
```
   - Will check the last block for extrinsic of `module.method`, throws or returns filtered list
   - Option to check against pending txPool instead of last block
   - Option to check of a particular block instead
   - Will verify whether the input module.method exists in the api blob (e.g. check for typos). Has option to disable
   - Will verify that it has associated extrinsicSuccess Event, with option to disable.
