### PR TITLE
feat: add test to verify that at max capacity bsp take only what it can store

### DIFF
--- a/test/suites/integration/bsp/storage-capacity.test.ts
+++ b/test/suites/integration/bsp/storage-capacity.test.ts
@@ -1,5 +1,16 @@
 import assert from "node:assert";
-import { addBsp, BspNetTestApi, bspKey, bspTwoKey, bspTwoSeed, describeBspNet, type EnrichedBspApi, ferdie, sleep, ShConsts } from "../../../util";
+import {
+  addBsp,
+  BspNetTestApi,
+  bspKey,
+  bspTwoKey,
+  bspTwoSeed,
+  describeBspNet,
+  type EnrichedBspApi,
+  ferdie,
+  sleep,
+  ShConsts
+} from "../../../util";
 
 describeBspNet("BSPNet: Validating max storage", ({ before, it, createUserApi, createBspApi }) => {
   let userApi: EnrichedBspApi;


### PR DESCRIPTION
This PR add a test to verify that the BSP will not take more than it can store. When increasing the capacity we can batch it to satisfy all the storage requests but it should never increase more than the max set in the configuration.
