### PR TITLE
feat: :sparkles:  New CIs to keep `main` pristine 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,3 +58,14 @@ jobs:
       - uses: ./.github/workflow-templates/setup-pnpm
       - run: pnpm install
       - run: pnpm lint
+
+  typecheck-ts:
+    name: "Typecheck with tsc"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/workflow-templates/setup-pnpm
+      - run: pnpm install
+      - run: |
+          cd test
+          pnpm typecheck

--- a/.github/workflows/parachain.yml
+++ b/.github/workflows/parachain.yml
@@ -344,5 +344,37 @@ jobs:
               --test-force-exit                    \
               ./suites/integration/**/**.test.ts
 
-# TODO: Add a typescript generation check for tests
-# This will catch any issues with interfaces not being up-to-date
+  typegen_check:
+    needs: [build_image, setup]
+    if: always()
+    name: "Check Rust/TS bindings are up to date"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/workflow-templates/setup-pnpm
+        with:
+          node_version: 22
+      - run: mkdir -p target/release/
+      - name: Get Node Binary if changed
+        if: needs.setup.outputs.node_changed == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: node
+          path: target/release/
+      - name: Get Latest Node Binary if not changed
+        if: needs.setup.outputs.node_changed == 'false'
+        run: |
+          docker pull moonsonglabs/storage-hub:latest
+          docker create --name temp_storage_hub moonsonglabs/storage-hub:latest
+          docker cp temp_storage_hub:/usr/local/bin/storage-hub-node target/release/storage-hub-node
+          docker rm temp_storage_hub
+      - name: Build Local Docker Image
+        run: |
+          chmod +x target/release/storage-hub-node
+          chmod -R 777 docker/dev-keystores
+          cd test
+          pnpm install
+          pnpm docker:build
+      - name: Check for changes
+        run: |
+          git diff --exit-code || (echo "Typegen produced changes. Please run 'pnpm typegen' locally and commit the changes." && exit 1)

--- a/.github/workflows/parachain.yml
+++ b/.github/workflows/parachain.yml
@@ -379,7 +379,13 @@ jobs:
         run: |
           cd test
           pnpm typegen
-      - run: pnpm fmt:fix
       - name: Check for changes
         run: |
-          git diff --exit-code || (echo "Typegen produced changes. Please run 'pnpm typegen' locally and commit the changes." && exit 1)
+          cd api-augment
+          if [ -n "$(git status --porcelain .)" ]; then
+            echo "Typegen produced changes. Please run 'pnpm typegen' locally and commit the changes."
+            exit 1
+          else
+            echo "No changes"
+            exit 0
+          fi

--- a/.github/workflows/parachain.yml
+++ b/.github/workflows/parachain.yml
@@ -375,6 +375,11 @@ jobs:
           cd test
           pnpm install
           pnpm docker:build
+      - name: Run Typegen
+        run: |
+          cd test
+          pnpm typegen
+      - run: pnpm fmt:fix
       - name: Check for changes
         run: |
           git diff --exit-code || (echo "Typegen produced changes. Please run 'pnpm typegen' locally and commit the changes." && exit 1)


### PR DESCRIPTION
This PR introduces two new CI tasks that aim to keep `main` branch as pristine as possible.

- `typegen_check` - Downloads the node, builds a docker image, runs typegen against it and then does a git diff to see if any new interfaces have been generated. If so, will error.
  - Purpose of this is to flag that this PR has changed the types interfaces, and so we should update the bindings to make sure the tests are doing the right thing.
- `typecheck-ts` - Runs `tsc` (the official Typescript Compiler) against the test project to show any type errors. This is especially useful during refactors or changes to the bindings which may not break a test, but still mismatch between inputs which given inconsistencies.

> [!IMPORTANT]  
> This PR only makes sense once https://github.com/Moonsong-Labs/storage-hub/pull/180 is merged, as that will fix many of the type issues.