### PR TITLE
fix: :bug: change update order of payment stream's rate and bucket size

### DIFF
--- a/test/suites/integration/msp/debt-collection.test.ts
+++ b/test/suites/integration/msp/debt-collection.test.ts
@@ -2,6 +2,7 @@ import assert, { strictEqual } from "node:assert";
 import { describeMspNet, shUser, sleep, type EnrichedBspApi } from "../../../util";
 import { DUMMY_MSP_ID, MSP_CHARGING_PERIOD } from "../../../util/bspNet/consts";
 import type { H256 } from "@polkadot/types/interfaces";
+import type { Option } from "@polkadot/types";
 
 describeMspNet("Single MSP collecting debt", ({ before, createMspApi, it, createUserApi }) => {
   let userApi: EnrichedBspApi;
@@ -28,18 +29,38 @@ describeMspNet("Single MSP collecting debt", ({ before, createMspApi, it, create
     const destination = ["test/whatsup.jpg", "test/adolphus.jpg", "test/smile.jpg"];
     const bucketName = "nothingmuch-3";
 
+    // Get the value propositions from the MSP. It should have at least one
     const valueProps = await userApi.call.storageProvidersApi.queryValuePropositionsForMsp(
       userApi.shConsts.DUMMY_MSP_ID
     );
-
+    // Get the ID of the first one. This is going to be used to access the price per giga-unit of data per tick
     const valuePropId = valueProps[0].id;
 
+    // Create a bucket for the user in this MSP
     const newBucketEventEvent = await userApi.createBucket(bucketName, valuePropId);
     const newBucketEventDataBlob =
       userApi.events.fileSystem.NewBucket.is(newBucketEventEvent) && newBucketEventEvent.data;
     assert(newBucketEventDataBlob, "NewBucket event data does not match expected type");
+
+    // Check that the payment stream between the user and the MSP was created and has a rate equal
+    // to the rate for a zero-sized bucket
+    const maybePaymentStream = await userApi.query.paymentStreams.fixedRatePaymentStreams(
+      userApi.shConsts.DUMMY_MSP_ID,
+      userApi.shConsts.NODE_INFOS.user.AddressId
+    );
+    assert(maybePaymentStream.isSome, "Payment stream not found");
+    let paymentStream = maybePaymentStream.unwrap();
+    const zeroSizeBucketFixedRate = userApi.consts.providers.zeroSizeBucketFixedRate.toNumber();
+    strictEqual(
+      paymentStream.rate.toNumber(),
+      zeroSizeBucketFixedRate,
+      "Payment stream rate does not match the expected value"
+    );
+
+    // Get the bucket ID from the event
     bucketId = newBucketEventDataBlob.bucketId;
 
+    // Load each file in storage and issue the storage requests
     const txs = [];
     for (let i = 0; i < source.length; i++) {
       const { fingerprint, file_size, location } =
@@ -61,24 +82,27 @@ describeMspNet("Single MSP collecting debt", ({ before, createMspApi, it, create
         )
       );
     }
-
     await userApi.block.seal({ calls: txs, signer: shUser });
 
-    // Allow time for the MSP to receive and store the file from the user
-    await sleep(3000);
+    // Allow time for the MSP to receive and store the files from the user
+    await sleep(5000);
 
-    const events = await userApi.assert.eventMany("fileSystem", "NewStorageRequest");
-
-    const matchedEvents = events.filter((e) =>
+    // Check that the storage request submission events were emitted
+    const newStorageRequestEvents = await userApi.assert.eventMany(
+      "fileSystem",
+      "NewStorageRequest"
+    );
+    const matchedStorageRequestEvents = newStorageRequestEvents.filter((e) =>
       userApi.events.fileSystem.NewStorageRequest.is(e.event)
     );
     assert(
-      matchedEvents.length === source.length,
+      matchedStorageRequestEvents.length === source.length,
       `Expected ${source.length} NewStorageRequest events`
     );
 
+    // For each issued storage request, check that the file is in the MSP's storage
     const issuedFileKeys = [];
-    for (const e of matchedEvents) {
+    for (const e of matchedStorageRequestEvents) {
       const newStorageRequestDataBlob =
         userApi.events.fileSystem.NewStorageRequest.is(e.event) && e.event.data;
 
@@ -96,26 +120,31 @@ describeMspNet("Single MSP collecting debt", ({ before, createMspApi, it, create
       issuedFileKeys.push(newStorageRequestDataBlob.fileKey);
     }
 
-    // Seal block containing the MSP's transaction response to the storage request
+    // Seal block containing the MSP's transaction response to the first received storage request
     await userApi.wait.mspResponseInTxPool();
     await userApi.block.seal();
 
     let mspAcceptedStorageRequestDataBlob: any = undefined;
 
-    const eventsRecorded = await userApi.query.system.events();
-    const mspAcceptedStorageRequestEvent = eventsRecorded.find(
-      (e) => e.event.section === "fileSystem" && e.event.method === "MspAcceptedStorageRequest"
+    // Check that there's only one `MspAcceptedStorageRequest` event
+    let mspAcceptedStorageRequestEvents = await userApi.assert.eventMany(
+      "fileSystem",
+      "MspAcceptedStorageRequest"
+    );
+    assert(
+      mspAcceptedStorageRequestEvents.length === 1,
+      "Expected a single MspAcceptedStorageRequest event"
     );
 
+    // Get its file key
+    const mspAcceptedStorageRequestEvent = mspAcceptedStorageRequestEvents[0];
     if (mspAcceptedStorageRequestEvent) {
       mspAcceptedStorageRequestDataBlob =
         userApi.events.fileSystem.MspAcceptedStorageRequest.is(
           mspAcceptedStorageRequestEvent.event
         ) && mspAcceptedStorageRequestEvent.event.data;
     }
-
     const acceptedFileKey = mspAcceptedStorageRequestDataBlob.fileKey.toString();
-
     assert(acceptedFileKey, "MspAcceptedStorageRequest event were found");
 
     // There is only a single key being accepted since it is the first file key to be processed and there is nothing to batch.
@@ -127,10 +156,12 @@ describeMspNet("Single MSP collecting debt", ({ before, createMspApi, it, create
     // Allow time for the MSP to update the local forest root
     await sleep(3000);
 
+    // Get the root of the bucket now that the file has been stored
     const localBucketRoot = await mspApi.rpc.storagehubclient.getForestRoot(
       newBucketEventDataBlob.bucketId.toString()
     );
 
+    // Ensure the `BucketRootChanged` event was emitted
     const { event: bucketRootChangedEvent } = await userApi.assert.eventPresent(
       "providers",
       "BucketRootChanged"
@@ -145,8 +176,10 @@ describeMspNet("Single MSP collecting debt", ({ before, createMspApi, it, create
       "Expected BucketRootChanged event but received event of different type"
     );
 
+    // Ensure the new root of the bucket matches the one in the event
     strictEqual(bucketRootChangedDataBlob.newRoot.toString(), localBucketRoot.toString());
 
+    // Ensure that the file has been stored in the MSP's forest, in the bucket's trie
     const isFileInForest = await mspApi.rpc.storagehubclient.isFileInForest(
       newBucketEventDataBlob.bucketId.toString(),
       acceptedFileKey
@@ -154,13 +187,36 @@ describeMspNet("Single MSP collecting debt", ({ before, createMspApi, it, create
 
     assert(isFileInForest.isTrue, "File is not in forest");
 
+    // Check that the rate of the payment stream between the user and the MSP has been updated
+    // to reflect the new size of the bucket
+    paymentStream = (
+      await userApi.query.paymentStreams.fixedRatePaymentStreams(
+        DUMMY_MSP_ID,
+        userApi.shConsts.NODE_INFOS.user.AddressId
+      )
+    ).unwrap();
+    const bucketOption: Option<H256> = userApi.createType("Option<H256>", bucketId);
+    const firstFileSize = (
+      await mspApi.rpc.storagehubclient.getFileMetadata(bucketOption, acceptedFileKey)
+    )
+      .unwrap()
+      .file_size.toNumber();
+    const unitsInGigaUnit = 1024 * 1024 * 1024;
+    let expectedPaymentStreamRate =
+      (valueProps[0].value_prop.price_per_giga_unit_of_data_per_block.toNumber() * firstFileSize) /
+        unitsInGigaUnit +
+      zeroSizeBucketFixedRate;
+    strictEqual(paymentStream.rate.toNumber(), Math.round(expectedPaymentStreamRate));
+
     // Seal block containing the MSP's transaction response to the storage request
     await userApi.wait.mspResponseInTxPool();
     await userApi.block.seal();
 
     const fileKeys2: string[] = [];
 
-    const mspAcceptedStorageRequestEvents = await userApi.assert.eventMany(
+    // Since we gave enough time to the MSP to receive both files before processing the response for the
+    // first one, we should have two `MspAcceptedStorageRequest` events (because of the batching)
+    mspAcceptedStorageRequestEvents = await userApi.assert.eventMany(
       "fileSystem",
       "MspAcceptedStorageRequest"
     );
@@ -178,10 +234,12 @@ describeMspNet("Single MSP collecting debt", ({ before, createMspApi, it, create
     // Allow time for the MSP to update the local forest root
     await sleep(3000);
 
+    // Get the root of the bucket now that the files have been stored
     const localBucketRoot2 = await mspApi.rpc.storagehubclient.getForestRoot(
       newBucketEventDataBlob.bucketId.toString()
     );
 
+    // Ensure the `BucketRootChanged` event was emitted
     const { event: bucketRootChangedEvent2 } = await userApi.assert.eventPresent(
       "providers",
       "BucketRootChanged"
@@ -196,8 +254,10 @@ describeMspNet("Single MSP collecting debt", ({ before, createMspApi, it, create
       "Expected BucketRootChanged event but received event of different type"
     );
 
+    // Ensure the new root of the bucket matches the one in the event
     strictEqual(bucketRootChangedDataBlob2.newRoot.toString(), localBucketRoot2.toString());
 
+    // Ensure that the files have been stored in the MSP's forest, in the bucket's trie
     for (const fileKey of fileKeys2) {
       const isFileInForest = await mspApi.rpc.storagehubclient.isFileInForest(
         newBucketEventDataBlob.bucketId.toString(),
@@ -205,23 +265,82 @@ describeMspNet("Single MSP collecting debt", ({ before, createMspApi, it, create
       );
       assert(isFileInForest.isTrue, "File is not in forest");
     }
+
+    // Check that the rate of the payment stream between the user and the MSP has been updated
+    // to reflect the new size of the bucket
+    paymentStream = (
+      await userApi.query.paymentStreams.fixedRatePaymentStreams(
+        DUMMY_MSP_ID,
+        userApi.shConsts.NODE_INFOS.user.AddressId
+      )
+    ).unwrap();
+    const secondFileSize = (
+      await mspApi.rpc.storagehubclient.getFileMetadata(bucketOption, fileKeys2[0])
+    )
+      .unwrap()
+      .file_size.toNumber();
+    const thirdFileSize = (
+      await mspApi.rpc.storagehubclient.getFileMetadata(bucketOption, fileKeys2[1])
+    )
+      .unwrap()
+      .file_size.toNumber();
+    const sumOfSizeOfFiles = firstFileSize + secondFileSize + thirdFileSize;
+    expectedPaymentStreamRate = Math.round(
+      (valueProps[0].value_prop.price_per_giga_unit_of_data_per_block.toNumber() *
+        sumOfSizeOfFiles) /
+        unitsInGigaUnit +
+        zeroSizeBucketFixedRate
+    );
+    strictEqual(paymentStream.rate.toNumber(), expectedPaymentStreamRate);
   });
 
   it("MSP is charging user", async () => {
+    // Get the current block
     let currentBlock = await userApi.rpc.chain.getHeader();
     let currentBlockNumber = currentBlock.number.toNumber();
 
-    const blocksToAdvance = MSP_CHARGING_PERIOD - (currentBlockNumber % MSP_CHARGING_PERIOD) + 1;
-    await userApi.block.skipTo(currentBlockNumber + blocksToAdvance - 1);
+    // We want to advance to the next time the MSP is going to try to charge the user.
+    const blocksToAdvance = MSP_CHARGING_PERIOD - (currentBlockNumber % MSP_CHARGING_PERIOD);
+    await userApi.block.skipTo(currentBlockNumber + blocksToAdvance);
 
     // Wait for the MSP to try to charge the user and seal a block.
     await sleep(2000);
     await userApi.block.seal();
 
-    // Verify that the MSP charged the users after the notified.
-    await userApi.assert.eventPresent("paymentStreams", "PaymentStreamCharged");
+    // Verify that the MSP was able to charge the user after the notify period.
+    // Get all the PaymentStreamCharged events
+    const firstPaymentStreamChargedEvents = await userApi.assert.eventMany(
+      "paymentStreams",
+      "PaymentStreamCharged"
+    );
 
-    // Advance many MSP charging periods, to charge again, but this time with a known number of
+    // Keep only the ones that belong to the MSP, by checking the Provider ID
+    const firstPaymentStreamChargedEventsFiltered = firstPaymentStreamChargedEvents.filter((e) => {
+      const event = e.event;
+      assert(userApi.events.paymentStreams.PaymentStreamCharged.is(event));
+      return event.data.providerId.eq(DUMMY_MSP_ID);
+    });
+
+    // There should be only one PaymentStreamCharged event for the MSP
+    assert(
+      firstPaymentStreamChargedEventsFiltered.length === 1,
+      "Expected a single PaymentStreamCharged event"
+    );
+
+    // Get it and check that the user account matches
+    const firstPaymentStreamChargedEvent = firstPaymentStreamChargedEvents[0];
+    assert(
+      userApi.events.paymentStreams.PaymentStreamCharged.is(firstPaymentStreamChargedEvent.event),
+      "Expected PaymentStreamCharged event"
+    );
+    assert(
+      firstPaymentStreamChargedEvent.event.data.userAccount.eq(
+        userApi.shConsts.NODE_INFOS.user.AddressId
+      ),
+      "User account does not match"
+    );
+
+    // Advance many MSP charging periods to charge again, but this time with a known number of
     // blocks since last charged. That way, we can check for the exact amount charged.
     // Since the MSP is going to charge each period, the last charge should be for one period.
     currentBlock = await userApi.rpc.chain.getHeader();
@@ -237,7 +356,7 @@ describeMspNet("Single MSP collecting debt", ({ before, createMspApi, it, create
       valueProps[0].value_prop.price_per_giga_unit_of_data_per_block.toNumber();
     const unitsInGigaUnit = 1024 * 1024 * 1024;
     const expectedRateOfPaymentStream =
-      Math.ceil((pricePerGigaUnitOfDataPerBlock * bucketSize) / unitsInGigaUnit) +
+      Math.round((pricePerGigaUnitOfDataPerBlock * bucketSize) / unitsInGigaUnit) +
       userApi.consts.providers.zeroSizeBucketFixedRate.toNumber();
     const paymentStream = (
       await userApi.query.paymentStreams.fixedRatePaymentStreams(


### PR DESCRIPTION
This PR fixes a bug where sometimes when increasing the size of a bucket (because the MSP that stores it accepts to store a new file for it from the user that owns it) the update of the rate of the fixed-rate payment stream between that MSP and that user was done incorrectly and ended up being greater than expected.

This was happening because the function that updates the rate of a fixed-rate payment stream (when updating the size of a bucket) expects that bucket's size as recorded in storage to not have been updated yet, since it uses the size of the bucket (previous to the update) and its delta to calculate the difference in rate, which then uses to update the rate of the payment stream to its new value. This expectation was not met, since the logic that increases a bucket's size was first updating it on the buckets' storage and then calling the aforementioned funcion.

This resulted in a scenario where the new rate of the payment stream was calculated as:
`new_payment_stream_rate = previous_rate_of_bucket + (2 * rate_delta_because_of_new_file - rate_delta_because_of_new_file)`

To the unsuspecting eye this calculation seems correct, and that's why everything was working correctly, BUT in the specific scenario where the calculation of `rate_delta_because_of_new_file` had a fractional part that was over 0.25 but lower than 0.5, the rounding of `rate_delta_because_of_new_file` would be down (since its fractional part was lower than 0.5) and the rounding of `2 * rate_delta_because_of_new_file` would be up (since its fractional part would be over 0.5)! This made it so in some scenarios the resulting new rate was one higher than the amount expected.

With the introduced changes, this calculation has now been changed to:
`new_payment_stream_rate = previous_rate_of_bucket + rate_delta_because_of_new_file`
avoiding the error completely.

As a bonus I did some changes to the test that was checking this to make it a bit more clear and explicit, avoiding the issue we were having where the issue was hard to reproduce.
