### PR TITLE
fix: 🩹 Create a collection only when updating to a private bucket

### DIFF
--- a/pallets/file-system/src/utils.rs
+++ b/pallets/file-system/src/utils.rs
@@ -430,8 +430,8 @@ where
             (true, None) => {
                 Some(Self::do_create_and_associate_collection_with_bucket(sender.clone(), bucket_id)?)
             }
-            // Handle case where the bucket has an existing collection.
-            (_, Some(current_collection_id))
+            // Handle case where the bucket has an existing collection, but the collection is not in stroage.
+            (true, Some(current_collection_id))
             if !<T::CollectionInspector as shp_traits::InspectCollections>::collection_exists(&current_collection_id) =>
                 {
                     Some(Self::do_create_and_associate_collection_with_bucket(sender.clone(), bucket_id)?)
@@ -450,7 +450,7 @@ where
 
     /// Create and associate collection with a bucket.
     ///
-    /// *Callable only by the owner of the bucket. The bucket must be private.*
+    /// *Callable only by the owner of the bucket.*
     ///
     /// It is possible to have a bucket that is private but does not have a collection associated with it. This can happen if
     /// a user destroys the collection associated with the bucket by calling the NFTs pallet directly.

--- a/pallets/file-system/src/utils.rs
+++ b/pallets/file-system/src/utils.rs
@@ -430,7 +430,7 @@ where
             (true, None) => {
                 Some(Self::do_create_and_associate_collection_with_bucket(sender.clone(), bucket_id)?)
             }
-            // Handle case where the bucket has an existing collection, but the collection is not in stroage.
+            // Handle case where the bucket has an existing collection, but the collection is not in storage.
             (true, Some(current_collection_id))
             if !<T::CollectionInspector as shp_traits::InspectCollections>::collection_exists(&current_collection_id) =>
                 {


### PR DESCRIPTION
When updating a bucket's privacy, we were previously creating and associating a collection when changing the privacy to public (if a collection ID existed but the collection did not exist in Storage). Now, this behavior is restricted to cases where the privacy is changed to private.

Additionally, some minor comment corrections were made to clarify that the `do_create_and_associate_collection_with_bucket` function does not validate the bucket's privacy.