### PR TITLE
test: ✅ Fix race conditions in integration tests

### DIFF
--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -884,7 +884,7 @@ impl Convert<<Runtime as frame_system::Config>::Hash, ThresholdType>
         // Get the hash as bytes
         let hash_bytes = hash.as_ref();
 
-        // Get the 4 least significant bytes of the hash and interpret them as a u32
+        // Get the 4 least significant bytes of the hash and interpret them as an u32
         let truncated_hash_bytes: [u8; 4] =
             hash_bytes[28..].try_into().expect("Hash is 32 bytes; qed");
 

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -884,7 +884,7 @@ impl Convert<<Runtime as frame_system::Config>::Hash, ThresholdType>
         // Get the hash as bytes
         let hash_bytes = hash.as_ref();
 
-        // Get the 4 least significant bytes of the hash and interpret them as an u32
+        // Get the 4 least significant bytes of the hash and interpret them as a u32
         let truncated_hash_bytes: [u8; 4] =
             hash_bytes[28..].try_into().expect("Hash is 32 bytes; qed");
 

--- a/test/scripts/generateBenchmarkProofs.ts
+++ b/test/scripts/generateBenchmarkProofs.ts
@@ -190,7 +190,7 @@ async function generateBenchmarkProofs() {
     fileKeys.push(fileMetadata.fileKey);
 
     await userApi.wait.bspVolunteer(1);
-    await bspApi.wait.bspFileStorageComplete(fileMetadata.fileKey);
+    await bspApi.wait.fileStorageComplete(fileMetadata.fileKey);
     await userApi.wait.bspStored(1);
   }
 

--- a/test/suites/integration/bsp/bsp-thresholds.test.ts
+++ b/test/suites/integration/bsp/bsp-thresholds.test.ts
@@ -114,7 +114,7 @@ describeBspNet(
       );
 
       await userApi.sealBlock(
-        userApi.tx.sudo.sudo(userApi.tx.fileSystem.setGlobalParameters(null, 10))
+        userApi.tx.sudo.sudo(userApi.tx.fileSystem.setGlobalParameters(null, 500))
       );
 
       // Create a new BSP and onboard with no reputation
@@ -131,8 +131,8 @@ describeBspNet(
       await userApi.wait.bspCatchUpToChainTip(bspDownApi);
 
       const { fileKey } = await userApi.file.createBucketAndSendNewStorageRequest(
-        "res/smile.jpg",
-        "test/smile.jpg",
+        "res/whatsup.jpg",
+        "test/whatsup.jpg",
         "bucket-1"
       );
 
@@ -150,17 +150,27 @@ describeBspNet(
         )
       ).asOk.toNumber();
 
-      if ((await userApi.rpc.chain.getHeader()).number.toNumber() < lowReputationVolunteerTick) {
-        await userApi.block.skipTo(lowReputationVolunteerTick);
-      }
+      const currentBlockNumber = (await userApi.rpc.chain.getHeader()).number.toNumber();
+      assert(
+        currentBlockNumber === normalReputationVolunteerTick,
+        "The BSP with high reputation should be able to volunteer immediately"
+      );
+      assert(
+        currentBlockNumber < lowReputationVolunteerTick,
+        "The volunteer tick for the low reputation BSP should be in the future"
+      );
 
-      if (normalReputationVolunteerTick < lowReputationVolunteerTick) {
-        await userApi.wait.bspVolunteer();
-      } else {
-        await userApi.wait.bspVolunteer(2);
-      }
+      // Checking volunteering and confirming for the high reputation BSP
+      await userApi.wait.bspVolunteer(1);
+      await bspApi.wait.bspFileStorageComplete(fileKey);
+      await userApi.wait.bspStored(1);
+
+      // Checking volunteering and confirming for the low reputation BSP
+      await userApi.block.skipTo(lowReputationVolunteerTick);
+      await userApi.wait.bspVolunteer(1);
       const matchedEvents = await userApi.assert.eventMany("fileSystem", "AcceptedBspVolunteer"); // T1
 
