### PR TITLE
fix: :bug: add checks to avoid panicking when decoding proofs with `sp-trie`

### DIFF
--- a/primitives/file-key-verifier/src/lib.rs
+++ b/primitives/file-key-verifier/src/lib.rs
@@ -80,6 +80,14 @@ where
             .try_into()
             .map_err(|_| "Failed to convert fingerprint to a hasher output.")?;
 
+        // Basic sanity check to make sure the received compact proof won't panic
+        // TODO: remove this after [this PR](https://github.com/paritytech/polkadot-sdk/pull/6486) is merged.
+        for encoded_node in proof.proof.encoded_nodes.iter() {
+            if encoded_node.len() < 2 {
+                return Err("Invalid encoded node in the proof.".into());
+            }
+        }
+
         // This generates a partial trie based on the proof and checks that the root hash matches the `expected_root`.
         let (memdb, root) = proof
             .proof

--- a/primitives/file-key-verifier/src/types.rs
+++ b/primitives/file-key-verifier/src/types.rs
@@ -62,6 +62,14 @@ impl<const H_LENGTH: usize, const CHUNK_SIZE: u64, const SIZE_TO_CHALLENGES: u64
             .try_into()
             .map_err(|_| ProvenFileKeyError::FingerprintAndTrieHashMismatch)?;
 
+        // Basic sanity check to make sure the received compact proof won't panic
+        // TODO: remove this after [this PR](https://github.com/paritytech/polkadot-sdk/pull/6486) is merged.
+        for encoded_node in self.proof.encoded_nodes.iter() {
+            if encoded_node.len() < 2 {
+                return Err(ProvenFileKeyError::FailedToDecodeChunkFromProof);
+            }
+        }
+
         // This generates a partial trie based on the proof and checks that the root hash matches the `expected_root`.
         let (memdb, root) = self
             .proof

--- a/primitives/forest-verifier/src/lib.rs
+++ b/primitives/forest-verifier/src/lib.rs
@@ -40,6 +40,14 @@ where
             return Err("No challenges provided.".into());
         }
 
+        // Basic sanity check to make sure the received compact proof won't panic
+        // TODO: remove this after [this PR](https://github.com/paritytech/polkadot-sdk/pull/6486) is merged.
+        for encoded_node in proof.encoded_nodes.iter() {
+            if encoded_node.len() < 2 {
+                return Err("Invalid encoded node in the proof.".into());
+            }
+        }
+
         // This generates a partial trie based on the proof and checks that the root hash matches the `expected_root`.
         let (memdb, root) = proof.to_memory_db(Some(root.into())).map_err(|_| {
             "Failed to convert proof to memory DB, root doesn't match with expected."
@@ -233,6 +241,14 @@ where
         // Check if the root is empty
         if root.as_ref().is_empty() {
             return Err("Root is empty.".into());
+        }
+
+        // Basic sanity check to make sure the received compact proof won't panic
+        // TODO: remove this after [this PR](https://github.com/paritytech/polkadot-sdk/pull/6486) is merged.
+        for encoded_node in proof.encoded_nodes.iter() {
+            if encoded_node.len() < 2 {
+                return Err("Invalid encoded node in the proof.".into());
+            }
         }
 
         // TODO: Understand why `CompactProof` cannot be used directly to construct memdb and modify a partial trie. (it fails with error IncompleteDatabase)


### PR DESCRIPTION
This happens because we accept arbitrary proofs from users, and `sp-trie` has an issue where a purposely crafted bad proof makes it panic when decoding it (instead of returning an error).

I've already opened a [PR](https://github.com/paritytech/polkadot-sdk/pull/6486) to fix it upstream but in the meantime we need this fix to allow the auditors to keep testing.