### PR TITLE
test: ✅ Add integrity tests to Proofs Dealer pallet

### DIFF
--- a/pallets/file-system/src/mock.rs
+++ b/pallets/file-system/src/mock.rs
@@ -261,7 +261,7 @@ impl pallet_storage_providers::Config for Test {
     type ProvidersProofSubmitters = MockSubmittingProviders;
     type ReputationWeightType = u32;
     type Treasury = TreasuryAccount;
-    type SpMinDeposit = ConstU128<10>;
+    type SpMinDeposit = ConstU128<{ 10 * UNITS }>;
     type SpMinCapacity = ConstU64<2>;
     type DepositPerData = ConstU128<2>;
     type MaxFileSize = ConstU64<{ u64::MAX }>;

--- a/pallets/proofs-dealer/src/lib.rs
+++ b/pallets/proofs-dealer/src/lib.rs
@@ -710,13 +710,34 @@ pub mod pallet {
             }
         }
 
-        // TODO: Document why we need to do this.
-        // TODO: This is related to the limitation of `CheckpointChallengePeriod` having to be greater or equal
-        // TODO: to the largest period of a Provider. The provider with largest period would be the one with the
-        // TODO: smallest stake.
+        /// This integrity test checks that the `CheckpointChallengePeriod` is greater or equal to the
+        /// longest period a Provider can have, and that `BlockFullnessPeriod` is smaller or equal than
+        /// `ChallengeTicksTolerance`.
+        ///
+        /// Any code located in this hook is placed in an auto-generated test, and generated as a part
+        /// of crate::construct_runtime's expansion.
+        /// Look for a test case with a name along the lines of: __construct_runtime_integrity_test.
         fn integrity_test() {
-            // TODO: Check that the `CheckpointChallengePeriod` is greater or equal to the largest period of a Provider. plus `ChallengeTicksTolerance`.
-            // TODO: Check that `BlockFullnessPeriod` is smaller or equal than `CheckpointChallengePeriod`.
+            // Calculate longest period a Provider can have.
+            // That would be the period of the Provider with the minimum stake.
+            let min_stake = T::ProvidersPallet::get_min_stake();
+            let max_period = Self::stake_to_challenge_period(min_stake);
+
+            // Check that `CheckpointChallengePeriod` is greater or equal to the longest period a Provider can have.
+            assert!(
+                T::CheckpointChallengePeriod::get() >= max_period,
+                "CheckpointChallengePeriod ({:?}) const in ProofsDealer pallet should be greater or equal than the longest period a Provider can have ({:?}).",
+                T::CheckpointChallengePeriod::get(),
+                max_period
+            );
+
+            // Check that `BlockFullnessPeriod` is smaller or equal than `ChallengeTicksTolerance`.
+            assert!(
+                T::BlockFullnessPeriod::get() <= T::ChallengeTicksTolerance::get(),
+                "BlockFullnessPeriod const ({:?}) in ProofsDealer pallet should be smaller or equal than ChallengeTicksTolerance ({:?}).",
+                T::BlockFullnessPeriod::get(),
+                T::ChallengeTicksTolerance::get()
+            );
         }
 
         /// This hook is used to trim down the `ValidProofSubmittersLastTicks` StorageMap up to the `TargetTicksOfProofsStorage`.

