### PR TITLE
fix: 🐛 correctly update Bucket root when MSP uses `stop_storing_for_insolvent_user`

### DIFF
--- a/pallets/file-system/src/tests.rs
+++ b/pallets/file-system/src/tests.rs
@@ -6266,9 +6266,176 @@ mod stop_storing_for_insolvent_user {
         });
     }
 
-    // TODO: Not sure if needed, since we might not store any MSP info in the future
     #[test]
-    fn stop_storing_for_insolvent_user_works_for_msps() {}
+    fn stop_storing_for_insolvent_user_works_for_msps() {
+        new_test_ext().execute_with(|| {
+            let owner_account_id = Keyring::Eve.to_account_id();
+            let owner_signed = RuntimeOrigin::signed(owner_account_id.clone());
+            let bsp_account_id = Keyring::Bob.to_account_id();
+            let bsp_signed = RuntimeOrigin::signed(bsp_account_id.clone());
+            let msp = Keyring::Charlie.to_account_id();
+            let msp_signed = RuntimeOrigin::signed(msp.clone());
+            let location = FileLocation::<Test>::try_from(b"test".to_vec()).unwrap();
+            let size = 4;
+            let fingerprint = H256::zero();
+            let peer_id = BoundedVec::try_from(vec![1]).unwrap();
+            let peer_ids: PeerIds<Test> = BoundedVec::try_from(vec![peer_id]).unwrap();
+            let storage_amount: StorageData<Test> = 50;
+
+            let msp_id = add_msp_to_provider_storage(&msp);
+
+            let name = BoundedVec::try_from(b"bucket".to_vec()).unwrap();
+            let bucket_id = create_bucket(&owner_account_id.clone(), name, msp_id);
+
+            // Dispatch storage request.
+            assert_ok!(FileSystem::issue_storage_request(
+                owner_signed.clone(),
+                bucket_id,
+                location.clone(),
+                fingerprint,
+                size,
+                msp_id,
+                peer_ids.clone(),
+            ));
+
+            // Sign up account as a Backup Storage Provider
+            assert_ok!(bsp_sign_up(bsp_signed.clone(), storage_amount));
+
+            let file_key = FileSystem::compute_file_key(
+                owner_account_id.clone(),
+                bucket_id,
+                location.clone(),
+                size,
+                fingerprint,
+            );
+
+            // Dispatch BSP volunteer.
+            assert_ok!(FileSystem::bsp_volunteer(bsp_signed.clone(), file_key,));
+
+            // Dispatch BSP confirm storing.
+            assert_ok!(FileSystem::bsp_confirm_storing(
+                bsp_signed.clone(),
+                CompactProof {
+                    encoded_nodes: vec![H256::default().as_ref().to_vec()],
+                },
+                BoundedVec::try_from(vec![(
+                    file_key,
+                    CompactProof {
+                        encoded_nodes: vec![H256::default().as_ref().to_vec()],
+                    }
+                )])
+                .unwrap(),
+            ));
+
+            // Dispatch MSP confirm storing.
+            assert_ok!(FileSystem::msp_accept_storage_request(
+                RuntimeOrigin::signed(msp.clone()),
+                file_key,
+                CompactProof {
+                    encoded_nodes: vec![H256::default().as_ref().to_vec()],
+                },
+                CompactProof {
+                    encoded_nodes: vec![H256::default().as_ref().to_vec()],
+                },
+            ));
+
+            // Assert that the storage was updated
+            assert_eq!(
+                FileSystem::storage_requests(file_key),
+                Some(StorageRequestMetadata {
+                    requested_at: 1,
+                    owner: owner_account_id.clone(),
+                    bucket_id,
+                    location: location.clone(),
+                    fingerprint,
+                    size,
+                    msp: Some((msp_id, true)),
+                    user_peer_ids: peer_ids.clone(),
+                    data_server_sps: BoundedVec::default(),
+                    bsps_required: ReplicationTarget::<Test>::get(),
+                    bsps_confirmed: 1,
+                    bsps_volunteered: 1,
+                })
+            );
+
+            let file_key = FileSystem::compute_file_key(
+                owner_account_id.clone(),
+                bucket_id,
+                location.clone(),
+                size,
+                fingerprint,
+            );
+
+            let new_bucket_root =
+				<<Test as crate::Config>::Providers as shp_traits::ReadBucketsInterface>::get_root_bucket(
+					&bucket_id,
+				)
+					.unwrap();
+
+            // Assert that the correct event was deposited
+            System::assert_last_event(
+                Event::MspAcceptedStoring {
+                    file_key,
+                    msp_id,
+                    bucket_id,
+                    owner: owner_account_id.clone(),
+                    new_bucket_root,
+                }
+                .into(),
+            );
+
+            // Assert that the capacity used by the MSP was updated
+            assert_eq!(
+                pallet_storage_providers::MainStorageProviders::<Test>::get(msp_id)
+                    .expect("MSP should exist in storage")
+                    .capacity_used,
+                size
+            );
+
+            // Now that the MSP has accepted storing, we can simulate the user being insolvent
+            // and the MSP stopping storing for the user.
+            // Try to stop storing for the insolvent user.
+            assert_ok!(FileSystem::stop_storing_for_insolvent_user(
+                msp_signed.clone(),
+                file_key,
+                bucket_id,
+                location.clone(),
+                owner_account_id.clone(),
+                fingerprint,
+                size,
+                CompactProof {
+                    encoded_nodes: vec![file_key.as_ref().to_vec()],
+                },
+            ));
+
+            // Get the new bucket root after deletion
+            let new_bucket_root_after_deletion =
+				<<Test as crate::Config>::Providers as shp_traits::ReadBucketsInterface>::get_root_bucket(
+					&bucket_id,
+				)
+					.unwrap();
+
+            // Assert that the correct event was deposited
+            System::assert_last_event(
+                Event::SpStopStoringInsolventUser {
+                    sp_id: msp_id,
+                    file_key,
+                    owner: owner_account_id,
+                    location,
+                    new_root: new_bucket_root_after_deletion,
+                }
+                .into(),
+            );
+
+            // Assert that the capacity used by the MSP was updated
+            assert_eq!(
+                pallet_storage_providers::MainStorageProviders::<Test>::get(msp_id)
+                    .expect("MSP should exist in storage")
+                    .capacity_used,
+                0
+            );
+        });
+    }
 
     #[test]
     fn stop_storing_for_insolvent_user_fails_if_caller_not_a_sp() {

--- a/pallets/file-system/src/utils.rs
+++ b/pallets/file-system/src/utils.rs
@@ -1377,12 +1377,31 @@ where
 
         // Verify the proof of inclusion.
         // If the Provider is a BSP, the proof is verified against the BSP's forest.
-        let proven_keys = if <T::Providers as ReadStorageProvidersInterface>::is_bsp(&sp_id) {
-            <T::ProofDealer as shp_traits::ProofsDealerInterface>::verify_forest_proof(
+        let new_root = if <T::Providers as ReadStorageProvidersInterface>::is_bsp(&sp_id) {
+            let proven_keys =
+                <T::ProofDealer as shp_traits::ProofsDealerInterface>::verify_forest_proof(
+                    &sp_id,
+                    &[file_key],
+                    &inclusion_forest_proof,
+                )?;
+
+            // Ensure that the file key IS part of the BSP's forest.
+            ensure!(
+                proven_keys.contains(&file_key),
+                Error::<T>::ExpectedInclusionProof
+            );
+
+            // Compute new root after removing file key from forest partial trie.
+            let new_root = <T::ProofDealer as shp_traits::ProofsDealerInterface>::apply_delta(
                 &sp_id,
-                &[file_key],
+                &[(file_key, TrieRemoveMutation::default().into())],
                 &inclusion_forest_proof,
-            )?
+            )?;
+
+            // Update root of the BSP.
+            <T::Providers as shp_traits::MutateProvidersInterface>::update_root(sp_id, new_root)?;
+
+            new_root
         } else {
             // If the Provider is a MSP, the proof is verified against the Bucket's root.
 
@@ -1402,28 +1421,34 @@ where
                 <T::Providers as shp_traits::ReadBucketsInterface>::get_root_bucket(&bucket_id)
                     .ok_or(Error::<T>::BucketNotFound)?;
 
-            <T::ProofDealer as shp_traits::ProofsDealerInterface>::verify_generic_forest_proof(
-                &bucket_root,
-                &[file_key],
-                &inclusion_forest_proof,
-            )?
+            let proven_keys =
+                <T::ProofDealer as shp_traits::ProofsDealerInterface>::verify_generic_forest_proof(
+                    &bucket_root,
+                    &[file_key],
+                    &inclusion_forest_proof,
+                )?;
+
+            // Ensure that the file key IS part of the Bucket's trie.
+            ensure!(
+                proven_keys.contains(&file_key),
+                Error::<T>::ExpectedInclusionProof
+            );
+
+            // Compute new root after removing file key from forest partial trie.
+            let new_root =
+                <T::ProofDealer as shp_traits::ProofsDealerInterface>::generic_apply_delta(
+                    &bucket_root,
+                    &[(file_key, TrieRemoveMutation::default().into())],
+                    &inclusion_forest_proof,
+                )?;
+
+            // Update root of the Bucket.
+            <T::Providers as shp_traits::MutateBucketsInterface>::change_root_bucket(
+                bucket_id, new_root,
+            )?;
+
+            new_root
         };
-
-        // Ensure that the file key IS part of the SP's forest.
-        ensure!(
-            proven_keys.contains(&file_key),
-            Error::<T>::ExpectedInclusionProof
-        );
-
-        // Compute new root after removing file key from forest partial trie.
-        let new_root = <T::ProofDealer as shp_traits::ProofsDealerInterface>::apply_delta(
-            &sp_id,
-            &[(file_key, TrieRemoveMutation::default().into())],
-            &inclusion_forest_proof,
-        )?;
-
-        // Update root of SP.
-        <T::Providers as shp_traits::MutateProvidersInterface>::update_root(sp_id, new_root)?;
 
         // Decrease data used by the SP.
         <T::Providers as MutateStorageProvidersInterface>::decrease_capacity_used(&sp_id, size)?;


### PR DESCRIPTION
Title