### PR TITLE
refactor: replace actors framework events boilerplate code with macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,6 +194,7 @@ pallet-storage-providers-runtime-api = { path = "pallets/providers/runtime-api",
 
 # Local - StorageHub Client (used by the node, can be std or no_std)
 shc-actors-framework = { path = "client/actors-framework", default-features = false }
+shc-actors-framework-macro = { path = "client/actors-framework-macro", default-features = false }
 shc-blockchain-service = { path = "client/blockchain-service", default-features = false }
 shc-file-transfer-service = { path = "client/file-transfer-service", default-features = false }
 shc-indexer-service = { path = "client/indexer-service", default-features = false }

--- a/client/actors-framework-macro/Cargo.toml
+++ b/client/actors-framework-macro/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "actors-framework-macro"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "1.0", features = ["full"] }

--- a/client/actors-framework-macro/src/lib.rs
+++ b/client/actors-framework-macro/src/lib.rs
@@ -1,0 +1,17 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_derive(EventBusMessage)]
+pub fn derive_event_bus_message(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = input.ident;
+
+    let expanded = quote! {
+        impl EventBusMessage for #name {}
+    };
+
+    TokenStream::from(expanded)
+}

--- a/client/actors-framework/Cargo.toml
+++ b/client/actors-framework/Cargo.toml
@@ -25,3 +25,5 @@ sc-utils = { workspace = true }
 
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
+
+actors-framework-macro = { workspace = true }

--- a/client/blockchain-service/Cargo.toml
+++ b/client/blockchain-service/Cargo.toml
@@ -67,3 +67,5 @@ pallet-proofs-dealer = { workspace = true }
 pallet-proofs-dealer-runtime-api = { workspace = true }
 pallet-storage-providers = { workspace = true }
 pallet-storage-providers-runtime-api = { workspace = true }
+
+actors-framework-macro = { workspace = true }

--- a/client/file-transfer-service/Cargo.toml
+++ b/client/file-transfer-service/Cargo.toml
@@ -42,3 +42,5 @@ shp-file-metadata = { workspace = true }
 
 [build-dependencies]
 prost-build = { workspace = true }
+
+actors-framework-macro = { workspace = true }

--- a/client/file-transfer-service/src/events.rs
+++ b/client/file-transfer-service/src/events.rs
@@ -1,48 +1,23 @@
 use sc_network::PeerId;
-use shc_actors_framework::event_bus::{EventBus, EventBusMessage, ProvidesEventBus};
+use shc_actors_framework::event_bus::{EventBusMessage, define_event_bus};
 use shc_common::types::{ChunkId, DownloadRequestId, FileKey, FileKeyProof};
 
-#[derive(Clone)]
+#[derive(Clone, EventBusMessage)]
 pub struct RemoteUploadRequest {
     pub peer: PeerId,
     pub file_key: FileKey,
     pub file_key_proof: FileKeyProof,
 }
 
-impl EventBusMessage for RemoteUploadRequest {}
-
-#[derive(Clone)]
+#[derive(Clone, EventBusMessage)]
 pub struct RemoteDownloadRequest {
     pub file_key: FileKey,
     pub chunk_id: ChunkId,
     pub request_id: DownloadRequestId,
 }
 
-impl EventBusMessage for RemoteDownloadRequest {}
-
-#[derive(Clone, Default)]
-pub struct FileTransferServiceEventBusProvider {
-    remote_upload_request_event_bus: EventBus<RemoteUploadRequest>,
-    remote_download_request_event_bus: EventBus<RemoteDownloadRequest>,
-}
-
-impl FileTransferServiceEventBusProvider {
-    pub fn new() -> Self {
-        Self {
-            remote_upload_request_event_bus: EventBus::new(),
-            remote_download_request_event_bus: EventBus::new(),
-        }
-    }
-}
-
-impl ProvidesEventBus<RemoteUploadRequest> for FileTransferServiceEventBusProvider {
-    fn event_bus(&self) -> &EventBus<RemoteUploadRequest> {
-        &self.remote_upload_request_event_bus
-    }
-}
-
-impl ProvidesEventBus<RemoteDownloadRequest> for FileTransferServiceEventBusProvider {
-    fn event_bus(&self) -> &EventBus<RemoteDownloadRequest> {
-        &self.remote_download_request_event_bus
-    }
-}
+define_event_bus!(
+    FileTransferServiceEventBusProvider,
+    RemoteUploadRequest,
+    RemoteDownloadRequest
+);


### PR DESCRIPTION
Refactor the actors framework repeatable code into a macro to reduce boilerplate code when defining `EventBus`.

* **Define EventBus Macro:**
  - Add `define_event_bus` macro in `client/actors-framework/src/event_bus.rs` to automate the definition and implementation of `EventBus` and `ProvidesEventBus` traits for different event types.
  - Replace existing `EventBus` and `ProvidesEventBus` trait implementations with the `define_event_bus` macro in `client/blockchain-service/src/events.rs` and `client/file-transfer-service/src/events.rs`.

* **Derive Macro for EventBusMessage:**
  - Add a new derive macro `EventBusMessage` in `client/actors-framework/src/event_bus.rs` to automate the implementation of `EventBusMessage` trait for different event types.
  - Create a new crate `actors-framework-macro` and implement the derive macro `EventBusMessage` in `client/actors-framework-macro/src/lib.rs`.
  - Use `derive(EventBusMessage)` for all event types in `client/blockchain-service/src/events.rs` and `client/file-transfer-service/src/events.rs`.
  - Delete the lines with `impl EventBusMessage for ...` in `client/blockchain-service/src/events.rs` and `client/file-transfer-service/src/events.rs`.

* **Cargo.toml Updates:**
  - Add `actors-framework-macro` dependency in `client/actors-framework/Cargo.toml`, `client/blockchain-service/Cargo.toml`, and `client/file-transfer-service/Cargo.toml`.
  - Add `actors-framework-macro` to the workspace in `Cargo.toml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Moonsong-Labs/storage-hub?shareId=f79db20a-6443-4e6c-b374-9ac9eab27deb).