--- a/pallets/providers/src/mock.rs
+++ b/pallets/providers/src/mock.rs
@@ -245,7 +245,7 @@ impl crate::Config for Test {
     type ProvidersProofSubmitters = MockSubmittingProviders;
     type ReputationWeightType = u32;
     type Treasury = TreasuryAccount;
-    type SpMinDeposit = ConstU128<10>;
+    type SpMinDeposit = ConstU128<{ 10 * UNITS }>;
     type SpMinCapacity = ConstU64<2>;
     type DepositPerData = ConstU128<2>;
     type MaxFileSize = ConstU64<{ u64::MAX }>;
@@ -335,13 +335,15 @@ pub fn _new_test_ext() -> sp_io::TestExternalities {
 }
 
 pub mod accounts {
-    pub const ALICE: (u64, u128) = (0, 5_000_000);
-    pub const BOB: (u64, u128) = (1, 10_000_000);
-    pub const CHARLIE: (u64, u128) = (2, 20_000_000);
-    pub const DAVID: (u64, u128) = (3, 30_000_000);
-    pub const EVE: (u64, u128) = (4, 400_000_000);
-    pub const FERDIE: (u64, u128) = (5, 5_000_000_000);
-    pub const GEORGE: (u64, u128) = (6, 600_000_000_000);
+    use super::UNITS;
+
+    pub const ALICE: (u64, u128) = (0, 5_000_000 * UNITS);
+    pub const BOB: (u64, u128) = (1, 10_000_000 * UNITS);
+    pub const CHARLIE: (u64, u128) = (2, 20_000_000 * UNITS);
+    pub const DAVID: (u64, u128) = (3, 30_000_000 * UNITS);
+    pub const EVE: (u64, u128) = (4, 400_000_000 * UNITS);
+    pub const FERDIE: (u64, u128) = (5, 5_000_000_000 * UNITS);
+    pub const GEORGE: (u64, u128) = (6, 600_000_000_000 * UNITS);
 }
 
 // Externalities builder with predefined balances for accounts and starting at block number 1

--- a/pallets/providers/src/utils.rs
+++ b/pallets/providers/src/utils.rs
@@ -1387,6 +1387,11 @@ impl<T: pallet::Config> ReadChallengeableProvidersInterface for pallet::Pallet<T
     fn is_provider(who: Self::ProviderId) -> bool {
         BackupStorageProviders::<T>::contains_key(&who)
     }
+
+    fn get_min_stake(
+    ) -> <Self::Balance as frame_support::traits::fungible::Inspect<Self::AccountId>>::Balance {
+        T::SpMinDeposit::get()
+    }
 }
 
 /// Implement the MutateChallengeableProvidersInterface for the Storage Providers pallet.

--- a/primitives/traits/src/lib.rs
+++ b/primitives/traits/src/lib.rs
@@ -470,6 +470,9 @@ pub trait ReadChallengeableProvidersInterface {
     fn get_stake(
         who: Self::ProviderId,
     ) -> Option<<Self::Balance as fungible::Inspect<Self::AccountId>>::Balance>;
+
+    /// Get the minimum stake for a registered challengeable Provider.
+    fn get_min_stake() -> <Self::Balance as fungible::Inspect<Self::AccountId>>::Balance;
 }
 
 /// A trait to mutate the state of challengeable Providers, such as updating their root.

--- a/xcm-simulator/src/storagehub/configs/mod.rs
+++ b/xcm-simulator/src/storagehub/configs/mod.rs
@@ -564,7 +564,7 @@ parameter_types! {
     pub const ChallengesQueueLength: u32 = 100;
     pub const CheckpointChallengePeriod: u32 = 10;
     pub const ChallengesFee: Balance = 1 * UNIT;
-    pub const StakeToChallengePeriod: Balance = 1_000_000 * UNIT;
+    pub const StakeToChallengePeriod: Balance = 200 * UNIT; // TODO: Change this value into something much higher like 1_000_000 * UNIT
     pub const MinChallengePeriod: u32 = 30;
     pub const ChallengeTicksTolerance: u32 = 50;
     pub const MaxSubmittersPerTick: u32 = 1000; // TODO: Change this value after benchmarking for it to coincide with the implicit limit given by maximum block weight


### PR DESCRIPTION
This PR:
1. Implements `integrity_test` hook in the Proofs Dealer pallet.
    1. Checks that `CheckpointChallengePeriod` is greater or equal to the longest period a Provider can have.
    2. Checks that `BlockFullnessPeriod` is smaller or equal than `ChallengeTicksTolerance`.
2. Makes the corresponding changes in every mocked runtime to abide by this test.
3. Adds `get_min_stake` function to `ReadChallengeableProvidersInterface`.

This ensures that we never build a runtime where those constraints are not met, given the constants that we set. You can test it by setting the `CheckpointChallengePeriod` in `runtime/src/configs/mod.rs` to something sufficiently small, and run `cargo test`.