### PR TITLE
feat: add task to let MSP charge user every X blocks

### DIFF
--- a/client/blockchain-service/src/events.rs
+++ b/client/blockchain-service/src/events.rs
@@ -246,6 +246,14 @@ pub struct SpStopStoringInsolventUser {
 }
 impl EventBusMessage for SpStopStoringInsolventUser {}
 
+/// Notify period event.
+///
+/// This event is emitted when a X amount of block has passed. It is configured at the start of the service.
+#[derive(Debug, Clone)]
+pub struct NotifyPeriod {}
+
+impl EventBusMessage for NotifyPeriod {}
+
 /// The event bus provider for the BlockchainService actor.
 ///
 /// It holds the event buses for the different events that the BlockchainService actor
@@ -268,6 +276,7 @@ pub struct BlockchainServiceEventBusProvider {
     user_without_funds_event_bus: EventBus<UserWithoutFunds>,
     sp_stop_storing_insolvent_user_event_bus: EventBus<SpStopStoringInsolventUser>,
     finalised_msp_stopped_storing_bucket_event_bus: EventBus<FinalisedMspStoppedStoringBucket>,
+    notify_period_event_bus: EventBus<NotifyPeriod>,
 }
 
 impl BlockchainServiceEventBusProvider {
@@ -288,6 +297,7 @@ impl BlockchainServiceEventBusProvider {
             user_without_funds_event_bus: EventBus::new(),
             sp_stop_storing_insolvent_user_event_bus: EventBus::new(),
             finalised_msp_stopped_storing_bucket_event_bus: EventBus::new(),
+            notify_period_event_bus: EventBus::new(),
         }
     }
 }
@@ -381,5 +391,11 @@ impl ProvidesEventBus<SpStopStoringInsolventUser> for BlockchainServiceEventBusP
 impl ProvidesEventBus<FinalisedMspStoppedStoringBucket> for BlockchainServiceEventBusProvider {
     fn event_bus(&self) -> &EventBus<FinalisedMspStoppedStoringBucket> {
         &self.finalised_msp_stopped_storing_bucket_event_bus
+    }
+}
+
+impl ProvidesEventBus<NotifyPeriod> for BlockchainServiceEventBusProvider {
+    fn event_bus(&self) -> &EventBus<NotifyPeriod> {
+        &self.notify_period_event_bus
     }
 }

--- a/client/blockchain-service/src/lib.rs
+++ b/client/blockchain-service/src/lib.rs
@@ -23,13 +23,19 @@ pub async fn spawn_blockchain_service(
     rpc_handlers: Arc<RpcHandlers>,
     keystore: KeystorePtr,
     rocksdb_root_path: impl Into<PathBuf>,
+    notify_period: Option<u32>,
 ) -> ActorHandle<BlockchainService> {
     let task_spawner = task_spawner
         .with_name("blockchain-service")
         .with_group("network");
 
-    let blockchain_service =
-        BlockchainService::new(client, rpc_handlers, keystore, rocksdb_root_path);
+    let blockchain_service = BlockchainService::new(
+        client,
+        rpc_handlers,
+        keystore,
+        rocksdb_root_path,
+        notify_period,
+    );
 
     task_spawner.spawn_actor(blockchain_service)
 }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -109,6 +109,12 @@ pub struct ProviderConfigurations {
     /// Extrinsic retry timeout in seconds.
     #[clap(long, default_value = "60")]
     pub extrinsic_retry_timeout: u64,
+
+    /// MSP charging fees frequency.
+    #[clap(long, required_if_eq_any([
+        ("provider_type", "msp"),
+    ]))]
+    pub msp_charging_freq: Option<u32>,
 }
 
 impl ProviderConfigurations {
@@ -128,6 +134,7 @@ impl ProviderConfigurations {
             max_storage_capacity: self.max_storage_capacity,
             jump_capacity: self.jump_capacity,
             extrinsic_retry_timeout: self.extrinsic_retry_timeout,
+            msp_charging_freq: self.msp_charging_freq,
         }
     }
 }

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -37,6 +37,8 @@ pub struct ProviderOptions {
     pub jump_capacity: Option<StorageDataUnit>,
     /// Extrinsic retry timeout in seconds.
     pub extrinsic_retry_timeout: u64,
+    /// MSP charging fees frequency.
+    pub msp_charging_freq: Option<u32>,
 }
 
 fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -215,11 +215,12 @@ where
             max_storage_capacity,
             jump_capacity,
             extrinsic_retry_timeout,
+            msp_charging_freq,
             ..
         }) => {
             info!(
-                "Starting as a Storage Provider. Storage path: {:?}, Max storage capacity: {:?}, Jump capacity: {:?}",
-                storage_path, max_storage_capacity, jump_capacity
+                "Starting as a Storage Provider. Storage path: {:?}, Max storage capacity: {:?}, Jump capacity: {:?}, MSP charging frequency: {:?}",
+                storage_path, max_storage_capacity, jump_capacity, msp_charging_freq,
             );
 
             // Start building the StorageHubHandler, if running as a provider.
@@ -244,6 +245,7 @@ where
                 *max_storage_capacity,
                 *jump_capacity,
                 *extrinsic_retry_timeout,
+                *msp_charging_freq,
             );
 
             let rpc_config = storage_hub_builder.create_rpc_config(keystore);

