### PR TITLE
fix: 🩹 add extra required leafs in proof generation to be able to use `apply_delta`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12782,6 +12782,8 @@ dependencies = [
  "reference-trie",
  "serde",
  "shc-common",
+ "shp-forest-verifier",
+ "shp-traits",
  "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-v1.9.0)",
  "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-v1.9.0)",
  "sp-state-machine 0.35.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-v1.9.0)",

--- a/client/forest-manager/Cargo.toml
+++ b/client/forest-manager/Cargo.toml
@@ -35,3 +35,7 @@ sp-state-machine = { workspace = true }
 sp-trie = { workspace = true, default-features = true }
 
 shc-common = { workspace = true }
+
+[dev-dependencies]
+shp-forest-verifier = { workspace = true }
+shp-traits = { workspace = true }

--- a/client/forest-manager/src/prove.rs
+++ b/client/forest-manager/src/prove.rs
@@ -44,6 +44,10 @@ where
     let next = iter.next().transpose()?;
     let prev = iter.next_back().transpose()?;
 
+    // This is just done to allow the `apply_delta` function to remove files from the trie without failing because of an incomplete database.
+    iter.next().transpose()?;
+    iter.next_back().transpose()?;
+
     match (prev, next) {
         // Scenario 1: Exact match
         (_, Some((key, _))) if challenged_file_key.as_ref() == key => Ok(Proven::new_exact_key(

--- a/client/forest-manager/src/prove.rs
+++ b/client/forest-manager/src/prove.rs
@@ -44,16 +44,17 @@ where
     let next = iter.next().transpose()?;
     let prev = iter.next_back().transpose()?;
 
-    // This is just done to allow the `apply_delta` function to remove files from the trie without failing because of an incomplete database.
-    iter.next().transpose()?;
-    iter.next_back().transpose()?;
-
     match (prev, next) {
         // Scenario 1: Exact match
-        (_, Some((key, _))) if challenged_file_key.as_ref() == key => Ok(Proven::new_exact_key(
-            convert_raw_bytes_to_hasher_out::<T>(key)?,
-            (),
-        )),
+        (_, Some((key, _))) if challenged_file_key.as_ref() == key => {
+            // This is just done to allow the `apply_delta` function to remove files from the trie without failing because of an incomplete database.
+            iter.next().transpose()?;
+            iter.next_back().transpose()?;
+            Ok(Proven::new_exact_key(
+                convert_raw_bytes_to_hasher_out::<T>(key)?,
+                (),
+            ))
+        }
         // Scenario 2: Between two keys
         (Some((prev_key, _)), Some((next_key, _)))
             if prev_key < challenged_file_key.as_ref().to_vec()

--- a/client/forest-manager/src/rocksdb.rs
+++ b/client/forest-manager/src/rocksdb.rs
@@ -392,7 +392,7 @@ mod tests {
     use sp_core::H256;
     use sp_runtime::traits::BlakeTwo256;
     use sp_trie::LayoutV1;
-    use trie_db::Trie;
+    use trie_db::{proof::verify_proof, Trie};
 
     // Reusable function to setup a new `StorageDb` and `RocksDBForestStorage`.
     fn setup_storage<T, DB>() -> Result<RocksDBForestStorage<T, InMemory>, ErrorT<T>>
@@ -500,6 +500,75 @@ mod tests {
         assert_eq!(proof.proven.len(), 1);
         assert!(
             matches!(proof.proven.first().expect("Proven leaves should have proven 1 challenge"), Proven::ExactKey(leaf) if leaf.key.as_ref() == challenge.as_bytes())
+        );
+    }
+
+    #[test]
+    fn test_generate_proof_includes_neighbor_keys() {
+        let mut forest_storage = setup_storage::<LayoutV1<BlakeTwo256>, InMemory>().unwrap();
+
+        let mut keys = Vec::new();
+        for i in 0..50 {
+            let file_metadata = FileMetadata {
+                bucket_id: "bucket".as_bytes().to_vec(),
+                location: "location".as_bytes().to_vec(),
+                owner: "Alice".as_bytes().to_vec(),
+                file_size: i,
+                fingerprint: Fingerprint::default(),
+            };
+
+            let file_key = forest_storage
+                .insert_files_metadata(&[file_metadata])
+                .unwrap();
+
+            keys.push(*file_key.first().unwrap());
+        }
+        keys.sort();
+
+        let challenge = keys[1];
+        let root = forest_storage.root;
+
+        let proof = forest_storage.generate_proof(vec![challenge]).unwrap();
+        let challenge_previous_with_value = (keys[0], Some(b"".as_ref()));
+        let challenge_with_value = (keys[1], Some(b"".as_ref()));
+        let challenge_next_with_value = (keys[2], Some(b"".as_ref()));
+        let included_keys_values = vec![
+            &challenge_previous_with_value,
+            &challenge_with_value,
+            &challenge_next_with_value,
+        ];
+        assert!(
+            verify_proof::<LayoutV1<BlakeTwo256>, Vec<&(H256, Option<&[u8]>)>, H256, &[u8]>(
+                &root,
+                &proof.proof.encoded_nodes,
+                included_keys_values
+            )
+            .is_ok()
+        );
+
+        let new_challenges = vec![keys[10], keys[40]];
+        let proof = forest_storage.generate_proof(new_challenges).unwrap();
+        let first_challenge_previous_with_value = (keys[9], Some(b"".as_ref()));
+        let first_challenge_with_value = (keys[10], Some(b"".as_ref()));
+        let first_challenge_next_with_value = (keys[11], Some(b"".as_ref()));
+        let second_challenge_previous_with_value = (keys[39], Some(b"".as_ref()));
+        let second_challenge_with_value = (keys[40], Some(b"".as_ref()));
+        let second_challenge_next_with_value = (keys[41], Some(b"".as_ref()));
+        let included_keys_values = vec![
+            &first_challenge_previous_with_value,
+            &first_challenge_with_value,
+            &first_challenge_next_with_value,
+            &second_challenge_previous_with_value,
+            &second_challenge_with_value,
+            &second_challenge_next_with_value,
+        ];
+        assert!(
+            verify_proof::<LayoutV1<BlakeTwo256>, Vec<&(H256, Option<&[u8]>)>, H256, &[u8]>(
+                &root,
+                &proof.proof.encoded_nodes,
+                included_keys_values
+            )
+            .is_ok()
         );
     }
 

--- a/test/package.json
+++ b/test/package.json
@@ -38,6 +38,7 @@
     "test:full": "node --no-deprecation --import tsx --test ./suites/zombie/**.spec.ts",
     "test:bspnet": "NODE_OPTIONS='--no-deprecation' pnpm tsx scripts/checkRunning.ts && node --no-deprecation --test-concurrency 1 --import tsx --test ./suites/integration/bsp/**.test.ts",
     "test:bspnet:only": "NODE_OPTIONS='--no-deprecation' pnpm tsx scripts/checkRunning.ts && node --no-deprecation --import tsx --test-concurrency 1 --test --test-only ./suites/integration/bsp/**.test.ts",
+	"test:bspnet:subproof": "NODE_OPTIONS='--no-deprecation' pnpm tsx scripts/checkRunning.ts && node --no-deprecation --import tsx --test-concurrency 1 --test ./suites/integration/bsp/submit-proofs.test.ts",
     "test:user": "NODE_OPTIONS='--no-deprecation' pnpm tsx scripts/checkRunning.ts && node --no-deprecation --test-concurrency 1 --import tsx --test ./suites/integration/user/**.test.ts",
     "test:user:only": "NODE_OPTIONS='--no-deprecation' pnpm tsx scripts/checkRunning.ts && node --no-deprecation --test-concurrency 1 --import tsx --test --test-only ./suites/integration/user/**.test.ts",
     "test:node": "node --no-deprecation --import tsx --test ./suites/solo-node/**/**.test.ts",

--- a/test/package.json
+++ b/test/package.json
@@ -38,7 +38,6 @@
     "test:full": "node --no-deprecation --import tsx --test ./suites/zombie/**.spec.ts",
     "test:bspnet": "NODE_OPTIONS='--no-deprecation' pnpm tsx scripts/checkRunning.ts && node --no-deprecation --test-concurrency 1 --import tsx --test ./suites/integration/bsp/**.test.ts",
     "test:bspnet:only": "NODE_OPTIONS='--no-deprecation' pnpm tsx scripts/checkRunning.ts && node --no-deprecation --import tsx --test-concurrency 1 --test --test-only ./suites/integration/bsp/**.test.ts",
-	"test:bspnet:subproof": "NODE_OPTIONS='--no-deprecation' pnpm tsx scripts/checkRunning.ts && node --no-deprecation --import tsx --test-concurrency 1 --test ./suites/integration/bsp/submit-proofs.test.ts",
     "test:user": "NODE_OPTIONS='--no-deprecation' pnpm tsx scripts/checkRunning.ts && node --no-deprecation --test-concurrency 1 --import tsx --test ./suites/integration/user/**.test.ts",
     "test:user:only": "NODE_OPTIONS='--no-deprecation' pnpm tsx scripts/checkRunning.ts && node --no-deprecation --test-concurrency 1 --import tsx --test --test-only ./suites/integration/user/**.test.ts",
     "test:node": "node --no-deprecation --import tsx --test ./suites/solo-node/**/**.test.ts",

--- a/test/suites/integration/bsp/submit-proofs.test.ts
+++ b/test/suites/integration/bsp/submit-proofs.test.ts
@@ -14,6 +14,7 @@ describeBspNet(
   { initialised: "multi", networkConfig: "standard" },
   ({ before, createUserApi, after, it, createApi, createBspApi, getLaunchResponse }) => {
     let userApi: EnrichedBspApi;
+    let bspApi: EnrichedBspApi;
     let bspTwoApi: EnrichedBspApi;
     let bspThreeApi: EnrichedBspApi;
     let fileData: FileMetadata;
@@ -24,6 +25,7 @@ describeBspNet(
       assert(launchResponse, "BSPNet failed to initialise");
       fileData = launchResponse.fileData;
       userApi = await createUserApi();
+      bspApi = await createBspApi();
       bspTwoApi = await createApi(`ws://127.0.0.1:${launchResponse?.bspTwoRpcPort}`);
       bspThreeApi = await createApi(`ws://127.0.0.1:${launchResponse?.bspThreeRpcPort}`);
     });
@@ -36,10 +38,7 @@ describeBspNet(
     it("Network launches and can be queried", async () => {
       const userNodePeerId = await userApi.rpc.system.localPeerId();
       strictEqual(userNodePeerId.toString(), userApi.shConsts.NODE_INFOS.user.expectedPeerId);
-
-      const bspApi = await createBspApi();
       const bspNodePeerId = await bspApi.rpc.system.localPeerId();
-      await bspApi.disconnect();
       strictEqual(bspNodePeerId.toString(), userApi.shConsts.NODE_INFOS.bsp.expectedPeerId);
     });
 
@@ -191,6 +190,49 @@ describeBspNet(
         //   ),
         //   bspThreeKey
         // );
+      }
+    );
+
+    it(
+      "BSP can correctly delete a file from its forest and runtime correctly updates its root",
+      { skip: "Not implemented yet. Needs RPC method to build proofs." },
+      async () => {
+        // TODO: Setup a BSP that has two files which lie under the same NibbledBranch in the forest.
+        // TODO: Generate the proof to delete one of the files.
+        /* let inclusionForestProof = bspThreeApi.rpc.storagehubclient.buildForestRoot(fileData.fileKey); */
+        // TODO: Request the deletion of the file:
+        /* const fileDeletionRequestResult = bspThreeApi.sealBlock(bspThreeApi.tx.fileSystem.bspRequestStopStoring(
+            fileData.fileKey,
+            fileData.bucketId,
+            fileData.location,
+            fileData.owner,
+            fileData.fingerprint,
+            fileData.fileSize,
+            false,
+            inclusion_forest_proof: ForestProof<T>,
+        ); */
+        // Wait enough blocks for the deletion to be allowed.
+        /* const currentBlock = await bspThreeApi.rpc.chain.getBlock();
+		const currentBlockNumber = currentBlock.block.header.number.toNumber();
+		const cooldown = currentBlockNumber + bspThreeApi.consts.fileSystem.minWaitForStopStoring.toNumber();
+		await bspThreeApi.advanceToBlock(cooldown); */
+        // TODO: Confirm the request of deletion. Make sure the extrinsic doesn't fail and the root is updated correctly.
+        /*  const fileDeletionConfirmResult = bspThreeApi.sealBlock(bspThreeApi.tx.fileSystem.bspConfirmStopStoring(
+				fileData.fileKey,
+				inclusionForestProof,
+			)); 
+			// Check for the confirm stopped storing event.
+      		let confirmStopStoringEvent = bspThreeApi.assert.eventPresent(
+        		"fileSystem",
+       			"BspConfirmStoppedStoring",
+        		fileDeletionConfirmResult.events
+      		);
+			// Make sure the new root was updated correctly.
+			bspThreeApi.rpc.storagehubclient.deleteFile(fileData.fileKey); // Not sure if this is the correct way to do it.
+			const newRoot = bspThreeApi.rpc.storagehubclient.getForestRoot();
+			const newRootInRuntime = confirmStopStoringEvent.event.data.newRoot;
+			assert(newRoot === newRootInRuntime, "The new root should be updated correctly");
+		*/
       }
     );
 
@@ -602,8 +644,228 @@ describeBspNet(
       assert(atLeastOneEventBelongsToSecondBsp, "No ProofAccepted event belongs to the second BSP");
     });
 
-    it("File is removed from Forest by BSP", { skip: "Not implemented yet." }, async () => {
-      // TODO: Check that file is deleted by BSP, and no longer is in the Forest.
+    it("File is removed from Forest by BSP", async () => {
+      // Get the root of the BSP that has the file before deletion.
+      const bspMetadata = await userApi.query.providers.backupStorageProviders(
+        ShConsts.DUMMY_BSP_ID
+      );
+      assert(bspMetadata, "BSP metadata should exist");
+      assert(bspMetadata.isSome, "BSP metadata should be Some");
+      const bspMetadataBlob = bspMetadata.unwrap();
+      const rootBeforeDeletion = bspMetadataBlob.root;
+      // Make sure it matches the one of the actual merkle forest.
+      const actualRoot = await bspApi.rpc.storagehubclient.getForestRoot(null);
+      strictEqual(
+        rootBeforeDeletion.toString(),
+        actualRoot.toString(),
+        "The root of the BSP should match the actual merkle forest root"
+      );
+
+      /* Send file deletion request, make it expire to enqueue priority challenge */
+      // Send out a file deletion request for the file that the BSP has.
+      const fileDeletionRequestResult = await userApi.sealBlock(
+        userApi.tx.fileSystem.deleteFile(
+          oneBspFileData.bucketId,
+          oneBspFileData.fileKey,
+          oneBspFileData.location,
+          oneBspFileData.fileSize,
+          oneBspFileData.fingerprint,
+          null
+        ),
+        shUser
+      );
+
+      // Make sure the file deletion request was successful.
+      const fileDeletionRequestEvent = userApi.assert.eventPresent(
+        "fileSystem",
+        "FileDeletionRequest",
+        fileDeletionRequestResult.events
+      );
+      const fileDeletionRequestEventDataBlob =
+        userApi.events.fileSystem.FileDeletionRequest.is(fileDeletionRequestEvent.event) &&
+        fileDeletionRequestEvent.event.data;
+      assert(fileDeletionRequestEventDataBlob, "Event doesn't match Type");
+      strictEqual(
+        fileDeletionRequestEventDataBlob.fileKey.toString(),
+        oneBspFileData.fileKey,
+        "The file key should match the one that was requested to be deleted"
+      );
+
+      // Wait the required number of blocks till it expires (since we don't have a MSP to send the corresponding challenge)
+      const fileDeletionRequestTtl = Number(
+        userApi.consts.fileSystem.pendingFileDeletionRequestTtl
+      );
+      const currentBlock = await userApi.rpc.chain.getBlock();
+      const currentBlockNumber = currentBlock.block.header.number.toNumber();
+      const fileDeletionRequestEnqueuedResult = await userApi.advanceToBlock(
+        currentBlockNumber + fileDeletionRequestTtl,
+        {
+          waitForBspProofs: [ShConsts.DUMMY_BSP_ID, ShConsts.BSP_TWO_ID, ShConsts.BSP_THREE_ID]
+        }
+      );
+
+      // Wait for BSPs to finish tasks and seal the block.
+      await sleep(500);
+      await userApi.sealBlock();
+
+      // Check for a file deletion checkpoint challenge queued event.
+      userApi.assert.eventPresent(
+        "fileSystem",
+        "PriorityChallengeForFileDeletionQueued",
+        fileDeletionRequestEnqueuedResult.events
+      );
+
+      /* Advance to challenge tick, make sure enqueued challenge for file deletion is included in checkpoint challenge */
+      // Advance to the next challenge checkpoint period.
+      const checkpointChallengePeriod = Number(
+        userApi.consts.proofsDealer.checkpointChallengePeriod
+      );
+      const lastCheckpointChallengeTick = Number(
+        await userApi.call.proofsDealerApi.getLastCheckpointChallengeTick()
+      );
+      const nextCheckpointChallengeBlock = lastCheckpointChallengeTick + checkpointChallengePeriod;
+      const checkpointChallengeSentBlockResult = await userApi.advanceToBlock(
+        nextCheckpointChallengeBlock,
+        {
+          waitForBspProofs: [ShConsts.DUMMY_BSP_ID, ShConsts.BSP_TWO_ID, ShConsts.BSP_THREE_ID]
+        }
+      );
+
+      // Check that the event for the priority challenge is emitted.
+      const newCheckpointChallengeSentEvent = userApi.assert.eventPresent(
+        "proofsDealer",
+        "NewCheckpointChallenge",
+        checkpointChallengeSentBlockResult.events
+      );
+
+      // Check that the file key is in the included checkpoint challenges.
+      const newCheckpointChallengesEventDataBlob =
+        userApi.events.proofsDealer.NewCheckpointChallenge.is(
+          newCheckpointChallengeSentEvent.event
+        ) && newCheckpointChallengeSentEvent.event.data;
+      assert(newCheckpointChallengesEventDataBlob, "Event doesn't match Type");
+      let containsFileKey = false;
+      for (const checkpointChallenge of newCheckpointChallengesEventDataBlob.challenges) {
+        if (checkpointChallenge[0].toHuman() === oneBspFileData.fileKey) {
+          containsFileKey = true;
+          break;
+        }
+      }
+      assert(containsFileKey, "The file key should be included in the checkpoint challenge.");
+
+      /* Advance to next challenge tick of BSP, make sure it responds with proof of inclusion and deletes file */
+      // Calculate next challenge tick for the BSP that has the file:
+      // Get the current tick.
+      const currentTick = (await userApi.call.proofsDealerApi.getCurrentTick()).toNumber();
+
+      // Get the last tick for which the BSP submitted a proof.
+      const dummyBspLastTickResult =
+        await userApi.call.proofsDealerApi.getLastTickProviderSubmittedProof(ShConsts.DUMMY_BSP_ID);
+      assert(dummyBspLastTickResult.isOk);
+      const lastTickBspSubmittedProof = dummyBspLastTickResult.asOk.toNumber();
+
+      // Get the challenge period for the BSP.
+      const dummyBspChallengePeriodResult = await userApi.call.proofsDealerApi.getChallengePeriod(
+        ShConsts.DUMMY_BSP_ID
+      );
+      assert(dummyBspChallengePeriodResult.isOk);
+      const dummyBspChallengePeriod = dummyBspChallengePeriodResult.asOk.toNumber();
+
+      // Calculate the next challenge tick.
+      let dummyBspNextChallengeTick = lastTickBspSubmittedProof + dummyBspChallengePeriod;
+
+      // If it is exactly equal to the current tick, take the next challenge tick.
+      if (dummyBspNextChallengeTick === currentTick) {
+        dummyBspNextChallengeTick += dummyBspChallengePeriod;
+      }
+
+      // Advance to the next challenge block.
+      await userApi.advanceToBlock(dummyBspNextChallengeTick, {
+        waitForBspProofs: [DUMMY_BSP_ID, BSP_TWO_ID, BSP_THREE_ID]
+      });
+
+      // Wait for tasks to execute and for the BSPs to submit proofs.
+      await sleep(500);
+
+      // There should be at least one pending submit proof transaction (for the dummy BSP)
+      const submitProofsPending = await userApi.assert.extrinsicPresent({
+        module: "proofsDealer",
+        method: "submitProof",
+        checkTxPool: true
+      });
+      assert(submitProofsPending.length > 0);
+
+      // Seal block and check that the transaction was successful.
+      const blockResult = await userApi.sealBlock();
+
+      // Assert for the event of the proof successfully submitted and verified.
+      const proofAcceptedEvents = userApi.assert.assertEventMany(
+        userApi,
+        "proofsDealer",
+        "ProofAccepted",
+        blockResult.events
+      );
+      strictEqual(
+        proofAcceptedEvents.length,
+        submitProofsPending.length,
+        "All pending submit proof transactions should have been successful"
+      );
+
+      // Check that at least one of the `ProofAccepted` events belongs to the dummy BSP.
+      const atLeastOneEventBelongsToDummyBsp = proofAcceptedEvents.some((eventRecord) => {
+        const proofAcceptedEventsDataBlob =
+          userApi.events.proofsDealer.ProofAccepted.is(eventRecord.event) && eventRecord.event.data;
+        assert(proofAcceptedEventsDataBlob, "Event doesn't match Type");
+
+        return proofAcceptedEventsDataBlob.provider.toString() === ShConsts.DUMMY_BSP_ID;
+      });
+      assert(atLeastOneEventBelongsToDummyBsp, "No ProofAccepted event belongs to the dummy BSP");
+
+      /* // Assert for the event of the mutations successfully applied in the runtime.
+      const mutationsAppliedEvents = userApi.assert.eventMany(
+        "proofsDealer",
+        "MutationsApplied",
+        blockResult.events
+      );
+      strictEqual(mutationsAppliedEvents.length, 1, "There should be one mutations applied event");
+
+      // Check that the mutations applied event belongs to the dummy BSP.
+      const mutationsAppliedEventDataBlob =
+        userApi.events.proofsDealer.MutationsApplied.is(mutationsAppliedEvents[0].event) &&
+        mutationsAppliedEvents[0].event.data;
+      assert(mutationsAppliedEventDataBlob, "Event doesn't match Type");
+      strictEqual(
+        mutationsAppliedEventDataBlob.provider.toString(),
+        ShConsts.DUMMY_BSP_ID,
+        "The mutations applied event should belong to the dummy BSP"
+      ); */
+
+      // Make sure the root was updated in the runtime
+      const bspMetadataAfterDeletion = await userApi.query.providers.backupStorageProviders(
+        ShConsts.DUMMY_BSP_ID
+      );
+      assert(bspMetadataAfterDeletion, "BSP metadata should exist");
+      assert(bspMetadataAfterDeletion.isSome, "BSP metadata should be Some");
+      const bspMetadataAfterDeletionBlob = bspMetadataAfterDeletion.unwrap();
+      console.log("Previous root:", rootBeforeDeletion.toHex());
+      console.log("Current root:", bspMetadataAfterDeletionBlob.root.toHex());
+      assert(
+        bspMetadataAfterDeletionBlob.root.toHex() !== rootBeforeDeletion.toHex(),
+        "The root should have been updated on chain"
+      );
+      /* strictEqual(
+        mutationsAppliedEventDataBlob.newRoot.toString(),
+        bspMetadataAfterDeletionBlob.root.toString(),
+        "The mutations applied event's new root should equal the new root in the runtime"
+      ); */
+
+      // Check that the runtime root matches the forest root of the BSP.
+      const forestRoot = await bspApi.rpc.storagehubclient.getForestRoot(null);
+      strictEqual(
+        bspMetadataAfterDeletionBlob.root.toString(),
+        forestRoot.toString(),
+        "The runtime root should match the forest root of the BSP"
+      );
     });
 
     it(


### PR DESCRIPTION
This PR:
- Adds, for each leaf of a proof, the previous and next one to make sure the generated proof is complete enough to be able to use `apply_delta` for file removals.
- Adds the test to check that this logic is working.
- Completes the proof submission integration test except for actually checking if a file is in storage (which could be done after #191 is merged)