### PR TITLE
CI/fix: :package: publish api-augment w/ pnpm & add dry-run

### DIFF
--- a/.github/workflows/api-augment-publish.yml
+++ b/.github/workflows/api-augment-publish.yml
@@ -15,27 +15,27 @@ jobs:
         with:
           ref: ${{ github.event.inputs.sha }}
 
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9
+        
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org/
 
       - name: Build API Augment
         run: |
           cd api-augment
-          pnpm install
+          pnpm i --frozen-lockfile
           pnpm run build
 
       - name: Publish API Augment
-        uses: JS-DevTools/npm-publish@v3
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          package: api-augment/package.json
-          registry: https://registry.npmjs.org/
-          access: public
-          command: pnpm publish
+        run: |
+          cd api-augment
+          pnpm publish ${{ github.event.inputs.DryRun && '--dry-run' || ''  }} --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
While it seems like the API augment is being published with `pnpm` it is not. Workflow is showing a warning on the unrecognized param `command: pnpm`:

```
publish-api-augment
Unexpected input(s) 'command', valid inputs are ['token', 'registry', 'package', 'tag', 'access', 'provenance', 'strategy', 'ignore-scripts', 'dry-run']
```

This results in a published package with `pnpm`-like syntax which breaks for people installing with `npm`. Notice the `workspace:*`:

```
"dependencies": {
    "@polkadot/api": "12.4.2",
    "@polkadot/api-base": "12.4.2",
    "@polkadot/rpc-core": "12.4.2",
    "@polkadot/typegen": "12.4.2",
    "@polkadot/types": "12.4.2",
    "@polkadot/types-codec": "12.4.2",
    "@storagehub/types-bundle": "workspace:*",
    "tsx": "4.19.0",
    "typescript": "5.5.4"
  }
  ```

Threw some other changes to the workflow: installing pnpm before Node (but I noticed there is a setup pnpm action?), added dry-run option, and lockfile & cache configs.