### PR TITLE
fix: :bug: change how file tries are constructed to avoid sp_trie issue

### DIFF
--- a/client/common/src/types.rs
+++ b/client/common/src/types.rs
@@ -5,7 +5,7 @@ use sc_executor::WasmExecutor;
 use sc_network::NetworkService;
 use sc_service::TFullClient;
 pub use shp_constants::{FILE_CHUNK_SIZE, FILE_SIZE_TO_CHALLENGES, H_LENGTH};
-pub use shp_file_metadata::{Chunk, ChunkId, Leaf};
+pub use shp_file_metadata::{Chunk, ChunkId, ChunkWithId, Leaf};
 use shp_traits::CommitmentVerifier;
 use sp_core::Hasher;
 use sp_runtime::{traits::Block as BlockT, KeyTypeId};

--- a/client/file-manager/src/traits.rs
+++ b/client/file-manager/src/traits.rs
@@ -65,6 +65,8 @@ pub enum FileStorageError {
     FailedToParseFileMetadata,
     /// Failed to convert raw bytes into [`Fingerprint`].
     FailedToParseFingerprint,
+    /// Failed to convert raw bytes into [`ChunkWithId`].
+    FailedToParseChunkWithId,
     /// Failed to delete chunk from storage.
     FailedToDeleteFileChunk,
     /// Failed to convert raw bytes into partial root.

--- a/primitives/file-metadata/src/lib.rs
+++ b/primitives/file-metadata/src/lib.rs
@@ -237,6 +237,13 @@ impl ChunkId {
 /// Typed chunk of a file. This is what is stored in the leaf of the stored Merkle tree.
 pub type Chunk = Vec<u8>;
 
+/// A chunk with its ID. This is the actual data stored in the Merkle tree for each chunk.
+#[derive(Clone, Debug, Encode, Decode, PartialEq)]
+pub struct ChunkWithId {
+    pub chunk_id: ChunkId,
+    pub data: Chunk,
+}
+
 /// A leaf in the in a trie.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Leaf<K, D: Debug> {

--- a/test/util/bspNet/consts.ts
+++ b/test/util/bspNet/consts.ts
@@ -29,7 +29,7 @@ export const TEST_ARTEFACTS = {
   "res/adolphus.jpg": {
     size: 416400n,
     checksum: "739fb97f7c2b8e7f192b608722a60dc67ee0797c85ff1ea849c41333a40194f2",
-    fingerprint: "0x9e86ecad3f86f52891acf9c0d47c5c5243a3592fc7bcf99811eb7db078997dcb"
+    fingerprint: "0x34eb5f637e05fc18f857ccb013250076534192189894d174ee3aa6d3525f6970"
   },
   "res/smile.jpg": {
     size: 633160n,


### PR DESCRIPTION
File tries leaves are now chunk ID + chunk data instead of only chunk data, to avoid sp_trie optimizing the trie into fewer leaves and generating issues when users send proofs to BSPs