--- a/node/src/tasks/mod.rs
+++ b/node/src/tasks/mod.rs
@@ -7,6 +7,7 @@ pub mod bsp_submit_proof;
 pub mod bsp_upload_file;
 pub mod mock_bsp_volunteer;
 pub mod mock_sp_react_to_event;
+pub mod msp_charge_fees;
 pub mod msp_delete_bucket;
 pub mod msp_upload_file;
 pub mod sp_slash_provider;

--- a/node/src/tasks/msp_charge_fees.rs
+++ b/node/src/tasks/msp_charge_fees.rs
@@ -1,0 +1,129 @@
+use anyhow::anyhow;
+use sc_tracing::tracing::*;
+use shc_actors_framework::event_bus::EventHandler;
+use shc_blockchain_service::commands::BlockchainServiceInterface;
+use shc_blockchain_service::events::NotifyPeriod;
+use shc_blockchain_service::types::Tip;
+use shc_common::types::MaxUsersToCharge;
+use shc_common::types::StorageProviderId;
+use sp_core::Get;
+use storage_hub_runtime::Balance;
+
+use crate::tasks::{FileStorageT, MspForestStorageHandlerT, StorageHubHandler};
+
+const LOG_TARGET: &str = "msp-charge-fees-task";
+const MIN_DEBT: Balance = 0;
+
+pub struct MspChargeFeesTask<FL, FSH>
+where
+    FL: FileStorageT,
+    FSH: MspForestStorageHandlerT,
+{
+    storage_hub_handler: StorageHubHandler<FL, FSH>,
+}
+
+impl<FL, FSH> Clone for MspChargeFeesTask<FL, FSH>
+where
+    FL: FileStorageT,
+    FSH: MspForestStorageHandlerT,
+{
+    fn clone(&self) -> MspChargeFeesTask<FL, FSH> {
+        Self {
+            storage_hub_handler: self.storage_hub_handler.clone(),
+        }
+    }
+}
+
+impl<FL, FSH> MspChargeFeesTask<FL, FSH>
+where
+    FL: FileStorageT,
+    FSH: MspForestStorageHandlerT,
+{
+    pub fn new(storage_hub_handler: StorageHubHandler<FL, FSH>) -> Self {
+        Self {
+            storage_hub_handler,
+        }
+    }
+}
+
+/// Handles the [`NotifyPeriod`] event.
+///
+/// This event is triggered every X amount of blocks.
+///
+/// This task will:
+/// - Charge users for the MSP when triggered
+impl<FL, FSH> EventHandler<NotifyPeriod> for MspChargeFeesTask<FL, FSH>
+where
+    FL: FileStorageT,
+    FSH: MspForestStorageHandlerT,
+{
+    async fn handle_event(&mut self, event: NotifyPeriod) -> anyhow::Result<()> {
+        info!(
+            target: LOG_TARGET,
+            "Charging users",
+        );
+
+        let own_provider_id = self
+            .storage_hub_handler
+            .blockchain
+            .query_storage_provider_id(None)
+            .await?;
+
+        let own_msp_id = match own_provider_id {
+            Some(id) => match id {
+                StorageProviderId::MainStorageProvider(id) => id,
+                StorageProviderId::BackupStorageProvider(_) => {
+                    let err_msg = "Current node account is a Backup Storage Provider. Expected a Main Storage Provider ID.";
+                    error!(target: LOG_TARGET, err_msg);
+                    return Err(anyhow!(err_msg));
+                }
+            },
+            None => {
+                let err_msg = "Failed to get own MSP ID.";
+                error!(target: LOG_TARGET, err_msg);
+                return Err(anyhow!(err_msg));
+            }
+        };
+
+        let users_with_debt = self
+            .storage_hub_handler
+            .blockchain
+            .query_users_with_debt(own_msp_id, MIN_DEBT)
+            .await
+            .map_err(|e| {
+                anyhow!(
+                    "Failed to retrieve users with debt from the runtime: {:?}",
+                    e
+                )
+            })?;
+
+        // Divides the users to charge in chunks of MaxUsersToCharge to avoid exceeding the block limit.
+        // Calls the `charge_multiple_users_payment_streams` extrinsic for each chunk in the list to be charged.
+        // Logs an error in case of failure and continues.
+        let user_chunk_size: u32 = MaxUsersToCharge::get();
+        for users_chunk in users_with_debt.chunks(user_chunk_size as usize) {
+            let call = storage_hub_runtime::RuntimeCall::PaymentStreams(
+                pallet_payment_streams::Call::charge_multiple_users_payment_streams {
+                    user_accounts: users_chunk.to_vec().try_into().expect("Chunk size is the same as MaxUsersToCharge, it has to fit in the BoundedVec"),
+                },
+            );
+
+            let charging_result = self
+                .storage_hub_handler
+                .blockchain
+                .send_extrinsic(call, Tip::from(0))
+                .await;
+
+            match charging_result {
+                Ok(submitted_transaction) => {
+                    info!(target: LOG_TARGET, "Submitted extrinsic to charge users with debt: {}", submitted_transaction.hash());
+                }
+                Err(e) => {
+                    error!(target: LOG_TARGET, "Failed to send extrinsic to charge users with debt: {}", e);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR add a `NotifyPeriod` event that would be triggered every X blocks. It helps notifyng the MSP task that X blocks has passed and that it can charge users for their service.

The amount of blocks (aka the msp charging frequency) is a configurable value that can be passed through the CLI.