+      // Check that it is in fact the BSP with low reputation that just volunteered
       const filtered = matchedEvents.filter(
         ({ event }) =>
           (userApi.events.fileSystem.AcceptedBspVolunteer.is(event) &&
@@ -224,49 +234,23 @@ describeBspNet(
         )
       ).asOk.toNumber();
 
-      if (bsp1VolunteerTick < bsp2VolunteerTick) {
-        // If the first BSP can volunteer first, wait for it to volunteer and confirm storing the file
-        if ((await userApi.rpc.chain.getHeader()).number.toNumber() < bsp1VolunteerTick) {
-          await userApi.block.skipTo(bsp1VolunteerTick);
-        }
-        await userApi.wait.bspVolunteer(1);
-        await bspApi.wait.bspFileStorageComplete(fileKey);
-        await userApi.wait.bspStored(1);
+      assert(bsp1VolunteerTick < bsp2VolunteerTick, "BSP one should be able to volunteer first");
+      const currentBlockNumber = (await userApi.rpc.chain.getHeader()).number.toNumber();
+      assert(
+        currentBlockNumber === bsp1VolunteerTick,
+        "BSP one should be able to volunteer immediately"
+      );
 
-        // Then wait for the second BSP to volunteer and confirm storing the file
-        if ((await userApi.rpc.chain.getHeader()).number.toNumber() < bsp2VolunteerTick) {
-          await userApi.block.skipTo(bsp2VolunteerTick);
-        }
-        await userApi.wait.bspVolunteer(1);
-        await bspTwoApi.wait.bspFileStorageComplete(fileKey);
-        await userApi.wait.bspStored(1);
-      } else if (bsp1VolunteerTick > bsp2VolunteerTick) {
-        // If the second BSP can volunteer first, wait for it to volunteer and confirm storing the file
-        if ((await userApi.rpc.chain.getHeader()).number.toNumber() < bsp2VolunteerTick) {
-          await userApi.block.skipTo(bsp2VolunteerTick);
-        }
-        await userApi.wait.bspVolunteer(1);
-        await bspTwoApi.wait.bspFileStorageComplete(fileKey);
-        await userApi.wait.bspStored(1);
+      await userApi.wait.bspVolunteer(1);
+      await bspApi.wait.bspFileStorageComplete(fileKey);
+      await userApi.wait.bspStored(1);
 
-        // Then wait for the first BSP to volunteer and confirm storing the file
-        if ((await userApi.rpc.chain.getHeader()).number.toNumber() < bsp1VolunteerTick) {
-          await userApi.block.skipTo(bsp1VolunteerTick);
-        }
-        await userApi.wait.bspVolunteer(1);
-        await bspApi.wait.bspFileStorageComplete(fileKey);
-        await userApi.wait.bspStored(1);
-      } else {
-        // If both BSPs can volunteer at the same time, advance to the tick where both can volunteer
-        if ((await userApi.rpc.chain.getHeader()).number.toNumber() < bsp1VolunteerTick) {
-          await userApi.block.skipTo(bsp1VolunteerTick);
-        }
-        // And wait for them to volunteer and confirm storing the file
-        await userApi.wait.bspVolunteer(2);
-        await bspApi.wait.bspFileStorageComplete(fileKey);
-        await bspTwoApi.wait.bspFileStorageComplete(fileKey);
-        await userApi.wait.bspStored(2);
-      }
+      // Then wait for the second BSP to volunteer and confirm storing the file
+      await userApi.block.skipTo(bsp2VolunteerTick);
+
+      await userApi.wait.bspVolunteer(1);
+      await bspTwoApi.wait.bspFileStorageComplete(fileKey);
+      await userApi.wait.bspStored(1);
 
       await bspTwoApi.disconnect();
       await userApi.docker.stopBspContainer("sh-bsp-two");

--- a/test/suites/integration/bsp/bsp-thresholds.test.ts
+++ b/test/suites/integration/bsp/bsp-thresholds.test.ts
@@ -162,7 +162,7 @@ describeBspNet(
 
       // Checking volunteering and confirming for the high reputation BSP
       await userApi.wait.bspVolunteer(1);
-      await bspApi.wait.bspFileStorageComplete(fileKey);
+      await bspApi.wait.fileStorageComplete(fileKey);
       await userApi.wait.bspStored(1);
 
       // Checking volunteering and confirming for the low reputation BSP
@@ -242,14 +242,14 @@ describeBspNet(
       );
 
       await userApi.wait.bspVolunteer(1);
-      await bspApi.wait.bspFileStorageComplete(fileKey);
+      await bspApi.wait.fileStorageComplete(fileKey);
       await userApi.wait.bspStored(1);
 
       // Then wait for the second BSP to volunteer and confirm storing the file
       await userApi.block.skipTo(bsp2VolunteerTick);
 
       await userApi.wait.bspVolunteer(1);
-      await bspTwoApi.wait.bspFileStorageComplete(fileKey);
+      await bspTwoApi.wait.fileStorageComplete(fileKey);
       await userApi.wait.bspStored(1);
 
       await bspTwoApi.disconnect();

--- a/test/suites/integration/bsp/bsp-thresholds.test.ts
+++ b/test/suites/integration/bsp/bsp-thresholds.test.ts
@@ -266,6 +266,7 @@ describeBspNet(
         bspStartingWeight: 800_000_000n
       });
       const bspThreeApi = await BspNetTestApi.create(`ws://127.0.0.1:${rpcPort}`);
+      await userApi.wait.bspCatchUpToChainTip(bspThreeApi);
 
       // Wait for it to catch up to the top of the chain
       await userApi.wait.bspCatchUpToChainTip(bspThreeApi);
@@ -303,11 +304,11 @@ describeBspNet(
       );
 
       // Advance to the tick where the new BSP can volunteer
-      if (
-        (await userApi.rpc.chain.getHeader()).number.toNumber() < highReputationBspVolunteerTick
-      ) {
-        await userApi.block.skipTo(highReputationBspVolunteerTick);
-      }
+      const currentBlockNumber = (await userApi.rpc.chain.getHeader()).number.toNumber();
+      assert(
+        currentBlockNumber === highReputationBspVolunteerTick,
+        "BSP with high reputation should be able to volunteer immediately"
+      );
 
       // Wait until the new BSP volunteers
       await userApi.wait.bspVolunteer(1);

--- a/test/suites/integration/bsp/debt-collection.test.ts
+++ b/test/suites/integration/bsp/debt-collection.test.ts
@@ -1,13 +1,6 @@
 import assert, { strictEqual } from "node:assert";
 import { after } from "node:test";
-import {
-  bob,
-  describeBspNet,
-  fetchEvent,
-  ShConsts,
-  sleep,
-  type EnrichedBspApi
-} from "../../../util";
+import { bob, describeBspNet, fetchEvent, ShConsts, type EnrichedBspApi } from "../../../util";
 import { BN } from "@polkadot/util";
 
 describeBspNet(
@@ -493,7 +486,6 @@ describeBspNet(
 
       // Seal a block to allow BSPs to charge the payment stream
       await userApi.sealBlock();
-      await sleep(500);
 
       // Assert that event for the BSP charging its payment stream was emitted
       await userApi.assert.eventPresent("paymentStreams", "PaymentStreamCharged");

--- a/test/suites/integration/bsp/debt-collection.test.ts
+++ b/test/suites/integration/bsp/debt-collection.test.ts
@@ -255,9 +255,9 @@ describeBspNet(
         3 // There are 3 running BSPs to fulfil the storage request
       );
       await userApi.wait.bspVolunteer(3);
-      await bspApi.wait.bspFileStorageComplete(cloudFileMetadata.fileKey);
-      await bspTwoApi.wait.bspFileStorageComplete(cloudFileMetadata.fileKey);
-      await bspThreeApi.wait.bspFileStorageComplete(cloudFileMetadata.fileKey);
+      await bspApi.wait.fileStorageComplete(cloudFileMetadata.fileKey);
+      await bspTwoApi.wait.fileStorageComplete(cloudFileMetadata.fileKey);
+      await bspThreeApi.wait.fileStorageComplete(cloudFileMetadata.fileKey);
       await userApi.wait.bspStored(3);
 
       const adolphusFileMetadata = await userApi.file.createBucketAndSendNewStorageRequest(
@@ -270,9 +270,9 @@ describeBspNet(
         3 // There are 3 running BSPs to fulfil the storage request
       );
       await userApi.wait.bspVolunteer(3);
-      await bspApi.wait.bspFileStorageComplete(adolphusFileMetadata.fileKey);
-      await bspTwoApi.wait.bspFileStorageComplete(adolphusFileMetadata.fileKey);
-      await bspThreeApi.wait.bspFileStorageComplete(adolphusFileMetadata.fileKey);
+      await bspApi.wait.fileStorageComplete(adolphusFileMetadata.fileKey);
+      await bspTwoApi.wait.fileStorageComplete(adolphusFileMetadata.fileKey);
+      await bspThreeApi.wait.fileStorageComplete(adolphusFileMetadata.fileKey);
       await userApi.wait.bspStored(3);
 
       // Check the payment stream info after adding the new files

--- a/test/suites/integration/bsp/multiple-delete.test.ts
+++ b/test/suites/integration/bsp/multiple-delete.test.ts
@@ -76,7 +76,7 @@ describeBspNet("Single BSP Volunteering", ({ before, createBspApi, it, createUse
     // Wait for the BSP to volunteer
     await userApi.wait.bspVolunteer(source.length);
     for (const fileKey of fileKeys) {
-      await bspApi.wait.bspFileStorageComplete(fileKey);
+      await bspApi.wait.fileStorageComplete(fileKey);
     }
 
     // Waiting for a confirmation of the first file to be stored
@@ -214,7 +214,7 @@ describeBspNet("Single BSP Volunteering", ({ before, createBspApi, it, createUse
       // Wait for the BSP to volunteer
       await userApi.wait.bspVolunteer(source.length);
       for (const fileKey of fileKeys) {
-        await bspApi.wait.bspFileStorageComplete(fileKey);
+        await bspApi.wait.fileStorageComplete(fileKey);
       }
 
       // Waiting for a confirmation of the first file to be stored

--- a/test/suites/integration/bsp/reorg-proof.test.ts
+++ b/test/suites/integration/bsp/reorg-proof.test.ts
@@ -40,7 +40,7 @@ describeBspNet(
       await userApi.block.seal(); // To make sure we have a finalised head
       const nextChallengeTick = await getNextChallengeHeight(userApi);
       await userApi.block.skipTo(nextChallengeTick, {
-        waitForBspProofs: [ShConsts.DUMMY_BSP_ID, ShConsts.BSP_TWO_ID, ShConsts.BSP_THREE_ID],
+        watchForBspProofs: [ShConsts.DUMMY_BSP_ID, ShConsts.BSP_TWO_ID, ShConsts.BSP_THREE_ID],
         finalised: true
       });
 

--- a/test/suites/integration/bsp/single-volunteer.test.ts
+++ b/test/suites/integration/bsp/single-volunteer.test.ts
@@ -226,7 +226,7 @@ describeBspNet("Single BSP multi-volunteers", ({ before, createBspApi, createUse
     // Wait for the BSP to receive and store all files
     for (let i = 0; i < source.length; i++) {
       const fileKey = fileKeys[i];
-      await bspApi.wait.bspFileStorageComplete(fileKey);
+      await bspApi.wait.fileStorageComplete(fileKey);
     }
 
     // The first file to be completed will immediately acquire the forest write lock

--- a/test/suites/integration/bsp/storage-capacity.test.ts
+++ b/test/suites/integration/bsp/storage-capacity.test.ts
@@ -1,220 +1,214 @@
 import assert from "node:assert";
 import { bspKey, describeBspNet, type EnrichedBspApi, ferdie, sleep } from "../../../util";
 
-describeBspNet(
-  "BSPNet: Validating max storage",
-  { only: true },
-  ({ before, it, createUserApi, createBspApi }) => {
-    let userApi: EnrichedBspApi;
-    let bspApi: EnrichedBspApi;
+describeBspNet("BSPNet: Validating max storage", ({ before, it, createUserApi }) => {
+  let userApi: EnrichedBspApi;
 
-    before(async () => {
-      userApi = await createUserApi();
-      bspApi = await createBspApi();
+  before(async () => {
+    userApi = await createUserApi();
+  });
+
+  it("Unregistered accounts fail when changing capacities", async () => {
+    const totalCapacityBefore = await userApi.query.providers.totalBspsCapacity();
+    const bspCapacityBefore = await userApi.query.providers.backupStorageProviders(
+      userApi.shConsts.DUMMY_BSP_ID
+    );
+    assert.ok(bspCapacityBefore.unwrap().capacity.eq(totalCapacityBefore));
+
+    const { events, extSuccess } = await userApi.sealBlock(
+      userApi.tx.providers.changeCapacity(userApi.shConsts.CAPACITY[1024]),
+      ferdie
+    );
+    assert.strictEqual(extSuccess, false);
+
+    await userApi.block.skip(20);
+    const {
+      data: { dispatchError: eventInfo }
+    } = userApi.assert.fetchEvent(userApi.events.system.ExtrinsicFailed, events);
+
+    const providersPallet = userApi.runtimeMetadata.asLatest.pallets.find(
+      (pallet) => pallet.name.toString() === "Providers"
+    );
+    const notRegisteredErrorIndex = userApi.errors.providers.NotRegistered.meta.index.toNumber();
+    assert.strictEqual(eventInfo.asModule.index.toNumber(), providersPallet?.index.toNumber());
+    assert.strictEqual(eventInfo.asModule.error[0], notRegisteredErrorIndex);
+
+    const totalCapacityAfter = await userApi.query.providers.totalBspsCapacity();
+    const bspCapacityAfter = await userApi.query.providers.backupStorageProviders(
+      userApi.shConsts.DUMMY_BSP_ID
+    );
+    assert.ok(bspCapacityAfter.unwrap().capacity.eq(totalCapacityBefore));
+    assert.ok(totalCapacityAfter.eq(totalCapacityBefore));
+  });
+
+  it("Change capacity ext called before volunteering for file size greater than available capacity", async () => {
+    // 1 block to maxthreshold (i.e. instant acceptance)
+    await userApi.sealBlock(
+      userApi.tx.sudo.sudo(userApi.tx.fileSystem.setGlobalParameters(null, 1))
+    );
+
+    const capacityUsed = (
+      await userApi.query.providers.backupStorageProviders(userApi.shConsts.DUMMY_BSP_ID)
+    )
+      .unwrap()
+      .capacityUsed.toNumber();
+    await userApi.block.skipToMinChangeTime();
+    const minCapacity = userApi.consts.providers.spMinCapacity.toNumber();
+    const newCapacity = Math.max(minCapacity, capacityUsed + 1);
+
+    // Set BSP's available capacity to 0 to force the BSP to increase its capacity before volunteering for the storage request.
+    const { extSuccess } = await userApi.sealBlock(
+      userApi.tx.providers.changeCapacity(newCapacity),
+      bspKey
+    );
+    assert.strictEqual(extSuccess, true);
+
+    const source = "res/cloud.jpg";
+    const location = "test/cloud.jpg";
+    const bucketName = "toobig-1";
+    await userApi.file.createBucketAndSendNewStorageRequest(source, location, bucketName);
+
+    //To allow for BSP to react to request
+    await sleep(500);
+
+    // Skip block height until BSP sends a call to change capacity.
+    await userApi.block.skipToMinChangeTime();
+    // Allow BSP enough time to send call to change capacity.
+    await sleep(500);
+    // Assert BSP has sent a call to increase its capacity.
+    await userApi.assert.extrinsicPresent({
+      module: "providers",
+      method: "changeCapacity",
+      checkTxPool: true
     });
 
-    it("Unregistered accounts fail when changing capacities", async () => {
-      const totalCapacityBefore = await userApi.query.providers.totalBspsCapacity();
-      const bspCapacityBefore = await userApi.query.providers.backupStorageProviders(
-        userApi.shConsts.DUMMY_BSP_ID
-      );
-      assert.ok(bspCapacityBefore.unwrap().capacity.eq(totalCapacityBefore));
+    await userApi.sealBlock();
 
-      const { events, extSuccess } = await userApi.sealBlock(
-        userApi.tx.providers.changeCapacity(userApi.shConsts.CAPACITY[1024]),
-        ferdie
-      );
-      assert.strictEqual(extSuccess, false);
+    // Assert that the capacity has changed.
+    await userApi.assert.eventPresent("providers", "CapacityChanged");
 
-      await userApi.block.skip(20);
-      const {
-        data: { dispatchError: eventInfo }
-      } = userApi.assert.fetchEvent(userApi.events.system.ExtrinsicFailed, events);
+    // Allow BSP enough time to send call to volunteer for the storage request.
+    await sleep(500);
 
-      const providersPallet = userApi.runtimeMetadata.asLatest.pallets.find(
-        (pallet) => pallet.name.toString() === "Providers"
-      );
-      const notRegisteredErrorIndex = userApi.errors.providers.NotRegistered.meta.index.toNumber();
-      assert.strictEqual(eventInfo.asModule.index.toNumber(), providersPallet?.index.toNumber());
-      assert.strictEqual(eventInfo.asModule.error[0], notRegisteredErrorIndex);
-
-      const totalCapacityAfter = await userApi.query.providers.totalBspsCapacity();
-      const bspCapacityAfter = await userApi.query.providers.backupStorageProviders(
-        userApi.shConsts.DUMMY_BSP_ID
-      );
-      assert.ok(bspCapacityAfter.unwrap().capacity.eq(totalCapacityBefore));
-      assert.ok(totalCapacityAfter.eq(totalCapacityBefore));
+    // Assert that the BSP has send a call to volunteer for the storage request.
+    await userApi.assert.extrinsicPresent({
+      module: "fileSystem",
+      method: "bspVolunteer",
+      checkTxPool: true
     });
 
-    it("Change capacity ext called before volunteering for file size greater than available capacity", async () => {
-      // 1 block to maxthreshold (i.e. instant acceptance)
-      await userApi.sealBlock(
-        userApi.tx.sudo.sudo(userApi.tx.fileSystem.setGlobalParameters(null, 1))
-      );
+    await userApi.sealBlock();
 
-      const capacityUsed = (
-        await userApi.query.providers.backupStorageProviders(userApi.shConsts.DUMMY_BSP_ID)
-      )
-        .unwrap()
-        .capacityUsed.toNumber();
-      await userApi.block.skipToMinChangeTime();
-      const minCapacity = userApi.consts.providers.spMinCapacity.toNumber();
-      const newCapacity = Math.max(minCapacity, capacityUsed + 1);
+    const updatedCapacity = BigInt(userApi.shConsts.JUMP_CAPACITY_BSP + newCapacity);
+    const bspCapacityAfter = await userApi.query.providers.backupStorageProviders(
+      userApi.shConsts.DUMMY_BSP_ID
+    );
+    assert.strictEqual(bspCapacityAfter.unwrap().capacity.toBigInt(), updatedCapacity);
 
-      // Set BSP's available capacity to 0 to force the BSP to increase its capacity before volunteering for the storage request.
-      const { extSuccess } = await userApi.sealBlock(
-        userApi.tx.providers.changeCapacity(newCapacity),
-        bspKey
-      );
-      assert.strictEqual(extSuccess, true);
+    // Assert that the BSP was accepted as a volunteer.
+    await userApi.assert.eventPresent("fileSystem", "AcceptedBspVolunteer");
+  });
 
-      const source = "res/cloud.jpg";
-      const location = "test/cloud.jpg";
-      const bucketName = "toobig-1";
-      await userApi.file.createBucketAndSendNewStorageRequest(source, location, bucketName);
+  it("Total capacity updated when single BSP capacity updated", async () => {
+    const newCapacity =
+      BigInt(Math.floor(Math.random() * 1000 * 1024 * 1024)) + userApi.shConsts.CAPACITY_512;
 
-      //To allow for BSP to react to request
-      await sleep(500);
+    // Skip block height past threshold
+    await userApi.block.skipToMinChangeTime();
 
-      // Skip block height until BSP sends a call to change capacity.
-      await userApi.block.skipToMinChangeTime();
-      // Allow BSP enough time to send call to change capacity.
-      await sleep(500);
-      // Assert BSP has sent a call to increase its capacity.
-      await userApi.assert.extrinsicPresent({
-        module: "providers",
-        method: "changeCapacity",
-        checkTxPool: true
-      });
+    await userApi.sealBlock(userApi.tx.providers.changeCapacity(newCapacity), bspKey);
 
-      await userApi.sealBlock();
+    const totalCapacityAfter = await userApi.query.providers.totalBspsCapacity();
+    const bspCapacityAfter = await userApi.query.providers.backupStorageProviders(
+      userApi.shConsts.DUMMY_BSP_ID
+    );
+    assert.strictEqual(bspCapacityAfter.unwrap().capacity.toBigInt(), newCapacity);
+    assert.strictEqual(totalCapacityAfter.toBigInt(), newCapacity);
+  });
 
-      // Assert that the capacity has changed.
-      await userApi.assert.eventPresent("providers", "CapacityChanged");
+  it("Test BSP storage size can not be decreased below used", async () => {
+    const source = "res/adolphus.jpg";
+    const location = "test/adolphus.jpg";
+    const bucketName = "nothingmuch-2";
+    await userApi.file.createBucketAndSendNewStorageRequest(source, location, bucketName);
 
-      // Allow BSP enough time to send call to volunteer for the storage request.
-      await sleep(500);
+    await userApi.wait.bspVolunteer();
+    await userApi.wait.bspStored();
 
-      // Assert that the BSP has send a call to volunteer for the storage request.
-      await userApi.assert.extrinsicPresent({
-        module: "fileSystem",
-        method: "bspVolunteer",
-        checkTxPool: true
-      });
+    // Skip block height past threshold
+    await userApi.block.skipToMinChangeTime();
 
-      await userApi.sealBlock();
+    const { events, extSuccess } = await userApi.sealBlock(
+      userApi.tx.providers.changeCapacity(2n),
+      bspKey
+    );
+    assert.strictEqual(extSuccess, false);
+    const {
+      data: { dispatchError: eventInfo }
+    } = userApi.assert.fetchEvent(userApi.events.system.ExtrinsicFailed, events);
 
-      const updatedCapacity = BigInt(userApi.shConsts.JUMP_CAPACITY_BSP + newCapacity);
-      const bspCapacityAfter = await userApi.query.providers.backupStorageProviders(
-        userApi.shConsts.DUMMY_BSP_ID
-      );
-      assert.strictEqual(bspCapacityAfter.unwrap().capacity.toBigInt(), updatedCapacity);
+    const providersPallet = userApi.runtimeMetadata.asLatest.pallets.find(
+      (pallet) => pallet.name.toString() === "Providers"
+    );
+    const newCapacityLessThanUsedStorageErrorIndex =
+      userApi.errors.providers.NewCapacityLessThanUsedStorage.meta.index.toNumber();
+    assert.strictEqual(eventInfo.asModule.index.toNumber(), providersPallet?.index.toNumber());
+    assert.strictEqual(eventInfo.asModule.error[0], newCapacityLessThanUsedStorageErrorIndex);
+  });
 
-      // Assert that the BSP was accepted as a volunteer.
-      await userApi.assert.eventPresent("fileSystem", "AcceptedBspVolunteer");
+  it("Test BSP storage size increased twice in the same increasing period (check for race condition)", async () => {
+    const capacityUsed = (
+      await userApi.query.providers.backupStorageProviders(userApi.shConsts.DUMMY_BSP_ID)
+    )
+      .unwrap()
+      .capacityUsed.toNumber();
+    await userApi.block.skipToMinChangeTime();
+    const minCapacity = userApi.consts.providers.spMinCapacity.toNumber();
+    const newCapacity = Math.max(minCapacity, capacityUsed + 1);
+
+    // Set BSP's available capacity to 0 to force the BSP to increase its capacity before volunteering for the storage request.
+    const { extSuccess } = await userApi.sealBlock(
+      userApi.tx.providers.changeCapacity(newCapacity),
+      bspKey
+    );
+    assert.strictEqual(extSuccess, true);
+
+    // First storage request
+    const source1 = "res/cloud.jpg";
+    const location1 = "test/cloud.jpg";
+    const bucketName1 = "bucket-1";
+    await userApi.file.createBucketAndSendNewStorageRequest(source1, location1, bucketName1);
+
+    // Second storage request
+    const source2 = "res/adolphus.jpg";
+    const location2 = "test/adolphus.jpg";
+    const bucketName2 = "bucket-2";
+    await userApi.file.createBucketAndSendNewStorageRequest(source2, location2, bucketName2);
+
+    //To allow for BSP to react to request
+    await sleep(500);
+
+    await userApi.block.skipToMinChangeTime();
+
+    // Allow BSP enough time to send call to change capacity.
+    await sleep(500);
+
+    // Assert BSP has sent a call to increase its capacity.
+    await userApi.assert.extrinsicPresent({
+      module: "providers",
+      method: "changeCapacity",
+      checkTxPool: true
     });
 
-    it("Total capacity updated when single BSP capacity updated", async () => {
-      const newCapacity =
-        BigInt(Math.floor(Math.random() * 1000 * 1024 * 1024)) + userApi.shConsts.CAPACITY_512;
+    await userApi.sealBlock();
 
-      // Skip block height past threshold
-      await userApi.block.skipToMinChangeTime();
+    // Assert that the capacity has changed.
+    await userApi.assert.eventPresent("providers", "CapacityChanged");
 
-      await userApi.sealBlock(userApi.tx.providers.changeCapacity(newCapacity), bspKey);
-
-      const totalCapacityAfter = await userApi.query.providers.totalBspsCapacity();
-      const bspCapacityAfter = await userApi.query.providers.backupStorageProviders(
-        userApi.shConsts.DUMMY_BSP_ID
-      );
-      assert.strictEqual(bspCapacityAfter.unwrap().capacity.toBigInt(), newCapacity);
-      assert.strictEqual(totalCapacityAfter.toBigInt(), newCapacity);
-    });
-
-    it("Test BSP storage size can not be decreased below used", async () => {
-      const source = "res/adolphus.jpg";
-      const location = "test/adolphus.jpg";
-      const bucketName = "nothingmuch-2";
-      await userApi.file.createBucketAndSendNewStorageRequest(source, location, bucketName);
-
-      await userApi.wait.bspVolunteer();
-      await userApi.wait.bspStored();
-
-      // Skip block height past threshold
-      await userApi.block.skipToMinChangeTime();
-
-      const { events, extSuccess } = await userApi.sealBlock(
-        userApi.tx.providers.changeCapacity(2n),
-        bspKey
-      );
-      assert.strictEqual(extSuccess, false);
-      const {
-        data: { dispatchError: eventInfo }
-      } = userApi.assert.fetchEvent(userApi.events.system.ExtrinsicFailed, events);
-
-      const providersPallet = userApi.runtimeMetadata.asLatest.pallets.find(
-        (pallet) => pallet.name.toString() === "Providers"
-      );
-      const newCapacityLessThanUsedStorageErrorIndex =
-        userApi.errors.providers.NewCapacityLessThanUsedStorage.meta.index.toNumber();
-      assert.strictEqual(eventInfo.asModule.index.toNumber(), providersPallet?.index.toNumber());
-      assert.strictEqual(eventInfo.asModule.error[0], newCapacityLessThanUsedStorageErrorIndex);
-    });
-
-    it("Test BSP storage size increased twice in the same increasing period (check for race condition)", async () => {
-      const capacityUsed = (
-        await userApi.query.providers.backupStorageProviders(userApi.shConsts.DUMMY_BSP_ID)
-      )
-        .unwrap()
-        .capacityUsed.toNumber();
-      await userApi.block.skipToMinChangeTime();
-      const minCapacity = userApi.consts.providers.spMinCapacity.toNumber();
-      const newCapacity = Math.max(minCapacity, capacityUsed + 1);
-
-      // Set BSP's available capacity to 0 to force the BSP to increase its capacity before volunteering for the storage request.
-      const { extSuccess } = await userApi.sealBlock(
-        userApi.tx.providers.changeCapacity(newCapacity),
-        bspKey
-      );
-      assert.strictEqual(extSuccess, true);
-
-      // First storage request
-      const source1 = "res/cloud.jpg";
-      const location1 = "test/cloud.jpg";
-      const bucketName1 = "bucket-1";
-      await userApi.file.createBucketAndSendNewStorageRequest(source1, location1, bucketName1);
-
-      // Second storage request
-      const source2 = "res/adolphus.jpg";
-      const location2 = "test/adolphus.jpg";
-      const bucketName2 = "bucket-2";
-      await userApi.file.createBucketAndSendNewStorageRequest(source2, location2, bucketName2);
-
-      //To allow for BSP to react to request
-      await sleep(500);
-
-      await userApi.block.skipToMinChangeTime();
-
-      // Allow BSP enough time to send call to change capacity.
-      await sleep(500);
-
-      // Assert BSP has sent a call to increase its capacity.
-      await userApi.assert.extrinsicPresent({
-        module: "providers",
-        method: "changeCapacity",
-        checkTxPool: true
-      });
-
-      await userApi.sealBlock();
-
-      // Assert that the capacity has changed.
-      await userApi.assert.eventPresent("providers", "CapacityChanged");
-
-      const updatedCapacity = BigInt(userApi.shConsts.JUMP_CAPACITY_BSP + newCapacity);
-      const bspCapacityAfter = await userApi.query.providers.backupStorageProviders(
-        userApi.shConsts.DUMMY_BSP_ID
-      );
-      assert.strictEqual(bspCapacityAfter.unwrap().capacity.toBigInt(), updatedCapacity);
-    });
-  }
-);
+    const updatedCapacity = BigInt(userApi.shConsts.JUMP_CAPACITY_BSP + newCapacity);
+    const bspCapacityAfter = await userApi.query.providers.backupStorageProviders(
+      userApi.shConsts.DUMMY_BSP_ID
+    );
+    assert.strictEqual(bspCapacityAfter.unwrap().capacity.toBigInt(), updatedCapacity);
+  });
+});

--- a/test/suites/integration/bsp/storage-capacity.test.ts
+++ b/test/suites/integration/bsp/storage-capacity.test.ts
@@ -1,216 +1,220 @@
 import assert from "node:assert";
 import { bspKey, describeBspNet, type EnrichedBspApi, ferdie, sleep } from "../../../util";
 
-describeBspNet("BSPNet: Validating max storage", ({ before, it, createUserApi, createBspApi }) => {
-  let userApi: EnrichedBspApi;
-  let bspApi: EnrichedBspApi;
+describeBspNet(
+  "BSPNet: Validating max storage",
+  { only: true },
+  ({ before, it, createUserApi, createBspApi }) => {
+    let userApi: EnrichedBspApi;
+    let bspApi: EnrichedBspApi;
 
-  before(async () => {
-    userApi = await createUserApi();
-    bspApi = await createBspApi();
-  });
-
-  it("Unregistered accounts fail when changing capacities", async () => {
-    const totalCapacityBefore = await userApi.query.providers.totalBspsCapacity();
-    const bspCapacityBefore = await userApi.query.providers.backupStorageProviders(
-      bspApi.shConsts.DUMMY_BSP_ID
-    );
-    assert.ok(bspCapacityBefore.unwrap().capacity.eq(totalCapacityBefore));
-
-    const { events, extSuccess } = await userApi.sealBlock(
-      userApi.tx.providers.changeCapacity(bspApi.shConsts.CAPACITY[1024]),
-      ferdie
-    );
-    assert.strictEqual(extSuccess, false);
-
-    await userApi.block.skip(20);
-    const {
-      data: { dispatchError: eventInfo }
-    } = userApi.assert.fetchEvent(userApi.events.system.ExtrinsicFailed, events);
-
-    const providersPallet = userApi.runtimeMetadata.asLatest.pallets.find(
-      (pallet) => pallet.name.toString() === "Providers"
-    );
-    const notRegisteredErrorIndex = userApi.errors.providers.NotRegistered.meta.index.toNumber();
-    assert.strictEqual(eventInfo.asModule.index.toNumber(), providersPallet?.index.toNumber());
-    assert.strictEqual(eventInfo.asModule.error[0], notRegisteredErrorIndex);
-
-    const totalCapacityAfter = await userApi.query.providers.totalBspsCapacity();
-    const bspCapacityAfter = await userApi.query.providers.backupStorageProviders(
-      bspApi.shConsts.DUMMY_BSP_ID
-    );
-    assert.ok(bspCapacityAfter.unwrap().capacity.eq(totalCapacityBefore));
-    assert.ok(totalCapacityAfter.eq(totalCapacityBefore));
-  });
-
-  it("Change capacity ext called before volunteering for file size greater than available capacity", async () => {
-    // 1 block to maxthreshold (i.e. instant acceptance)
-    await userApi.sealBlock(
-      userApi.tx.sudo.sudo(userApi.tx.fileSystem.setGlobalParameters(null, 1))
-    );
-
-    const capacityUsed = (
-      await userApi.query.providers.backupStorageProviders(bspApi.shConsts.DUMMY_BSP_ID)
-    )
-      .unwrap()
-      .capacityUsed.toNumber();
-    await userApi.block.skipToMinChangeTime();
-    const minCapacity = userApi.consts.providers.spMinCapacity.toNumber();
-    const newCapacity = Math.max(minCapacity, capacityUsed + 1);
-
-    // Set BSP's available capacity to 0 to force the BSP to increase its capacity before volunteering for the storage request.
-    const { extSuccess } = await userApi.sealBlock(
-      userApi.tx.providers.changeCapacity(newCapacity),
-      bspKey
-    );
-    assert.strictEqual(extSuccess, true);
-
-    const source = "res/cloud.jpg";
-    const location = "test/cloud.jpg";
-    const bucketName = "toobig-1";
-    await userApi.file.createBucketAndSendNewStorageRequest(source, location, bucketName);
-
-    //To allow for BSP to react to request
-    await sleep(500);
-
-    // Skip block height until BSP sends a call to change capacity.
-    await userApi.block.skipToMinChangeTime();
-    // Allow BSP enough time to send call to change capacity.
-    await sleep(500);
-    // Assert BSP has sent a call to increase its capacity.
-    await userApi.assert.extrinsicPresent({
-      module: "providers",
-      method: "changeCapacity",
-      checkTxPool: true
+    before(async () => {
+      userApi = await createUserApi();
+      bspApi = await createBspApi();
     });
 
-    await userApi.sealBlock();
+    it("Unregistered accounts fail when changing capacities", async () => {
+      const totalCapacityBefore = await userApi.query.providers.totalBspsCapacity();
+      const bspCapacityBefore = await userApi.query.providers.backupStorageProviders(
+        userApi.shConsts.DUMMY_BSP_ID
+      );
+      assert.ok(bspCapacityBefore.unwrap().capacity.eq(totalCapacityBefore));
 
-    // Assert that the capacity has changed.
-    await userApi.assert.eventPresent("providers", "CapacityChanged");
+      const { events, extSuccess } = await userApi.sealBlock(
+        userApi.tx.providers.changeCapacity(userApi.shConsts.CAPACITY[1024]),
+        ferdie
+      );
+      assert.strictEqual(extSuccess, false);
 
-    // Allow BSP enough time to send call to volunteer for the storage request.
-    await sleep(500);
+      await userApi.block.skip(20);
+      const {
+        data: { dispatchError: eventInfo }
+      } = userApi.assert.fetchEvent(userApi.events.system.ExtrinsicFailed, events);
 
-    // Assert that the BSP has send a call to volunteer for the storage request.
-    await userApi.assert.extrinsicPresent({
-      module: "fileSystem",
-      method: "bspVolunteer",
-      checkTxPool: true
+      const providersPallet = userApi.runtimeMetadata.asLatest.pallets.find(
+        (pallet) => pallet.name.toString() === "Providers"
+      );
+      const notRegisteredErrorIndex = userApi.errors.providers.NotRegistered.meta.index.toNumber();
+      assert.strictEqual(eventInfo.asModule.index.toNumber(), providersPallet?.index.toNumber());
+      assert.strictEqual(eventInfo.asModule.error[0], notRegisteredErrorIndex);
+
+      const totalCapacityAfter = await userApi.query.providers.totalBspsCapacity();
+      const bspCapacityAfter = await userApi.query.providers.backupStorageProviders(
+        userApi.shConsts.DUMMY_BSP_ID
+      );
+      assert.ok(bspCapacityAfter.unwrap().capacity.eq(totalCapacityBefore));
+      assert.ok(totalCapacityAfter.eq(totalCapacityBefore));
     });
 
-    await userApi.sealBlock();
+    it("Change capacity ext called before volunteering for file size greater than available capacity", async () => {
+      // 1 block to maxthreshold (i.e. instant acceptance)
+      await userApi.sealBlock(
+        userApi.tx.sudo.sudo(userApi.tx.fileSystem.setGlobalParameters(null, 1))
+      );
 
-    const updatedCapacity = BigInt(bspApi.shConsts.JUMP_CAPACITY_BSP + newCapacity);
-    const bspCapacityAfter = await userApi.query.providers.backupStorageProviders(
-      bspApi.shConsts.DUMMY_BSP_ID
-    );
-    assert.strictEqual(bspCapacityAfter.unwrap().capacity.toBigInt(), updatedCapacity);
+      const capacityUsed = (
+        await userApi.query.providers.backupStorageProviders(userApi.shConsts.DUMMY_BSP_ID)
+      )
+        .unwrap()
+        .capacityUsed.toNumber();
+      await userApi.block.skipToMinChangeTime();
+      const minCapacity = userApi.consts.providers.spMinCapacity.toNumber();
+      const newCapacity = Math.max(minCapacity, capacityUsed + 1);
 
-    // Assert that the BSP was accepted as a volunteer.
-    await userApi.assert.eventPresent("fileSystem", "AcceptedBspVolunteer");
-  });
+      // Set BSP's available capacity to 0 to force the BSP to increase its capacity before volunteering for the storage request.
+      const { extSuccess } = await userApi.sealBlock(
+        userApi.tx.providers.changeCapacity(newCapacity),
+        bspKey
+      );
+      assert.strictEqual(extSuccess, true);
 
-  it("Total capacity updated when single BSP capacity updated", async () => {
-    const newCapacity =
-      BigInt(Math.floor(Math.random() * 1000 * 1024 * 1024)) + bspApi.shConsts.CAPACITY_512;
+      const source = "res/cloud.jpg";
+      const location = "test/cloud.jpg";
+      const bucketName = "toobig-1";
+      await userApi.file.createBucketAndSendNewStorageRequest(source, location, bucketName);
 
-    // Skip block height past threshold
-    await userApi.block.skipToMinChangeTime();
+      //To allow for BSP to react to request
+      await sleep(500);
 
-    await userApi.sealBlock(userApi.tx.providers.changeCapacity(newCapacity), bspKey);
+      // Skip block height until BSP sends a call to change capacity.
+      await userApi.block.skipToMinChangeTime();
+      // Allow BSP enough time to send call to change capacity.
+      await sleep(500);
+      // Assert BSP has sent a call to increase its capacity.
+      await userApi.assert.extrinsicPresent({
+        module: "providers",
+        method: "changeCapacity",
+        checkTxPool: true
+      });
 
-    const totalCapacityAfter = await userApi.query.providers.totalBspsCapacity();
-    const bspCapacityAfter = await userApi.query.providers.backupStorageProviders(
-      bspApi.shConsts.DUMMY_BSP_ID
-    );
-    assert.strictEqual(bspCapacityAfter.unwrap().capacity.toBigInt(), newCapacity);
-    assert.strictEqual(totalCapacityAfter.toBigInt(), newCapacity);
-  });
+      await userApi.sealBlock();
 
-  it("Test BSP storage size can not be decreased below used", async () => {
-    const source = "res/adolphus.jpg";
-    const location = "test/adolphus.jpg";
-    const bucketName = "nothingmuch-2";
-    await userApi.file.createBucketAndSendNewStorageRequest(source, location, bucketName);
+      // Assert that the capacity has changed.
+      await userApi.assert.eventPresent("providers", "CapacityChanged");
 
-    await userApi.wait.bspVolunteer();
-    await userApi.wait.bspStored();
+      // Allow BSP enough time to send call to volunteer for the storage request.
+      await sleep(500);
 
-    // Skip block height past threshold
-    await userApi.block.skipToMinChangeTime();
+      // Assert that the BSP has send a call to volunteer for the storage request.
+      await userApi.assert.extrinsicPresent({
+        module: "fileSystem",
+        method: "bspVolunteer",
+        checkTxPool: true
+      });
 
-    const { events, extSuccess } = await userApi.sealBlock(
-      userApi.tx.providers.changeCapacity(2n),
-      bspKey
-    );
-    assert.strictEqual(extSuccess, false);
-    const {
-      data: { dispatchError: eventInfo }
-    } = userApi.assert.fetchEvent(userApi.events.system.ExtrinsicFailed, events);
+      await userApi.sealBlock();
 
-    const providersPallet = userApi.runtimeMetadata.asLatest.pallets.find(
-      (pallet) => pallet.name.toString() === "Providers"
-    );
-    const newCapacityLessThanUsedStorageErrorIndex =
-      userApi.errors.providers.NewCapacityLessThanUsedStorage.meta.index.toNumber();
-    assert.strictEqual(eventInfo.asModule.index.toNumber(), providersPallet?.index.toNumber());
-    assert.strictEqual(eventInfo.asModule.error[0], newCapacityLessThanUsedStorageErrorIndex);
-  });
+      const updatedCapacity = BigInt(userApi.shConsts.JUMP_CAPACITY_BSP + newCapacity);
+      const bspCapacityAfter = await userApi.query.providers.backupStorageProviders(
+        userApi.shConsts.DUMMY_BSP_ID
+      );
+      assert.strictEqual(bspCapacityAfter.unwrap().capacity.toBigInt(), updatedCapacity);
 
-  it("Test BSP storage size increased twice in the same increasing period (check for race condition)", async () => {
-    const capacityUsed = (
-      await userApi.query.providers.backupStorageProviders(bspApi.shConsts.DUMMY_BSP_ID)
-    )
-      .unwrap()
-      .capacityUsed.toNumber();
-    await userApi.block.skipToMinChangeTime();
-    const minCapacity = userApi.consts.providers.spMinCapacity.toNumber();
-    const newCapacity = Math.max(minCapacity, capacityUsed + 1);
-
-    // Set BSP's available capacity to 0 to force the BSP to increase its capacity before volunteering for the storage request.
-    const { extSuccess } = await userApi.sealBlock(
-      userApi.tx.providers.changeCapacity(newCapacity),
-      bspKey
-    );
-    assert.strictEqual(extSuccess, true);
-
-    // First storage request
-    const source1 = "res/cloud.jpg";
-    const location1 = "test/cloud.jpg";
-    const bucketName1 = "bucket-1";
-    await userApi.file.createBucketAndSendNewStorageRequest(source1, location1, bucketName1);
-
-    // Second storage request
-    const source2 = "res/adolphus.jpg";
-    const location2 = "test/adolphus.jpg";
-    const bucketName2 = "bucket-2";
-    await userApi.file.createBucketAndSendNewStorageRequest(source2, location2, bucketName2);
-
-    //To allow for BSP to react to request
-    await sleep(500);
-
-    await userApi.block.skipToMinChangeTime();
-
-    // Allow BSP enough time to send call to change capacity.
-    await sleep(500);
-
-    // Assert BSP has sent a call to increase its capacity.
-    await bspApi.assert.extrinsicPresent({
-      module: "providers",
-      method: "changeCapacity",
-      checkTxPool: true
+      // Assert that the BSP was accepted as a volunteer.
+      await userApi.assert.eventPresent("fileSystem", "AcceptedBspVolunteer");
     });
 
-    await userApi.sealBlock();
+    it("Total capacity updated when single BSP capacity updated", async () => {
+      const newCapacity =
+        BigInt(Math.floor(Math.random() * 1000 * 1024 * 1024)) + userApi.shConsts.CAPACITY_512;
 
-    // Assert that the capacity has changed.
-    await userApi.assert.eventPresent("providers", "CapacityChanged");
+      // Skip block height past threshold
+      await userApi.block.skipToMinChangeTime();
 
-    const updatedCapacity = BigInt(userApi.shConsts.JUMP_CAPACITY_BSP + newCapacity);
-    const bspCapacityAfter = await userApi.query.providers.backupStorageProviders(
-      bspApi.shConsts.DUMMY_BSP_ID
-    );
-    assert.strictEqual(bspCapacityAfter.unwrap().capacity.toBigInt(), updatedCapacity);
-  });
-});
+      await userApi.sealBlock(userApi.tx.providers.changeCapacity(newCapacity), bspKey);
+
+      const totalCapacityAfter = await userApi.query.providers.totalBspsCapacity();
+      const bspCapacityAfter = await userApi.query.providers.backupStorageProviders(
+        userApi.shConsts.DUMMY_BSP_ID
+      );
+      assert.strictEqual(bspCapacityAfter.unwrap().capacity.toBigInt(), newCapacity);
+      assert.strictEqual(totalCapacityAfter.toBigInt(), newCapacity);
+    });
+
+    it("Test BSP storage size can not be decreased below used", async () => {
+      const source = "res/adolphus.jpg";
+      const location = "test/adolphus.jpg";
+      const bucketName = "nothingmuch-2";
+      await userApi.file.createBucketAndSendNewStorageRequest(source, location, bucketName);
+
+      await userApi.wait.bspVolunteer();
+      await userApi.wait.bspStored();
+
+      // Skip block height past threshold
+      await userApi.block.skipToMinChangeTime();
+
+      const { events, extSuccess } = await userApi.sealBlock(
+        userApi.tx.providers.changeCapacity(2n),
+        bspKey
+      );
+      assert.strictEqual(extSuccess, false);
+      const {
+        data: { dispatchError: eventInfo }
+      } = userApi.assert.fetchEvent(userApi.events.system.ExtrinsicFailed, events);
+
+      const providersPallet = userApi.runtimeMetadata.asLatest.pallets.find(
+        (pallet) => pallet.name.toString() === "Providers"
+      );
+      const newCapacityLessThanUsedStorageErrorIndex =
+        userApi.errors.providers.NewCapacityLessThanUsedStorage.meta.index.toNumber();
+      assert.strictEqual(eventInfo.asModule.index.toNumber(), providersPallet?.index.toNumber());
+      assert.strictEqual(eventInfo.asModule.error[0], newCapacityLessThanUsedStorageErrorIndex);
+    });
+
+    it("Test BSP storage size increased twice in the same increasing period (check for race condition)", async () => {
+      const capacityUsed = (
+        await userApi.query.providers.backupStorageProviders(userApi.shConsts.DUMMY_BSP_ID)
+      )
+        .unwrap()
+        .capacityUsed.toNumber();
+      await userApi.block.skipToMinChangeTime();
+      const minCapacity = userApi.consts.providers.spMinCapacity.toNumber();
+      const newCapacity = Math.max(minCapacity, capacityUsed + 1);
+
+      // Set BSP's available capacity to 0 to force the BSP to increase its capacity before volunteering for the storage request.
+      const { extSuccess } = await userApi.sealBlock(
+        userApi.tx.providers.changeCapacity(newCapacity),
+        bspKey
+      );
+      assert.strictEqual(extSuccess, true);
+
+      // First storage request
+      const source1 = "res/cloud.jpg";
+      const location1 = "test/cloud.jpg";
+      const bucketName1 = "bucket-1";
+      await userApi.file.createBucketAndSendNewStorageRequest(source1, location1, bucketName1);
+
+      // Second storage request
+      const source2 = "res/adolphus.jpg";
+      const location2 = "test/adolphus.jpg";
+      const bucketName2 = "bucket-2";
+      await userApi.file.createBucketAndSendNewStorageRequest(source2, location2, bucketName2);
+
+      //To allow for BSP to react to request
+      await sleep(500);
+
+      await userApi.block.skipToMinChangeTime();
+
+      // Allow BSP enough time to send call to change capacity.
+      await sleep(500);
+
+      // Assert BSP has sent a call to increase its capacity.
+      await userApi.assert.extrinsicPresent({
+        module: "providers",
+        method: "changeCapacity",
+        checkTxPool: true
+      });
+
+      await userApi.sealBlock();
+
+      // Assert that the capacity has changed.
+      await userApi.assert.eventPresent("providers", "CapacityChanged");
+
+      const updatedCapacity = BigInt(userApi.shConsts.JUMP_CAPACITY_BSP + newCapacity);
+      const bspCapacityAfter = await userApi.query.providers.backupStorageProviders(
+        userApi.shConsts.DUMMY_BSP_ID
+      );
+      assert.strictEqual(bspCapacityAfter.unwrap().capacity.toBigInt(), updatedCapacity);
+    });
+  }
+);

--- a/test/suites/integration/bsp/storage-capacity.test.ts
+++ b/test/suites/integration/bsp/storage-capacity.test.ts
@@ -57,6 +57,7 @@ describeBspNet("BSPNet: Validating max storage", ({ before, it, createUserApi })
     const newCapacity = Math.max(minCapacity, capacityUsed + 1);
 
     // Set BSP's available capacity to 0 to force the BSP to increase its capacity before volunteering for the storage request.
+    await userApi.wait.waitForAvailabilityToSendTx(bspKey.address.toString());
     const { extSuccess } = await userApi.sealBlock(
       userApi.tx.providers.changeCapacity(newCapacity),
       bspKey
@@ -116,6 +117,7 @@ describeBspNet("BSPNet: Validating max storage", ({ before, it, createUserApi })
     // Skip block height past threshold
     await userApi.block.skipToMinChangeTime();
 
+    await userApi.wait.waitForAvailabilityToSendTx(bspKey.address.toString());
     await userApi.sealBlock(userApi.tx.providers.changeCapacity(newCapacity), bspKey);
 
     const totalCapacityAfter = await userApi.query.providers.totalBspsCapacity();
@@ -138,6 +140,7 @@ describeBspNet("BSPNet: Validating max storage", ({ before, it, createUserApi })
     // Skip block height past threshold
     await userApi.block.skipToMinChangeTime();
 
+    await userApi.wait.waitForAvailabilityToSendTx(bspKey.address.toString());
     const { events, extSuccess } = await userApi.sealBlock(
       userApi.tx.providers.changeCapacity(2n),
       bspKey
@@ -167,6 +170,7 @@ describeBspNet("BSPNet: Validating max storage", ({ before, it, createUserApi })
     const newCapacity = Math.max(minCapacity, capacityUsed + 1);
 
     // Set BSP's available capacity to 0 to force the BSP to increase its capacity before volunteering for the storage request.
+    await userApi.wait.waitForAvailabilityToSendTx(bspKey.address.toString());
     const { extSuccess } = await userApi.sealBlock(
       userApi.tx.providers.changeCapacity(newCapacity),
       bspKey

--- a/test/suites/integration/bsp/submit-proofs.test.ts
+++ b/test/suites/integration/bsp/submit-proofs.test.ts
@@ -12,7 +12,7 @@ import { BSP_THREE_ID, BSP_TWO_ID, DUMMY_BSP_ID, NODE_INFOS } from "../../../uti
 
 describeBspNet(
   "BSP: Many BSPs Submit Proofs",
-  { initialised: "multi", networkConfig: "standard", only: true },
+  { initialised: "multi", networkConfig: "standard" },
   ({ before, createUserApi, after, it, createApi, createBspApi, getLaunchResponse }) => {
     let userApi: EnrichedBspApi;
     let bspApi: EnrichedBspApi;

--- a/test/suites/integration/bsp/submit-proofs.test.ts
+++ b/test/suites/integration/bsp/submit-proofs.test.ts
@@ -334,7 +334,11 @@ describeBspNet(
       });
 
       // Wait for BSPs to resync.
-      await sleep(1000);
+      await userApi.wait.bspCatchUpToChainTip(bspTwoApi);
+      await userApi.wait.bspCatchUpToChainTip(bspThreeApi);
+
+      // And give some time to process proofs.
+      await sleep(3000);
 
       // There shouldn't be any pending volunteer transactions.
       await assert.rejects(
@@ -376,11 +380,10 @@ describeBspNet(
 
       if (nextChallengeTick > currentBlockNumber) {
         // Advance to the next challenge tick if needed
-        await userApi.block.skipTo(nextChallengeTick);
+        await userApi.block.skipTo(nextChallengeTick, {
+          watchForBspProofs: [ShConsts.DUMMY_BSP_ID, ShConsts.BSP_TWO_ID, ShConsts.BSP_THREE_ID]
+        });
       }
-
-      // Wait for tasks to execute and for the BSPs to submit proofs.
-      await sleep(500);
 
       // There should be at least one pending submit proof transaction.
       const submitProofsPending = await userApi.assert.extrinsicPresent({

--- a/test/suites/integration/bsp/submit-proofs.test.ts
+++ b/test/suites/integration/bsp/submit-proofs.test.ts
@@ -12,7 +12,7 @@ import { BSP_THREE_ID, BSP_TWO_ID, DUMMY_BSP_ID, NODE_INFOS } from "../../../uti
 
 describeBspNet(
   "BSP: Many BSPs Submit Proofs",
-  { initialised: "multi", networkConfig: "standard" },
+  { initialised: "multi", networkConfig: "standard", only: true },
   ({ before, createUserApi, after, it, createApi, createBspApi, getLaunchResponse }) => {
     let userApi: EnrichedBspApi;
     let bspApi: EnrichedBspApi;

--- a/test/suites/integration/bsp/submit-proofs.test.ts
+++ b/test/suites/integration/bsp/submit-proofs.test.ts
@@ -12,7 +12,7 @@ import { BSP_THREE_ID, BSP_TWO_ID, DUMMY_BSP_ID, NODE_INFOS } from "../../../uti
 
 describeBspNet(
   "BSP: Many BSPs Submit Proofs",
-  { initialised: "multi", networkConfig: "standard" },
+  { initialised: "multi", networkConfig: "standard", only: true },
   ({ before, createUserApi, after, it, createApi, createBspApi, getLaunchResponse }) => {
     let userApi: EnrichedBspApi;
     let bspApi: EnrichedBspApi;
@@ -322,7 +322,7 @@ describeBspNet(
       const currentBlock = await userApi.rpc.chain.getBlock();
       const currentBlockNumber = currentBlock.block.header.number.toNumber();
       await userApi.block.skipTo(currentBlockNumber + storageRequestTtl, {
-        waitForBspProofs: [ShConsts.DUMMY_BSP_ID]
+        watchForBspProofs: [ShConsts.DUMMY_BSP_ID]
       });
 
       // Resume BSP-Two and BSP-Three.
@@ -464,7 +464,7 @@ describeBspNet(
       const currentBlock = await userApi.rpc.chain.getBlock();
       const currentBlockNumber = currentBlock.block.header.number.toNumber();
       await userApi.block.skipTo(currentBlockNumber + deletionRequestTtl, {
-        waitForBspProofs: [ShConsts.DUMMY_BSP_ID, ShConsts.BSP_TWO_ID, ShConsts.BSP_THREE_ID]
+        watchForBspProofs: [ShConsts.DUMMY_BSP_ID, ShConsts.BSP_TWO_ID, ShConsts.BSP_THREE_ID]
       });
 
       // Check for a file deletion request event.
@@ -481,7 +481,7 @@ describeBspNet(
       );
       const nextCheckpointChallengeBlock = lastCheckpointChallengeTick + checkpointChallengePeriod;
       await userApi.block.skipTo(nextCheckpointChallengeBlock, {
-        waitForBspProofs: [ShConsts.DUMMY_BSP_ID, ShConsts.BSP_TWO_ID, ShConsts.BSP_THREE_ID]
+        watchForBspProofs: [ShConsts.DUMMY_BSP_ID, ShConsts.BSP_TWO_ID, ShConsts.BSP_THREE_ID]
       });
 
       // Check that the event for the priority challenge is emitted.
@@ -561,7 +561,7 @@ describeBspNet(
       if (firstBlockToAdvance !== currentBlockNumber) {
         // Advance to first next challenge block.
         await userApi.block.skipTo(firstBlockToAdvance, {
-          waitForBspProofs: [DUMMY_BSP_ID, BSP_TWO_ID, BSP_THREE_ID]
+          watchForBspProofs: [DUMMY_BSP_ID, BSP_TWO_ID, BSP_THREE_ID]
         });
       }
 
@@ -617,7 +617,7 @@ describeBspNet(
         if (secondBlockToAdvance !== currentBlockNumber) {
           // Advance to second next challenge block.
           await userApi.block.skipTo(secondBlockToAdvance, {
-            waitForBspProofs: [ShConsts.DUMMY_BSP_ID, ShConsts.BSP_TWO_ID, ShConsts.BSP_THREE_ID]
+            watchForBspProofs: [ShConsts.DUMMY_BSP_ID, ShConsts.BSP_TWO_ID, ShConsts.BSP_THREE_ID]
           });
         }
 

--- a/test/suites/integration/msp/debt-collection.test.ts
+++ b/test/suites/integration/msp/debt-collection.test.ts
@@ -109,7 +109,7 @@ describeMspNet("Single MSP collecting debt", ({ before, createMsp1Api, it, creat
 
       assert(newStorageRequestDataBlob, "Event doesn't match NewStorageRequest type");
 
-      await mspApi.wait.mspFileStorageComplete(newStorageRequestDataBlob.fileKey);
+      await mspApi.wait.fileStorageComplete(newStorageRequestDataBlob.fileKey);
 
       issuedFileKeys.push(newStorageRequestDataBlob.fileKey);
     }

--- a/test/suites/integration/msp/debt-collection.test.ts
+++ b/test/suites/integration/msp/debt-collection.test.ts
@@ -334,12 +334,12 @@ describeMspNet("Single MSP collecting debt", ({ before, createMsp1Api, it, creat
       "User account does not match"
     );
 
-    // Advance many MSP charging periods to charge again, but this time with a known number of
+    // Advance one MSP charging period to charge again, but this time with a known number of
     // blocks since last charged. That way, we can check for the exact amount charged.
     // Since the MSP is going to charge each period, the last charge should be for one period.
     currentBlock = await userApi.rpc.chain.getHeader();
     currentBlockNumber = currentBlock.number.toNumber();
-    await userApi.block.skipTo(currentBlockNumber + 10 * MSP_CHARGING_PERIOD);
+    await userApi.block.skipTo(currentBlockNumber + MSP_CHARGING_PERIOD);
 
     // Calculate the expected rate of the payment stream and compare it to the actual rate.
     const valueProps = await userApi.call.storageProvidersApi.queryValuePropositionsForMsp(
@@ -387,7 +387,7 @@ describeMspNet("Single MSP collecting debt", ({ before, createMsp1Api, it, creat
     );
 
     // Verify that it charged for the correct amount.
-    const paymentStreamChargedEvent = firstPaymentStreamChargedEvents[0];
+    const paymentStreamChargedEvent = paymentStreamChargedEventsFiltered[0];
     assert(userApi.events.paymentStreams.PaymentStreamCharged.is(paymentStreamChargedEvent.event));
     const paymentStreamChargedEventAmount = paymentStreamChargedEvent.event.data.amount.toNumber();
 

--- a/test/suites/integration/msp/respond-multi-requests.test.ts
+++ b/test/suites/integration/msp/respond-multi-requests.test.ts
@@ -85,7 +85,7 @@ describeMspNet(
           userApi.events.fileSystem.NewStorageRequest.is(e.event) && e.event.data;
         assert(newStorageRequestDataBlob, "Event doesn't match NewStorageRequest type");
 
-        await mspApi.wait.mspFileStorageComplete(newStorageRequestDataBlob.fileKey);
+        await mspApi.wait.fileStorageComplete(newStorageRequestDataBlob.fileKey);
       }
 
       // Seal block containing the MSP's first response.

--- a/test/suites/integration/msp/stop-storing-bucket.test.ts
+++ b/test/suites/integration/msp/stop-storing-bucket.test.ts
@@ -39,11 +39,7 @@ describeMspNet(
       const fileMetadata = await userApi.file.newStorageRequest(source, destination, bucketId);
 
       // Wait for MSP to download file from user
-      await sleep(2000);
-
-      const result = await mspApi.rpc.storagehubclient.isFileInFileStorage(fileMetadata.fileKey);
-
-      assert(result.isFileFound, "File not found in storage");
+      mspApi.wait.fileStorageComplete(fileMetadata.fileKey);
 
       // Seal block containing the MSP's transaction response to the storage request
       await userApi.wait.mspResponseInTxPool();

--- a/test/util/bspNet/block.ts
+++ b/test/util/bspNet/block.ts
@@ -410,7 +410,7 @@ export const advanceToBlock = async (
       }
 
       // Wait for all corresponding BSPs to have submitted their proofs.
-      waitForTxInPool(api, {
+      await waitForTxInPool(api, {
         module: "proofsDealer",
         method: "submitProof",
         checkQuantity: txsToWaitFor

--- a/test/util/bspNet/block.ts
+++ b/test/util/bspNet/block.ts
@@ -400,7 +400,8 @@ export const advanceToBlock = async (
       await waitForTxInPool(api, {
         module: "proofsDealer",
         method: "submitProof",
-        checkQuantity: txsToWaitFor
+        checkQuantity: txsToWaitFor,
+        strictQuantity: false
       });
     }
 

--- a/test/util/bspNet/block.ts
+++ b/test/util/bspNet/block.ts
@@ -313,6 +313,7 @@ export const advanceToBlock = async (
   const challengeBlockNumbers: { nextChallengeBlock: number; challengePeriod: number }[] = [];
   if (options.watchForBspProofs) {
     for (const bspId of options.watchForBspProofs) {
+      // TODO: Change this to a runtime API that gets the next challenge tick for a BSP.
       // First we get the last tick for which the BSP submitted a proof.
       const lastTickResult =
         await api.call.proofsDealerApi.getLastTickProviderSubmittedProof(bspId);
@@ -405,7 +406,6 @@ export const advanceToBlock = async (
 
           // Update next challenge block.
           challengeBlockNumbers[0].nextChallengeBlock += challengeBlockNumber.challengePeriod;
-          break;
         }
       }
 

--- a/test/util/bspNet/block.ts
+++ b/test/util/bspNet/block.ts
@@ -309,33 +309,6 @@ export const advanceToBlock = async (
     verbose?: boolean;
   }
 ): Promise<SealedBlock> => {
-  // If watching for BSP proofs, we need to know the blocks at which they are challenged.
-  const challengeBlockNumbers: { nextChallengeBlock: number; challengePeriod: number }[] = [];
-  if (options.watchForBspProofs) {
-    for (const bspId of options.watchForBspProofs) {
-      // TODO: Change this to a runtime API that gets the next challenge tick for a BSP.
-      // First we get the last tick for which the BSP submitted a proof.
-      const lastTickResult =
-        await api.call.proofsDealerApi.getLastTickProviderSubmittedProof(bspId);
-      if (lastTickResult.isErr) {
-        options.verbose && console.log(`Failed to get last tick for BSP ${bspId}`);
-        continue;
-      }
-      const lastTickBspSubmittedProof = lastTickResult.asOk.toNumber();
-      // Then we get the challenge period for the BSP.
-      const challengePeriodResult = await api.call.proofsDealerApi.getChallengePeriod(bspId);
-      assert(challengePeriodResult.isOk);
-      const challengePeriod = challengePeriodResult.asOk.toNumber();
-      // Then we calculate the next challenge tick.
-      const nextChallengeTick = lastTickBspSubmittedProof + challengePeriod;
-
-      challengeBlockNumbers.push({
-        nextChallengeBlock: nextChallengeTick,
-        challengePeriod
-      });
-    }
-  }
-
   const currentBlock = await api.rpc.chain.getBlock();
   let currentBlockNumber = currentBlock.block.header.number.toNumber();
 
@@ -361,6 +334,7 @@ export const advanceToBlock = async (
   const maxNormalBlockWeight = api.consts.system.blockWeights.perClass.normal.maxTotal.unwrap();
 
   for (let i = 0; i < blocksToAdvance; i++) {
+    // Only for spamming!
     if (options.spam && i < blocksToSpam) {
       if (options.verbose) {
         console.log(`Spamming block ${i + 1} of ${blocksToSpam}`);
@@ -397,15 +371,28 @@ export const advanceToBlock = async (
       console.log(`Current tick: ${currentTick}`);
     }
 
-    // Check if we need to wait for BSP proofs.
+    // If watching for BSP proofs, we need to know if this block is a challenge block for any of the BSPs.
     if (options.watchForBspProofs) {
       let txsToWaitFor = 0;
-      for (const challengeBlockNumber of challengeBlockNumbers) {
-        if (currentBlockNumber === challengeBlockNumber.nextChallengeBlock) {
-          txsToWaitFor++;
+      for (const bspId of options.watchForBspProofs) {
+        // TODO: Change this to a runtime API that gets the next challenge tick for a BSP.
+        // First we get the last tick for which the BSP submitted a proof.
+        const lastTickResult =
+          await api.call.proofsDealerApi.getLastTickProviderSubmittedProof(bspId);
+        if (lastTickResult.isErr) {
+          options.verbose && console.log(`Failed to get last tick for BSP ${bspId}`);
+          continue;
+        }
+        const lastTickBspSubmittedProof = lastTickResult.asOk.toNumber();
+        // Then we get the challenge period for the BSP.
+        const challengePeriodResult = await api.call.proofsDealerApi.getChallengePeriod(bspId);
+        assert(challengePeriodResult.isOk);
+        const challengePeriod = challengePeriodResult.asOk.toNumber();
+        // Then we calculate the next challenge tick.
+        const nextChallengeTick = lastTickBspSubmittedProof + challengePeriod;
 
-          // Update next challenge block.
-          challengeBlockNumbers[0].nextChallengeBlock += challengeBlockNumber.challengePeriod;
+        if (currentBlockNumber === nextChallengeTick) {
+          txsToWaitFor++;
         }
       }
 

--- a/test/util/bspNet/test-api.ts
+++ b/test/util/bspNet/test-api.ts
@@ -36,9 +36,8 @@ export interface WaitForTxOptions {
   checkQuantity?: number;
   shouldSeal?: boolean;
   expectedEvent?: string;
-  iterations?: number;
-  delay?: number;
   timeout?: number;
+  verbose?: boolean;
 }
 
 /**

--- a/test/util/bspNet/test-api.ts
+++ b/test/util/bspNet/test-api.ts
@@ -445,7 +445,7 @@ export class BspNetTestApi implements AsyncDisposable {
         blockNumber: number,
         options?: {
           waitBetweenBlocks?: number | boolean;
-          waitForBspProofs?: string[];
+          watchForBspProofs?: string[];
           finalised?: boolean;
           spam?: boolean;
           verbose?: boolean;

--- a/test/util/bspNet/test-api.ts
+++ b/test/util/bspNet/test-api.ts
@@ -34,6 +34,7 @@ export interface WaitForTxOptions {
   module: string;
   method: string;
   checkQuantity?: number;
+  strictQuantity?: boolean;
   shouldSeal?: boolean;
   expectedEvent?: string;
   timeout?: number;

--- a/test/util/bspNet/test-api.ts
+++ b/test/util/bspNet/test-api.ts
@@ -260,12 +260,12 @@ export class BspNetTestApi implements AsyncDisposable {
         Waits.waitForBspStoredWithoutSealing(this._api, expectedExts),
 
       /**
-       * Waits for a BSP to complete storing a file key.
+       * Waits for a Storage Provider to complete storing a file key.
        * @param fileKey - Param to specify the file key to wait for.
        * @returns A promise that resolves when a BSP has completed to store a file.
        */
-      bspFileStorageComplete: (fileKey: H256 | string) =>
-        Waits.waitForBspFileStorageComplete(this._api, fileKey),
+      fileStorageComplete: (fileKey: H256 | string) =>
+        Waits.waitForFileStorageComplete(this._api, fileKey),
 
       /**
        * Waits for a BSP to complete deleting a file from its forest.
@@ -298,14 +298,6 @@ export class BspNetTestApi implements AsyncDisposable {
        */
       mspResponseInTxPool: (expectedExts?: number) =>
         Waits.waitForMspResponseWithoutSealing(this._api, expectedExts),
-
-      /**
-       * Waits for a MSP to complete storing a file key.
-       * @param fileKey - Param to specify the file key to wait for.
-       * @returns A promise that resolves when the MSP has completed to store a file.
-       */
-      mspFileStorageComplete: (fileKey: H256 | string) =>
-        Waits.waitForBspFileStorageComplete(this._api, fileKey),
 
       /**
        * Waits for a block where the given address has no pending extrinsics.

--- a/test/util/bspNet/test-api.ts
+++ b/test/util/bspNet/test-api.ts
@@ -305,7 +305,24 @@ export class BspNetTestApi implements AsyncDisposable {
        * @returns A promise that resolves when the MSP has completed to store a file.
        */
       mspFileStorageComplete: (fileKey: H256 | string) =>
-        Waits.waitForBspFileStorageComplete(this._api, fileKey)
+        Waits.waitForBspFileStorageComplete(this._api, fileKey),
+
+      /**
+       * Waits for a block where the given address has no pending extrinsics.
+       *
+       * This can be used to wait for a block where it is safe to send a transaction signed by the given address,
+       * without risking it clashing with another transaction with the same nonce already in the pool. For example,
+       * BSP nodes are often sending transactions, so if you want to send a transaction using one of the BSP keys,
+       * you should wait for the BSP to have no pending extrinsics before sending the transaction.
+       *
+       * IMPORTANT: As long as the address keeps having pending extrinsics, this function will keep waiting and building
+       * blocks to include such transactions.
+       *
+       * @param address - The address of the account to wait for.
+       * @returns A promise that resolves when the address has no pending extrinsics.
+       */
+      waitForAvailabilityToSendTx: (address: string) =>
+        Waits.waitForAvailabilityToSendTx(this._api, address)
     };
 
     /**

--- a/test/util/bspNet/waits.ts
+++ b/test/util/bspNet/waits.ts
@@ -49,7 +49,7 @@ export const waitForTxInPool = async (api: ApiPromise, options: WaitForTxOptions
     } catch (e) {
       if (i === iterations - 1) {
         throw new Error(
-          `Failed to detect ${module}.${method} extrinsic in txPool after ${(i * delay) / 1000}s`
+          `Failed to detect ${module}.${method} extrinsic in txPool after ${(i * delay) / 1000}s. Last error: ${e}`
         );
       }
     }

--- a/test/util/bspNet/waits.ts
+++ b/test/util/bspNet/waits.ts
@@ -18,7 +18,7 @@ export const waitForTxInPool = async (api: ApiPromise, options: WaitForTxOptions
     checkQuantity,
     shouldSeal = false,
     expectedEvent,
-    timeout = 100,
+    timeout = 1000,
     verbose = false
   } = options;
   // Handle the case where the expected amount of extrinsics is 0

--- a/test/util/bspNet/waits.ts
+++ b/test/util/bspNet/waits.ts
@@ -16,6 +16,7 @@ export const waitForTxInPool = async (api: ApiPromise, options: WaitForTxOptions
     module,
     method,
     checkQuantity,
+    strictQuantity = false,
     shouldSeal = false,
     expectedEvent,
     timeout = 1000,
@@ -39,10 +40,15 @@ export const waitForTxInPool = async (api: ApiPromise, options: WaitForTxOptions
       checkTxPool: true,
       timeout
     });
-    if (checkQuantity) {
+    if (checkQuantity && strictQuantity) {
       assert(
         matches.length === checkQuantity,
         `Expected ${checkQuantity} extrinsics, but found ${matches.length} for ${module}.${method}`
+      );
+    } else if (checkQuantity && !strictQuantity) {
+      assert(
+        matches.length >= checkQuantity,
+        `Expected at least ${checkQuantity} extrinsics, but found ${matches.length} for ${module}.${method}`
       );
     }
 
@@ -276,8 +282,8 @@ export const waitForBspToCatchUpToChainTip = async (
   syncedApi: ApiPromise,
   bspBehindApi: ApiPromise
 ) => {
-  // To allow time for BSP to catch up to the tip of the chain (10s)
-  const iterations = 100;
+  // To allow time for BSP to catch up to the tip of the chain (30s)
+  const iterations = 300;
   const delay = 100;
   for (let i = 0; i < iterations + 1; i++) {
     try {

--- a/test/util/bspNet/waits.ts
+++ b/test/util/bspNet/waits.ts
@@ -217,7 +217,7 @@ export const waitForBspStoredWithoutSealing = async (api: ApiPromise, checkQuant
  *
  * @throws Will throw an error if the file is not complete in the file storage after a timeout.
  */
-export const waitForBspFileStorageComplete = async (api: ApiPromise, fileKey: H256 | string) => {
+export const waitForFileStorageComplete = async (api: ApiPromise, fileKey: H256 | string) => {
   // To allow time for local file transfer to complete (10s)
   const iterations = 10;
   const delay = 1000;

--- a/test/util/bspNet/waits.ts
+++ b/test/util/bspNet/waits.ts
@@ -194,7 +194,7 @@ export const waitForBspStoredWithoutSealing = async (api: ApiPromise, checkQuant
     module: "fileSystem",
     method: "bspConfirmStoring",
     checkQuantity,
-    timeout: 1000
+    timeout: 10000
   });
 };
 
@@ -330,7 +330,7 @@ export const waitForMspResponseWithoutSealing = async (api: ApiPromise, checkQua
     module: "fileSystem",
     method: "mspRespondStorageRequestsMultipleBuckets",
     checkQuantity,
-    timeout: 1000
+    timeout: 10000
   });
 };
 


### PR DESCRIPTION
In this PR:
1. Fix race condition in `skipTo` waiting for proofs (eliminated `sleep`s).
2. Fix race condition where there could have been multiple `PaymentStreamCharged` events in `debt-collection.test.ts`.
3. Fix race condition where MSP didn't add a file to it's local File Storage in time in `respond-multi-requests.test.ts`.
4. Remove redundant iterations in `waitForTxInPool`.
5. Change file from `smile.jpg` to `whatsup.jpg` in `bsp-threshold.test.ts` to make it so that `BSP_DOWN` cannot immediately volunteer.
6. Simplify logic in `bsp-threshold.test.ts` and make it deterministic which BSP should be volunteering first (that shouldn't change given that their IDs and the file keys of the files uploaded don't change ever).
7. Fix race condition in `bsp-threshold.test.ts` where BSP was not yet synced with chain tip before waiting for volunteer.
8. Wait for BSPs to catch up to chain tip in `submit-proofs.test.ts`.
9. Add minimum check of number of txs in pool.
10. Fix race condition in `storage-capacity.test.ts` where a transaction was submitted with the BSP key, but the BSP node had already submitted a transaction with the same nonce.