### PR TITLE
fix FileTransferService register

### DIFF
--- a/client/file-transfer-service/src/handler.rs
+++ b/client/file-transfer-service/src/handler.rs
@@ -238,6 +238,11 @@ impl Actor for FileTransferService {
                         false => Err(RequestError::FileAlreadyRegisteredForPeer),
                     };
 
+                    self.peers_by_file
+                        .entry(file_key)
+                        .or_insert_with(Vec::new)
+                        .push(peer_id);
+
                     match callback.send(result) {
                         Ok(()) => {}
                         Err(_) => error!(

--- a/node/src/tasks/bsp_upload_file.rs
+++ b/node/src/tasks/bsp_upload_file.rs
@@ -443,13 +443,13 @@ where
             .unregister_file(file_key.as_ref().into())
             .await;
 
+        // TODO: Send transaction to runtime to unvolunteer the file.
+
         // Delete the file from the file storage.
         let mut write_file_storage = self.storage_hub_handler.file_storage.write().await;
 
         // TODO: Handle error
         let _ = write_file_storage.delete_file(&file_key);
-
-        // TODO: Send transaction to runtime to unvolunteer the file.
 
         Ok(())
     }
@@ -457,12 +457,12 @@ where
     async fn on_file_complete(&self, file_key: &H256) -> anyhow::Result<()> {
         info!(target: LOG_TARGET, "File upload complete ({:?})", file_key);
 
-        // // Unregister the file from the file transfer service.
-        // self.storage_hub_handler
-        //     .file_transfer
-        //     .unregister_file(file_key.as_ref().into())
-        //     .await
-        //     .map_err(|e| anyhow!("File is not registered. This should not happen!: {:?}", e))?;
+        // Unregister the file from the file transfer service.
+        self.storage_hub_handler
+            .file_transfer
+            .unregister_file((*file_key).into())
+            .await
+            .map_err(|e| anyhow!("File is not registered. This should not happen!: {:?}", e))?;
 
         // Queue a request to confirm the storing of the file.
         self.storage_hub_handler


### PR DESCRIPTION
This fixes `FileTransferService`'s `RegisterNewFile` command and also adds back the unregister once a file is complete.