### PR TITLE
fix: 🩹 Execute `verifyContainerFreshness` in `before` block of each test suite

### DIFF
--- a/test/suites/integration/bsp/storage-capacity.test.ts
+++ b/test/suites/integration/bsp/storage-capacity.test.ts
@@ -1,12 +1,5 @@
 import assert from "node:assert";
-import {
-  bspKey,
-  describeBspNet,
-  type EnrichedBspApi,
-  ferdie,
-  skipBlocksToMinChangeTime,
-  sleep
-} from "../../../util";
+import { bspKey, describeBspNet, type EnrichedBspApi, ferdie, sleep } from "../../../util";
 
 describeBspNet("BSPNet: Validating max storage", ({ before, it, createUserApi, createBspApi }) => {
   let userApi: EnrichedBspApi;
@@ -77,7 +70,7 @@ describeBspNet("BSPNet: Validating max storage", ({ before, it, createUserApi, c
     await sleep(500);
 
     // Skip block height until BSP sends a call to change capacity.
-    await skipBlocksToMinChangeTime(userApi);
+    await userApi.block.skipToMinChangeTime();
     // Allow BSP enough time to send call to change capacity.
     await sleep(500);
     // Assert BSP has sent a call to increase its capacity.
@@ -119,7 +112,7 @@ describeBspNet("BSPNet: Validating max storage", ({ before, it, createUserApi, c
       BigInt(Math.floor(Math.random() * 1000 * 1024 * 1024)) + bspApi.shConsts.CAPACITY_512;
 
     // Skip block height past threshold
-    await skipBlocksToMinChangeTime(userApi);
+    await userApi.block.skipToMinChangeTime();
 
     await userApi.sealBlock(userApi.tx.providers.changeCapacity(newCapacity), bspKey);
 

--- a/test/util/bspNet/testrunner.ts
+++ b/test/util/bspNet/testrunner.ts
@@ -38,8 +38,6 @@ export function describeBspNet(
 export async function describeBspNet<
   T extends [(context: BspNetContext) => void] | [TestOptions, (context: BspNetContext) => void]
 >(title: string, ...args: T): Promise<void> {
-  await verifyContainerFreshness();
-
   const options = args.length === 2 ? args[0] : {};
   const tests = args.length === 2 ? args[1] : args[0];
 
@@ -58,6 +56,8 @@ export async function describeBspNet<
       let responseListenerPromise: ReturnType<typeof NetworkLauncher.create>;
 
       before(async () => {
+        await verifyContainerFreshness();
+
         responseListenerPromise = new Promise((resolve) => {
           launchEventEmitter.once("networkLaunched", resolve);
         });

--- a/test/util/bspNet/testrunner.ts
+++ b/test/util/bspNet/testrunner.ts
@@ -119,8 +119,6 @@ export async function describeBspNet<
 export async function describeMspNet<
   T extends [(context: FullNetContext) => void] | [TestOptions, (context: FullNetContext) => void]
 >(title: string, ...args: T): Promise<void> {
-  await verifyContainerFreshness();
-
   const options = args.length === 2 ? args[0] : {};
   const tests = args.length === 2 ? args[1] : args[0];
 
@@ -140,6 +138,8 @@ export async function describeMspNet<
       let responseListenerPromise: ReturnType<typeof NetworkLauncher.create>;
 
       before(async () => {
+        await verifyContainerFreshness();
+
         responseListenerPromise = new Promise((resolve) => {
           launchEventEmitter.once("networkLaunched", resolve);
         });


### PR DESCRIPTION
Before it was being executed at the beginning of the `describeBspNet` which caused unexpected errors when a test suite was executed with `only: true` and `keepAlive: true`. Now it is executed in the `before` block of each test suite meaning two things:
1. Test suites without `only: true` are filtered out and don't execute `verifyContainerFreshness` when running `pnpm test:bspnet:only`.
2. `verifyContainerFreshness` is run on every test suite, including same test suites but with different network configs (like memory DB and Rocks DB).