### PR TITLE
feat: ✨ Trigger proof submission catch up every 4 blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "approx"
@@ -215,7 +215,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -438,7 +438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -464,7 +464,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -581,7 +581,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -697,7 +697,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
  "synstructure 0.13.1",
 ]
 
@@ -720,7 +720,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -896,7 +896,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -951,7 +951,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.36.5",
+ "object 0.36.7",
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
@@ -1042,7 +1042,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "15.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "hash-db",
  "log",
@@ -1075,7 +1075,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -1253,12 +1253,12 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.14.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "staging-xcm 14.2.0",
 ]
 
@@ -1306,9 +1306,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"
@@ -1369,7 +1369,7 @@ checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.23",
+ "semver 1.0.24",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -1377,9 +1377,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.3"
+version = "1.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
+checksum = "8d6dbb628b8f8555f86d0323c2eb39e3ec81901f4b83e091db8a6a76d316a333"
 dependencies = [
  "jobserver",
  "libc",
@@ -1559,7 +1559,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -1607,7 +1607,7 @@ dependencies = [
  "nom",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -1670,15 +1670,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.8"
+version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
- "unicode-width 0.1.14",
- "windows-sys 0.52.0",
+ "once_cell",
+ "unicode-width 0.2.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1908,9 +1908,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1927,18 +1927,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -2011,7 +2011,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -2021,14 +2021,14 @@ dependencies = [
  "sc-service",
  "sp-blockchain",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "url",
 ]
 
 [[package]]
 name = "cumulus-client-collator"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -2044,14 +2044,14 @@ dependencies = [
  "sp-api 34.0.0",
  "sp-consensus",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -2085,7 +2085,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-inherents 34.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-timestamp 34.0.0",
  "substrate-prometheus-endpoint",
@@ -2096,7 +2096,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -2115,7 +2115,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-slots 0.40.1",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-timestamp 34.0.0",
  "sp-trie 37.0.0",
  "sp-version 37.0.0",
@@ -2126,14 +2126,14 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "anyhow",
  "async-trait",
  "cumulus-primitives-parachain-inherent",
  "sp-consensus",
  "sp-inherents 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "thiserror 1.0.69",
 ]
@@ -2141,7 +2141,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -2158,7 +2158,7 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-version 37.0.0",
  "tracing",
@@ -2167,7 +2167,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2179,7 +2179,7 @@ dependencies = [
  "sp-api 34.0.0",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
  "sp-inherents 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-storage 21.0.0",
  "sp-trie 37.0.0",
@@ -2189,7 +2189,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2207,7 +2207,7 @@ dependencies = [
  "sp-api 34.0.0",
  "sp-consensus",
  "sp-maybe-compressed-blob",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-version 37.0.0",
  "tracing",
 ]
@@ -2215,7 +2215,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -2245,17 +2245,17 @@ dependencies = [
  "sp-consensus",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-transaction-pool",
 ]
 
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "cumulus-pallet-parachain-system",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "pallet-aura",
  "pallet-timestamp 37.0.0",
@@ -2263,13 +2263,13 @@ dependencies = [
  "scale-info",
  "sp-application-crypto 38.0.0",
  "sp-consensus-aura",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.17.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2278,7 +2278,7 @@ dependencies = [
  "cumulus-primitives-proof-size-hostfunction",
  "environmental",
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "impl-trait-for-tuples",
  "log",
@@ -2292,65 +2292,65 @@ dependencies = [
  "sp-externalities 0.29.0",
  "sp-inherents 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
  "sp-trie 37.0.0",
  "sp-version 37.0.0",
  "staging-xcm 14.2.0",
- "staging-xcm-builder 17.0.1",
+ "staging-xcm-builder 17.0.3",
  "trie-db 0.29.1",
 ]
 
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "pallet-session 38.0.0",
  "parity-scale-codec",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "staging-xcm 14.2.0",
 ]
 
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
  "cumulus-primitives-core",
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "pallet-message-queue 41.0.2",
@@ -2360,16 +2360,16 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "staging-xcm 14.2.0",
- "staging-xcm-builder 17.0.1",
+ "staging-xcm-builder 17.0.3",
  "staging-xcm-executor 17.0.0",
 ]
 
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "sp-api 34.0.0",
  "sp-consensus-aura",
@@ -2378,7 +2378,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives 15.0.0",
@@ -2386,7 +2386,7 @@ dependencies = [
  "polkadot-primitives 16.0.0",
  "scale-info",
  "sp-api 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-trie 37.0.0",
  "staging-xcm 14.2.0",
 ]
@@ -2394,7 +2394,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2408,7 +2408,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "sp-externalities 0.29.0",
  "sp-runtime-interface 28.0.0",
@@ -2418,40 +2418,40 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "8.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
  "docify",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "log",
  "pallet-asset-conversion",
  "parity-scale-codec",
  "polkadot-runtime-common 17.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "staging-xcm 14.2.0",
- "staging-xcm-builder 17.0.1",
+ "staging-xcm-builder 17.0.3",
  "staging-xcm-executor 17.0.0",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2468,14 +2468,14 @@ dependencies = [
  "sp-api 34.0.0",
  "sp-consensus",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2494,7 +2494,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -2520,7 +2520,7 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "tokio",
  "tracing",
@@ -2529,7 +2529,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2554,7 +2554,7 @@ dependencies = [
  "sp-authority-discovery 34.0.0",
  "sp-consensus-babe 0.40.0",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-storage 21.0.0",
  "sp-version 37.0.0",
@@ -2568,12 +2568,12 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
  "polkadot-primitives 16.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-trie 37.0.0",
 ]
@@ -2615,7 +2615,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -2633,9 +2633,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e1ec88093d2abd9cf1b09ffd979136b8e922bf31cad966a8fe0d73233112ef"
+checksum = "ad7c7515609502d316ab9a24f67dc045132d93bfd3f00713389e90d9898bf30d"
 dependencies = [
  "cc",
  "cxxbridge-cmd",
@@ -2647,47 +2647,47 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afa390d956ee7ccb41aeed7ed7856ab3ffb4fc587e7216be7e0f83e949b4e6c"
+checksum = "8bfd16fca6fd420aebbd80d643c201ee4692114a0de208b790b9cd02ceae65fb"
 dependencies = [
  "cc",
  "codespan-reporting",
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c23bfff654d6227cbc83de8e059d2f8678ede5fc3a6c5a35d5c379983cc61e6"
+checksum = "6c33fd49f5d956a1b7ee5f7a9768d58580c6752838d92e39d0d56439efdedc35"
 dependencies = [
  "clap",
  "codespan-reporting",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c01b36e22051bc6928a78583f1621abaaf7621561c2ada1b00f7878fbe2caa"
+checksum = "be0f1077278fac36299cce8446effd19fe93a95eedb10d39265f3bf67b3036c9"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e14013136fac689345d17b9a6df55977251f11d333c0a571e8d963b55e1f95"
+checksum = "3da7e4d6e74af6b79031d264b2f13c3ea70af1978083741c41ffce9308f1f24f"
 dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -2711,7 +2711,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -2722,7 +2722,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -2841,7 +2841,7 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -2854,7 +2854,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -2874,7 +2874,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -2920,7 +2920,7 @@ dependencies = [
  "dsl_auto_type",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -2929,7 +2929,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
 dependencies = [
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -3018,7 +3018,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -3058,7 +3058,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.90",
+ "syn 2.0.93",
  "termcolor",
  "toml 0.8.19",
  "walkdir",
@@ -3087,7 +3087,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -3201,7 +3201,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -3232,9 +3232,9 @@ dependencies = [
 
 [[package]]
 name = "encode_unicode"
-version = "0.3.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "enum-as-inner"
@@ -3257,7 +3257,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -3277,7 +3277,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -3297,7 +3297,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -3308,7 +3308,7 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -3405,7 +3405,7 @@ dependencies = [
  "prettyplease 0.2.25",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -3456,7 +3456,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -3581,9 +3581,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "foreign-types"
@@ -3603,7 +3603,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3662,9 +3662,9 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-support-procedural 30.0.3",
  "frame-system 38.0.0",
  "linregress",
@@ -3677,7 +3677,7 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-runtime-interface 28.0.0",
  "sp-storage 21.0.0",
  "static_assertions",
@@ -3686,7 +3686,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -3694,7 +3694,7 @@ dependencies = [
  "clap",
  "comfy-table",
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "gethostname",
  "handlebars",
@@ -3724,7 +3724,7 @@ dependencies = [
  "sp-inherents 34.0.0",
  "sp-io 38.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-storage 21.0.0",
  "sp-trie 37.0.0",
@@ -3742,18 +3742,18 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "14.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -3777,26 +3777,26 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-election-provider-solution-type 14.0.1",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-npos-elections 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "frame-executive"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "aquamarine",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "frame-try-runtime",
  "log",
@@ -3804,7 +3804,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-tracing 17.0.1",
 ]
 
@@ -3821,29 +3821,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "frame-metadata"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daaf440c68eb2c3d88e5760fe8c7af3f9fee9181fab6c2f2c4e7cc48dcc40bb8"
-dependencies = [
- "cfg-if",
- "parity-scale-codec",
- "scale-info",
-]
-
-[[package]]
 name = "frame-metadata-hash-extension"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "array-bytes",
  "docify",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -3857,7 +3846,7 @@ dependencies = [
  "bitflags 1.3.2",
  "docify",
  "environmental",
- "frame-metadata 16.0.0",
+ "frame-metadata",
  "frame-support-procedural 24.0.0",
  "impl-trait-for-tuples",
  "k256",
@@ -3890,15 +3879,15 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+version = "38.2.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "aquamarine",
  "array-bytes",
  "bitflags 1.3.2",
  "docify",
  "environmental",
- "frame-metadata 16.0.0",
+ "frame-metadata",
  "frame-support-procedural 30.0.3",
  "impl-trait-for-tuples",
  "k256",
@@ -3919,7 +3908,7 @@ dependencies = [
  "sp-inherents 34.0.0",
  "sp-io 38.0.0",
  "sp-metadata-ir 0.7.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
  "sp-state-machine 0.43.0",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
@@ -3946,13 +3935,13 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "frame-support-procedural"
 version = "30.0.3"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3966,7 +3955,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -3979,19 +3968,19 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-support-procedural-tools-derive 12.0.0",
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -4002,17 +3991,17 @@ checksum = "68672b9ec6fe72d259d3879dc212c5e42e977588cdac830c76f54d9f492aeb58"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -4039,18 +4028,18 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "cfg-if",
  "docify",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
  "sp-version 37.0.0",
  "sp-weights 31.0.0",
@@ -4059,21 +4048,21 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -4083,12 +4072,12 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "parity-scale-codec",
  "sp-api 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -4221,7 +4210,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -4369,9 +4358,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "governor"
@@ -4613,11 +4602,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4707,9 +4696,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.31"
+version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -4731,9 +4720,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -4757,7 +4746,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
@@ -4775,7 +4764,7 @@ dependencies = [
  "futures-util",
  "http 1.2.0",
  "http-body 1.0.1",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "pin-project-lite",
  "tokio",
  "tower-service",
@@ -4919,7 +4908,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -5014,7 +5003,7 @@ dependencies = [
  "bytes",
  "futures",
  "http 0.2.12",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "log",
  "rand",
  "tokio",
@@ -5077,7 +5066,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -5327,7 +5316,7 @@ dependencies = [
  "http 1.2.0",
  "jsonrpsee-core",
  "pin-project",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto 0.8.1",
@@ -5375,7 +5364,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -5388,7 +5377,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -5528,9 +5517,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libloading"
@@ -5879,7 +5868,7 @@ dependencies = [
  "proc-macro-warning 0.4.2",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -5990,7 +5979,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
- "redox_syscall 0.5.7",
+ "redox_syscall 0.5.8",
 ]
 
 [[package]]
@@ -6086,9 +6075,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linked_hash_set"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47186c6da4d81ca383c7c47c1bfc80f4b95f4720514d860a5407aaf4233f9588"
+checksum = "bae85b5be22d9843c80e5fc80e9b64c8a3b1f98f867c709956eca3efff4e92e2"
 dependencies = [
  "linked-hash-map",
 ]
@@ -6270,7 +6259,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -6284,7 +6273,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -6295,7 +6284,7 @@ checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -6306,7 +6295,7 @@ checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -6412,13 +6401,13 @@ dependencies = [
 
 [[package]]
 name = "merkleized-metadata"
-version = "0.1.2"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943f6d92804ed0100803d51fa9b21fd9432b5d122ba4c713dc26fe6d2f619cf6"
+checksum = "f313fcff1d2a4bcaa2deeaa00bf7530d77d5f7bd0467a117dde2e29a75a7a17a"
 dependencies = [
  "array-bytes",
  "blake3",
- "frame-metadata 18.0.0",
+ "frame-metadata",
  "parity-scale-codec",
  "scale-decode",
  "scale-info",
@@ -6455,9 +6444,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
 dependencies = [
  "adler2",
 ]
@@ -6501,7 +6490,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "futures",
  "log",
@@ -6514,13 +6503,13 @@ dependencies = [
  "sp-consensus-beefy",
  "sp-core 34.0.0",
  "sp-mmr-primitives",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "mmr-rpc"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -6529,7 +6518,7 @@ dependencies = [
  "sp-blockchain",
  "sp-core 34.0.0",
  "sp-mmr-primitives",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -6558,7 +6547,7 @@ dependencies = [
  "fragile",
  "lazy_static",
  "mockall_derive 0.12.1",
- "predicates 3.1.2",
+ "predicates 3.1.3",
  "predicates-tree",
 ]
 
@@ -6583,7 +6572,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -6803,9 +6792,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416060d346fbaf1f23f9512963e3e878f1a78e707cb699ba9215761754244307"
+checksum = "16c903aa70590cb93691bf97a767c8d1d6122d2cc9070433deb3bbf36ce8bd23"
 dependencies = [
  "bytes",
  "futures",
@@ -7009,9 +6998,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -7075,7 +7064,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -7163,10 +7152,10 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-asset-conversion"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
@@ -7175,7 +7164,7 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -7197,56 +7186,56 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
- "pallet-transaction-payment 38.0.0",
+ "pallet-transaction-payment 38.0.2",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-assets"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-aura"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "pallet-timestamp 37.0.0",
@@ -7254,7 +7243,7 @@ dependencies = [
  "scale-info",
  "sp-application-crypto 38.0.0",
  "sp-consensus-aura",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -7277,16 +7266,16 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "pallet-session 38.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-application-crypto 38.0.0",
  "sp-authority-discovery 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -7307,14 +7296,14 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -7345,10 +7334,10 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "pallet-authorship 38.0.0",
@@ -7360,7 +7349,7 @@ dependencies = [
  "sp-consensus-babe 0.40.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session 36.0.0",
  "sp-staking 36.0.0",
 ]
@@ -7368,13 +7357,13 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "aquamarine",
  "docify",
  "frame-benchmarking 38.0.0",
  "frame-election-provider-support 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "pallet-balances 39.0.0",
@@ -7382,7 +7371,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-tracing 17.0.1",
 ]
 
@@ -7406,24 +7395,24 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "docify",
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-beefy"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "pallet-authorship 38.0.0",
@@ -7432,7 +7421,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-consensus-beefy",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session 36.0.0",
  "sp-staking 36.0.0",
 ]
@@ -7440,12 +7429,12 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "pallet-beefy",
@@ -7458,17 +7447,17 @@ dependencies = [
  "sp-consensus-beefy",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
 ]
 
 [[package]]
 name = "pallet-bounties"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "pallet-treasury 37.0.0",
@@ -7476,7 +7465,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -7500,12 +7489,12 @@ dependencies = [
 
 [[package]]
 name = "pallet-broker"
-version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+version = "0.17.2"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "bitvec",
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
@@ -7513,7 +7502,7 @@ dependencies = [
  "sp-api 34.0.0",
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -7521,7 +7510,7 @@ name = "pallet-bucket-nfts"
 version = "0.1.0"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "num-bigint",
  "pallet-balances 39.0.0",
@@ -7540,7 +7529,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-keyring",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
  "sp-trie 29.0.0",
 ]
@@ -7548,10 +7537,10 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "pallet-bounties",
@@ -7560,16 +7549,16 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-collator-selection"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "pallet-authorship 38.0.0",
@@ -7578,47 +7567,47 @@ dependencies = [
  "parity-scale-codec",
  "rand",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
 ]
 
 [[package]]
 name = "pallet-collective"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-conviction-voting"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "assert_matches",
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-cr-randomness"
 version = "0.1.0"
 dependencies = [
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "pallet-balances 39.0.0",
@@ -7635,7 +7624,7 @@ dependencies = [
  "shp-treasury-funding",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
  "sp-trie 29.0.0",
 ]
@@ -7643,25 +7632,25 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
 ]
 
 [[package]]
 name = "pallet-democracy"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
@@ -7669,7 +7658,7 @@ dependencies = [
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -7699,11 +7688,11 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
  "frame-election-provider-support 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "pallet-election-provider-support-benchmarking 37.0.0",
@@ -7714,7 +7703,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-npos-elections 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "strum 0.26.3",
 ]
 
@@ -7736,23 +7725,23 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
  "frame-election-provider-support 38.0.0",
  "frame-system 38.0.0",
  "parity-scale-codec",
  "sp-npos-elections 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-elections-phragmen"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
@@ -7760,7 +7749,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-npos-elections 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
 ]
 
@@ -7787,18 +7776,18 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "docify",
  "frame-benchmarking 38.0.0",
  "frame-election-provider-support 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
 ]
 
@@ -7807,7 +7796,7 @@ name = "pallet-file-system"
 version = "0.1.0"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "num-bigint",
@@ -7830,7 +7819,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-keyring",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
  "sp-trie 29.0.0",
  "sp-weights 31.0.0",
@@ -7843,16 +7832,16 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-grandpa"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "pallet-authorship 38.0.0",
@@ -7863,7 +7852,7 @@ dependencies = [
  "sp-consensus-grandpa",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session 36.0.0",
  "sp-staking 36.0.0",
 ]
@@ -7889,26 +7878,26 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "enumflags2",
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-im-online"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "pallet-authorship 38.0.0",
@@ -7917,40 +7906,40 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
 ]
 
 [[package]]
 name = "pallet-indices"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-keyring",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-membership"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -7977,11 +7966,11 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "41.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "environmental",
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
@@ -7989,17 +7978,17 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
 ]
 
 [[package]]
 name = "pallet-mmr"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
@@ -8007,62 +7996,62 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-mmr-primitives",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-multisig"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-nfts"
 version = "32.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "enumflags2",
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-nis"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-nomination-pools"
-version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+version = "35.0.2"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "pallet-balances 39.0.0",
@@ -8070,7 +8059,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
  "sp-tracing 17.0.1",
 ]
@@ -8078,11 +8067,11 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
  "frame-election-provider-support 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "pallet-bags-list",
  "pallet-delegated-staking",
@@ -8090,15 +8079,15 @@ dependencies = [
  "pallet-staking 38.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-runtime-interface 28.0.0",
  "sp-staking 36.0.0",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
-version = "33.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+version = "33.0.2"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -8108,27 +8097,27 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "pallet-balances 39.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
 ]
 
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
  "frame-election-provider-support 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "pallet-babe 38.0.0",
@@ -8140,25 +8129,25 @@ dependencies = [
  "pallet-staking 38.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
 ]
 
 [[package]]
 name = "pallet-parameters"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "docify",
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8166,7 +8155,7 @@ name = "pallet-payment-streams"
 version = "0.1.0"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "pallet-balances 39.0.0",
  "pallet-nfts",
@@ -8182,7 +8171,7 @@ dependencies = [
  "shp-treasury-funding",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-trie 29.0.0",
  "sp-weights 31.0.0",
 ]
@@ -8194,24 +8183,24 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
 ]
 
 [[package]]
 name = "pallet-preimage"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8219,7 +8208,7 @@ name = "pallet-proofs-dealer"
 version = "0.1.0"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "hex",
  "pallet-balances 39.0.0",
@@ -8238,7 +8227,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-keyring",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
  "sp-trie 29.0.0",
  "sp-weights 31.0.0",
@@ -8251,22 +8240,22 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
 ]
 
 [[package]]
 name = "pallet-proxy"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8274,7 +8263,7 @@ name = "pallet-randomness"
 version = "0.1.0"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "pallet-balances 39.0.0",
@@ -8285,17 +8274,17 @@ dependencies = [
  "shp-session-keys",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
 ]
 
 [[package]]
 name = "pallet-ranked-collective"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+version = "38.2.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "impl-trait-for-tuples",
  "log",
@@ -8304,31 +8293,31 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-recovery"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-referenda"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "assert_matches",
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
@@ -8336,37 +8325,37 @@ dependencies = [
  "serde",
  "sp-arithmetic 26.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-root-testing"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-scheduler"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "docify",
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
 ]
 
@@ -8396,9 +8385,9 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "impl-trait-for-tuples",
  "log",
@@ -8407,7 +8396,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session 36.0.0",
  "sp-staking 36.0.0",
  "sp-state-machine 0.43.0",
@@ -8417,26 +8406,26 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "pallet-session 38.0.0",
  "pallet-staking 38.0.0",
  "parity-scale-codec",
  "rand",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session 36.0.0",
 ]
 
 [[package]]
 name = "pallet-society"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
@@ -8444,7 +8433,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic 26.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8473,11 +8462,11 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
  "frame-election-provider-support 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "pallet-authorship 38.0.0",
@@ -8488,7 +8477,7 @@ dependencies = [
  "serde",
  "sp-application-crypto 38.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
 ]
 
@@ -8505,7 +8494,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "log",
  "sp-arithmetic 26.0.0",
@@ -8514,7 +8503,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "parity-scale-codec",
  "sp-api 34.0.0",
@@ -8524,17 +8513,17 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8542,7 +8531,7 @@ name = "pallet-storage-providers"
 version = "0.1.0"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "pallet-balances 39.0.0",
@@ -8561,7 +8550,7 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
  "sp-trie 29.0.0",
 ]
@@ -8573,22 +8562,22 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-sudo"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "docify",
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8615,18 +8604,18 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "docify",
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-inherents 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-storage 21.0.0",
  "sp-timestamp 34.0.0",
 ]
@@ -8634,10 +8623,10 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "pallet-treasury 37.0.0",
@@ -8646,7 +8635,7 @@ dependencies = [
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8668,23 +8657,23 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+version = "38.0.2"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -8693,19 +8682,19 @@ dependencies = [
  "sp-blockchain",
  "sp-core 34.0.0",
  "sp-rpc",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
- "pallet-transaction-payment 38.0.0",
+ "pallet-transaction-payment 38.0.2",
  "parity-scale-codec",
  "sp-api 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
 ]
 
@@ -8732,11 +8721,11 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "docify",
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "impl-trait-for-tuples",
  "pallet-balances 39.0.0",
@@ -8744,36 +8733,36 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-uniques"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-utility"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8795,39 +8784,39 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-whitelist"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "parity-scale-codec",
  "scale-info",
  "sp-api 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-xcm"
 version = "17.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "pallet-balances 39.0.0",
@@ -8836,9 +8825,9 @@ dependencies = [
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "staging-xcm 14.2.0",
- "staging-xcm-builder 17.0.1",
+ "staging-xcm-builder 17.0.3",
  "staging-xcm-executor 17.0.0",
  "tracing",
  "xcm-runtime-apis",
@@ -8847,29 +8836,29 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "staging-xcm 14.2.0",
- "staging-xcm-builder 17.0.1",
+ "staging-xcm-builder 17.0.3",
  "staging-xcm-executor 17.0.0",
 ]
 
 [[package]]
 name = "parachains-common"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "log",
  "pallet-asset-tx-payment",
@@ -8885,7 +8874,7 @@ dependencies = [
  "sp-consensus-aura",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "staging-parachain-info",
  "staging-xcm 14.2.0",
  "staging-xcm-executor 17.0.0",
@@ -9008,7 +8997,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.7",
+ "redox_syscall 0.5.8",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -9083,7 +9072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 2.0.6",
+ "thiserror 2.0.9",
  "ucd-trie",
 ]
 
@@ -9107,7 +9096,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -9166,7 +9155,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -9210,8 +9199,8 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "polkadot-approval-distribution"
-version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+version = "18.2.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "bitvec",
  "futures",
@@ -9231,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "always-assert",
  "futures",
@@ -9247,7 +9236,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "derive_more 0.99.18",
  "fatality",
@@ -9271,7 +9260,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "fatality",
@@ -9304,7 +9293,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "cfg-if",
  "clap",
@@ -9324,7 +9313,7 @@ dependencies = [
  "sp-io 38.0.0",
  "sp-keyring",
  "sp-maybe-compressed-blob",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-build-script-utils",
  "thiserror 1.0.69",
 ]
@@ -9332,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "bitvec",
  "fatality",
@@ -9346,7 +9335,7 @@ dependencies = [
  "schnellru",
  "sp-core 34.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
  "tokio-util",
  "tracing-gum",
@@ -9368,18 +9357,18 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "derive_more 0.99.18",
  "fatality",
@@ -9404,7 +9393,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -9418,7 +9407,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "futures",
  "futures-timer",
@@ -9440,7 +9429,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -9463,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -9480,8 +9469,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-approval-voting"
-version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+version = "18.2.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "bitvec",
  "derive_more 0.99.18",
@@ -9506,7 +9495,7 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-consensus",
  "sp-consensus-slots 0.40.1",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
@@ -9514,7 +9503,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "bitvec",
  "futures",
@@ -9536,7 +9525,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "bitvec",
  "fatality",
@@ -9556,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -9571,7 +9560,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "futures",
@@ -9593,7 +9582,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -9607,7 +9596,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "futures",
  "futures-timer",
@@ -9624,7 +9613,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "fatality",
  "futures",
@@ -9643,7 +9632,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "futures",
@@ -9660,7 +9649,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "17.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "fatality",
  "futures",
@@ -9674,7 +9663,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "bitvec",
  "fatality",
@@ -9692,7 +9681,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "always-assert",
  "array-bytes",
@@ -9721,7 +9710,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -9737,7 +9726,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "cpu-time",
  "futures",
@@ -9763,7 +9752,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -9778,7 +9767,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "lazy_static",
  "log",
@@ -9797,7 +9786,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "bs58 0.5.1",
  "futures",
@@ -9815,8 +9804,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-network-protocol"
-version = "18.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+version = "18.2.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -9833,7 +9822,7 @@ dependencies = [
  "sc-authority-discovery",
  "sc-network",
  "sc-network-types",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "strum 0.26.3",
  "thiserror 1.0.69",
  "tracing-gum",
@@ -9842,7 +9831,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -9860,7 +9849,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-keystore 0.40.0",
  "sp-maybe-compressed-blob",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
  "zstd 0.12.4",
 ]
@@ -9868,7 +9857,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -9878,7 +9867,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -9900,7 +9889,7 @@ dependencies = [
  "sp-authority-discovery 34.0.0",
  "sp-blockchain",
  "sp-consensus-babe 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
@@ -9908,7 +9897,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "derive_more 0.99.18",
@@ -9944,7 +9933,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "futures",
@@ -9984,7 +9973,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "bounded-collections",
  "derive_more 0.99.18",
@@ -9993,7 +9982,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
 ]
 
@@ -10028,7 +10017,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -10047,14 +10036,14 @@ dependencies = [
  "sp-inherents 34.0.0",
  "sp-io 38.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
 ]
 
 [[package]]
 name = "polkadot-rpc"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -10081,7 +10070,7 @@ dependencies = [
  "sp-consensus-babe 0.40.0",
  "sp-consensus-beefy",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-frame-rpc-system",
  "substrate-state-trie-migration-rpc",
 ]
@@ -10140,12 +10129,12 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "bitvec",
  "frame-benchmarking 38.0.0",
  "frame-election-provider-support 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "impl-trait-for-tuples",
  "libsecp256k1",
@@ -10154,7 +10143,7 @@ dependencies = [
  "pallet-authorship 38.0.0",
  "pallet-babe 38.0.0",
  "pallet-balances 39.0.0",
- "pallet-broker 0.17.0",
+ "pallet-broker 0.17.2",
  "pallet-election-provider-multi-phase 37.0.0",
  "pallet-fast-unstake 37.0.0",
  "pallet-identity 38.0.0",
@@ -10162,7 +10151,7 @@ dependencies = [
  "pallet-staking 38.0.0",
  "pallet-staking-reward-fn 22.0.0",
  "pallet-timestamp 37.0.0",
- "pallet-transaction-payment 38.0.0",
+ "pallet-transaction-payment 38.0.2",
  "pallet-treasury 37.0.0",
  "pallet-vesting 38.0.0",
  "parity-scale-codec",
@@ -10178,11 +10167,11 @@ dependencies = [
  "sp-inherents 34.0.0",
  "sp-io 38.0.0",
  "sp-npos-elections 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session 36.0.0",
  "sp-staking 36.0.0",
  "staging-xcm 14.2.0",
- "staging-xcm-builder 17.0.1",
+ "staging-xcm-builder 17.0.3",
  "staging-xcm-executor 17.0.0",
  "static_assertions",
 ]
@@ -10219,7 +10208,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "bs58 0.5.1",
  "frame-benchmarking 38.0.0",
@@ -10280,13 +10269,13 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "17.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
  "derive_more 0.99.18",
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "impl-trait-for-tuples",
  "log",
@@ -10294,7 +10283,7 @@ dependencies = [
  "pallet-authorship 38.0.0",
  "pallet-babe 38.0.0",
  "pallet-balances 39.0.0",
- "pallet-broker 0.17.0",
+ "pallet-broker 0.17.2",
  "pallet-message-queue 41.0.2",
  "pallet-mmr",
  "pallet-session 38.0.0",
@@ -10317,7 +10306,7 @@ dependencies = [
  "sp-inherents 34.0.0",
  "sp-io 38.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session 36.0.0",
  "sp-staking 36.0.0",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
@@ -10329,7 +10318,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "frame-benchmarking 38.0.0",
@@ -10343,7 +10332,7 @@ dependencies = [
  "kvdb-rocksdb",
  "log",
  "mmr-gadget",
- "pallet-transaction-payment 38.0.0",
+ "pallet-transaction-payment 38.0.2",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-db",
  "parity-scale-codec",
@@ -10421,7 +10410,7 @@ dependencies = [
  "sp-keyring",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session 36.0.0",
  "sp-timestamp 34.0.0",
  "sp-transaction-pool",
@@ -10438,7 +10427,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "arrayvec 0.7.6",
  "bitvec",
@@ -10461,7 +10450,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives 16.0.0",
@@ -10502,9 +10491,9 @@ dependencies = [
 
 [[package]]
 name = "polkavm-common"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f0dbafef4ab6ceecb4982ac3b550df430ef4f9fdbf07c108b7d4f91a0682fce"
+checksum = "31ff33982a807d8567645d4784b9b5d7ab87bcb494f534a57cadd9012688e102"
 
 [[package]]
 name = "polkavm-derive"
@@ -10517,11 +10506,11 @@ dependencies = [
 
 [[package]]
 name = "polkavm-derive"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206caf322dfc02144510ad8360ff2051e5072f0874dcab3b410f78cdd52d0ebb"
+checksum = "c2eb703f3b6404c13228402e98a5eae063fd16b8f58afe334073ec105ee4117e"
 dependencies = [
- "polkavm-derive-impl-macro 0.17.0",
+ "polkavm-derive-impl-macro 0.18.0",
 ]
 
 [[package]]
@@ -10533,19 +10522,19 @@ dependencies = [
  "polkavm-common 0.9.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "polkavm-derive-impl"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42565aed4adbc4034612d0b17dea8db3681fb1bd1aed040d6edc5455a9f478a1"
+checksum = "12d2840cc62a0550156b1676fed8392271ddf2fab4a00661db56231424674624"
 dependencies = [
- "polkavm-common 0.17.0",
+ "polkavm-common 0.18.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -10555,17 +10544,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
 dependencies = [
  "polkavm-derive-impl 0.9.0",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "polkavm-derive-impl-macro"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d9838e95241b0bce4fe269cdd4af96464160505840ed5a8ac8536119ba19e2"
+checksum = "48c16669ddc7433e34c1007d31080b80901e3e8e523cb9d4b441c3910cf9294b"
 dependencies = [
- "polkavm-derive-impl 0.17.0",
- "syn 2.0.90",
+ "polkavm-derive-impl 0.18.0",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -10718,9 +10707,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "3.1.2"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "predicates-core",
@@ -10728,15 +10717,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -10759,7 +10748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -10856,7 +10845,7 @@ checksum = "3d1eaa7fa0aa1929ffdf7eeb6eac234dde6268914a14ad44d23521ab6a9b258e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -10867,7 +10856,7 @@ checksum = "834da187cfe638ae8abb0203f0b33e5ccdb02a28e7199f2f47b3e2754f50edca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -10913,7 +10902,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -10975,7 +10964,7 @@ dependencies = [
  "prost 0.12.6",
  "prost-types 0.12.6",
  "regex",
- "syn 2.0.90",
+ "syn 2.0.93",
  "tempfile",
 ]
 
@@ -11002,7 +10991,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -11034,9 +11023,9 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
+checksum = "773ce68d0bb9bc7ef20be3536ffe94e223e1f365bd374108b2659fac0c65cfe6"
 dependencies = [
  "crossbeam-utils",
  "libc",
@@ -11174,9 +11163,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -11300,9 +11289,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -11347,7 +11336,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -11514,14 +11503,14 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
  "frame-benchmarking 38.0.0",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
@@ -11565,7 +11554,7 @@ dependencies = [
  "pallet-sudo",
  "pallet-timestamp 37.0.0",
  "pallet-tips",
- "pallet-transaction-payment 38.0.0",
+ "pallet-transaction-payment 38.0.2",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-treasury 37.0.0",
  "pallet-utility",
@@ -11597,14 +11586,14 @@ dependencies = [
  "sp-io 38.0.0",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session 36.0.0",
  "sp-staking 36.0.0",
  "sp-storage 21.0.0",
  "sp-transaction-pool",
  "sp-version 37.0.0",
  "staging-xcm 14.2.0",
- "staging-xcm-builder 17.0.1",
+ "staging-xcm-builder 17.0.3",
  "staging-xcm-executor 17.0.0",
  "static_assertions",
  "substrate-wasm-builder",
@@ -11614,17 +11603,17 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "polkadot-primitives 16.0.0",
  "polkadot-runtime-common 17.0.0",
  "smallvec",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
  "staging-xcm 14.2.0",
- "staging-xcm-builder 17.0.1",
+ "staging-xcm-builder 17.0.3",
 ]
 
 [[package]]
@@ -11702,7 +11691,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.23",
+ "semver 1.0.24",
 ]
 
 [[package]]
@@ -11780,9 +11769,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.19"
+version = "0.23.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
+checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
 dependencies = [
  "log",
  "once_cell",
@@ -11838,9 +11827,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 
 [[package]]
 name = "rustls-platform-verifier"
@@ -11853,7 +11842,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "rustls-native-certs 0.7.3",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.102.8",
@@ -11892,9 +11881,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ruzstd"
@@ -11926,9 +11915,9 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "safe_arch"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3460605018fdc9612bce72735cba0d27efbcd9904780d44c7e3a9948f96148a"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
 dependencies = [
  "bytemuck",
 ]
@@ -11945,7 +11934,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "log",
  "sp-core 34.0.0",
@@ -11956,7 +11945,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "futures",
@@ -11978,7 +11967,7 @@ dependencies = [
  "sp-blockchain",
  "sp-core 34.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
@@ -11986,7 +11975,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12001,14 +11990,14 @@ dependencies = [
  "sp-consensus",
  "sp-core 34.0.0",
  "sp-inherents 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-block-builder"
 version = "0.42.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "parity-scale-codec",
  "sp-api 34.0.0",
@@ -12016,14 +12005,14 @@ dependencies = [
  "sp-blockchain",
  "sp-core 34.0.0",
  "sp-inherents 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-trie 37.0.0",
 ]
 
 [[package]]
 name = "sc-chain-spec"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "array-bytes",
  "docify",
@@ -12042,7 +12031,7 @@ dependencies = [
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
  "sp-genesis-builder 0.15.1",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-tracing 17.0.1",
 ]
@@ -12050,18 +12039,18 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "sc-cli"
 version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -12093,7 +12082,7 @@ dependencies = [
  "sp-keyring",
  "sp-keystore 0.40.0",
  "sp-panic-handler 13.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-version 37.0.0",
  "thiserror 1.0.69",
  "tokio",
@@ -12102,7 +12091,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "fnv",
  "futures",
@@ -12118,7 +12107,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-database",
  "sp-externalities 0.29.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-statement-store",
  "sp-storage 21.0.0",
@@ -12129,7 +12118,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.44.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -12147,7 +12136,7 @@ dependencies = [
  "sp-blockchain",
  "sp-core 34.0.0",
  "sp-database",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-trie 37.0.0",
 ]
@@ -12155,7 +12144,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "futures",
@@ -12170,7 +12159,7 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
@@ -12179,7 +12168,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "futures",
@@ -12200,7 +12189,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-inherents 34.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
@@ -12208,7 +12197,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -12236,7 +12225,7 @@ dependencies = [
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
  "sp-inherents 34.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
@@ -12244,7 +12233,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -12259,14 +12248,14 @@ dependencies = [
  "sp-consensus-babe 0.40.0",
  "sp-core 34.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-consensus-beefy"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -12292,7 +12281,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tokio",
@@ -12302,7 +12291,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -12315,27 +12304,27 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-consensus-beefy",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
  "sc-client-api",
  "sc-consensus",
  "sp-blockchain",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.30.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "ahash 0.8.11",
  "array-bytes",
@@ -12371,7 +12360,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
@@ -12379,7 +12368,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.30.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -12392,14 +12381,14 @@ dependencies = [
  "serde",
  "sp-blockchain",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.46.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -12425,7 +12414,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-inherents 34.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-timestamp 34.0.0",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
@@ -12434,7 +12423,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "futures",
@@ -12450,14 +12439,14 @@ dependencies = [
  "sp-consensus-slots 0.40.1",
  "sp-core 34.0.0",
  "sp-inherents 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
 ]
 
 [[package]]
 name = "sc-executor"
 version = "0.40.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -12480,7 +12469,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -12493,7 +12482,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "log",
  "polkavm",
@@ -12504,7 +12493,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -12522,7 +12511,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "console",
  "futures",
@@ -12533,13 +12522,13 @@ dependencies = [
  "sc-network-common",
  "sc-network-sync",
  "sp-blockchain",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "sc-keystore"
 version = "33.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -12553,7 +12542,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.6",
@@ -12575,14 +12564,14 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-keystore 0.40.0",
  "sp-mixnet",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-network"
-version = "0.45.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+version = "0.45.3"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -12619,7 +12608,7 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-blockchain",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tokio",
@@ -12633,7 +12622,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -12645,13 +12634,13 @@ dependencies = [
  "sc-network-types",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "sc-network-gossip"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "ahash 0.8.11",
  "futures",
@@ -12662,7 +12651,7 @@ dependencies = [
  "sc-network-sync",
  "sc-network-types",
  "schnellru",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
@@ -12670,7 +12659,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.44.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -12684,14 +12673,14 @@ dependencies = [
  "sc-network-types",
  "sp-blockchain",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-network-sync"
 version = "0.44.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -12718,7 +12707,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tokio",
@@ -12728,7 +12717,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.44.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "array-bytes",
  "futures",
@@ -12740,14 +12729,14 @@ dependencies = [
  "sc-network-types",
  "sc-utils",
  "sp-consensus",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-network-types"
 version = "0.12.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "bs58 0.5.1",
  "ed25519-dalek",
@@ -12764,14 +12753,14 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "array-bytes",
  "bytes",
  "fnv",
  "futures",
  "futures-timer",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "hyper-rustls",
  "log",
  "num_cpus",
@@ -12790,7 +12779,7 @@ dependencies = [
  "sp-externalities 0.29.0",
  "sp-keystore 0.40.0",
  "sp-offchain",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "threadpool",
  "tracing",
 ]
@@ -12798,7 +12787,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -12807,7 +12796,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -12829,7 +12818,7 @@ dependencies = [
  "sp-keystore 0.40.0",
  "sp-offchain",
  "sp-rpc",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session 36.0.0",
  "sp-statement-store",
  "sp-version 37.0.0",
@@ -12839,7 +12828,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -12851,15 +12840,15 @@ dependencies = [
  "serde_json",
  "sp-core 34.0.0",
  "sp-rpc",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-version 37.0.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-rpc-server"
-version = "17.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+version = "17.1.2"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -12867,7 +12856,7 @@ dependencies = [
  "governor",
  "http 1.2.0",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "ip_network",
  "jsonrpsee",
  "log",
@@ -12883,7 +12872,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "array-bytes",
  "futures",
@@ -12905,7 +12894,7 @@ dependencies = [
  "sp-blockchain",
  "sp-core 34.0.0",
  "sp-rpc",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-version 37.0.0",
  "thiserror 1.0.69",
  "tokio",
@@ -12915,7 +12904,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.46.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "directories",
@@ -12959,7 +12948,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-externalities 0.29.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session 36.0.0",
  "sp-state-machine 0.43.0",
  "sp-storage 21.0.0",
@@ -12979,7 +12968,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.36.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -12990,7 +12979,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.22.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "clap",
  "fs4",
@@ -13003,7 +12992,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13015,14 +13004,14 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-sysinfo"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "derive_more 0.99.18",
  "futures",
@@ -13043,7 +13032,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "chrono",
  "futures",
@@ -13063,7 +13052,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "37.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "chrono",
  "console",
@@ -13081,7 +13070,7 @@ dependencies = [
  "sp-blockchain",
  "sp-core 34.0.0",
  "sp-rpc",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-tracing 17.0.1",
  "thiserror 1.0.69",
  "tracing",
@@ -13092,18 +13081,18 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "sc-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "futures",
@@ -13120,7 +13109,7 @@ dependencies = [
  "sp-blockchain",
  "sp-core 34.0.0",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-tracing 17.0.1",
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
@@ -13130,7 +13119,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "futures",
@@ -13139,14 +13128,14 @@ dependencies = [
  "serde",
  "sp-blockchain",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-utils"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -13204,7 +13193,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -13381,9 +13370,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
+checksum = "1863fd3768cd83c56a7f60faa4dc0d403f1b6df0a38c3c25f44b7894e45370d5"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -13400,9 +13389,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
 dependencies = [
  "serde",
 ]
@@ -13421,9 +13410,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
@@ -13439,20 +13428,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
 dependencies = [
  "itoa",
  "memchr",
@@ -13495,7 +13484,7 @@ dependencies = [
  "frame-benchmarking 38.0.0",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
@@ -13524,7 +13513,7 @@ dependencies = [
  "pallet-storage-providers-runtime-api",
  "pallet-sudo",
  "pallet-timestamp 37.0.0",
- "pallet-transaction-payment 38.0.0",
+ "pallet-transaction-payment 38.0.2",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-uniques",
  "pallet-xcm",
@@ -13552,7 +13541,7 @@ dependencies = [
  "sp-inherents 34.0.0",
  "sp-io 38.0.0",
  "sp-offchain",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session 36.0.0",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
  "sp-tracing 17.0.1",
@@ -13562,7 +13551,7 @@ dependencies = [
  "sp-weights 31.0.0",
  "staging-parachain-info",
  "staging-xcm 14.2.0",
- "staging-xcm-builder 17.0.1",
+ "staging-xcm-builder 17.0.3",
  "staging-xcm-executor 17.0.0",
  "xcm-runtime-apis",
  "xcm-simulator",
@@ -13669,7 +13658,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "tokio",
 ]
 
@@ -13683,7 +13672,7 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-storage-weight-reclaim",
  "frame-metadata-hash-extension",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "futures",
  "lazy_static",
@@ -13696,7 +13685,7 @@ dependencies = [
  "pallet-proofs-dealer-runtime-api",
  "pallet-storage-providers",
  "pallet-storage-providers-runtime-api",
- "pallet-transaction-payment 38.0.0",
+ "pallet-transaction-payment 38.0.2",
  "parity-scale-codec",
  "polkadot-primitives 16.0.0",
  "polkadot-runtime-common 17.0.0",
@@ -13715,7 +13704,7 @@ dependencies = [
  "sp-api 34.0.0",
  "sp-core 34.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "storage-hub-runtime",
  "substrate-frame-rpc-system",
  "tokio",
@@ -13729,7 +13718,7 @@ dependencies = [
  "bincode",
  "cumulus-client-service",
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "lazy_static",
  "log",
@@ -13752,7 +13741,7 @@ dependencies = [
  "sp-blockchain",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
  "sp-trie 29.0.0",
  "storage-hub-runtime",
@@ -13775,7 +13764,7 @@ dependencies = [
  "shc-common",
  "shp-traits",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-trie 29.0.0",
  "thiserror 1.0.69",
@@ -13827,7 +13816,7 @@ dependencies = [
  "shp-forest-verifier",
  "shp-traits",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-trie 29.0.0",
  "thiserror 1.0.69",
@@ -13864,7 +13853,7 @@ dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "diesel",
  "diesel-async",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "futures",
  "lazy_static",
@@ -13879,7 +13868,7 @@ dependencies = [
  "pallet-randomness",
  "pallet-storage-providers",
  "pallet-storage-providers-runtime-api",
- "pallet-transaction-payment 38.0.0",
+ "pallet-transaction-payment 38.0.2",
  "parity-scale-codec",
  "polkadot-primitives 16.0.0",
  "polkadot-runtime-common 17.0.0",
@@ -13896,7 +13885,7 @@ dependencies = [
  "sp-api 34.0.0",
  "sp-blockchain",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "storage-hub-runtime",
  "substrate-frame-rpc-system",
  "thiserror 1.0.69",
@@ -13919,7 +13908,7 @@ dependencies = [
  "sp-blockchain",
  "sp-core 34.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-trie 29.0.0",
  "tokio",
 ]
@@ -13935,21 +13924,21 @@ name = "shp-constants"
 version = "0.1.0"
 dependencies = [
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "shp-data-price-updater"
 version = "0.1.0"
 dependencies = [
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "shp-traits",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
 ]
 
@@ -13958,7 +13947,7 @@ name = "shp-file-key-verifier"
 version = "0.1.0"
 dependencies = [
  "bincode",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "num-bigint",
  "parity-scale-codec",
  "rand",
@@ -13968,7 +13957,7 @@ dependencies = [
  "shp-traits",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
  "sp-trie 29.0.0",
  "trie-db 0.29.1",
@@ -13993,14 +13982,14 @@ name = "shp-forest-verifier"
 version = "0.1.0"
 dependencies = [
  "bincode",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "shp-traits",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
  "sp-trie 29.0.0",
  "trie-db 0.29.1",
@@ -14016,7 +14005,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-inherents 34.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
 ]
 
@@ -14024,13 +14013,13 @@ dependencies = [
 name = "shp-traits"
 version = "0.1.0"
 dependencies = [
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
  "sp-trie 29.0.0",
 ]
@@ -14129,12 +14118,12 @@ dependencies = [
 [[package]]
 name = "slot-range-helper"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "enumn",
  "parity-scale-codec",
  "paste",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -14358,7 +14347,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "docify",
  "hash-db",
@@ -14369,7 +14358,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-externalities 0.29.0",
  "sp-metadata-ir 0.7.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-runtime-interface 28.0.0",
  "sp-state-machine 0.43.0",
  "sp-trie 37.0.0",
@@ -14389,13 +14378,13 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "sp-api-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -14403,7 +14392,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -14423,7 +14412,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14450,7 +14439,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -14496,29 +14485,29 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api 34.0.0",
  "sp-application-crypto 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "sp-block-builder"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "sp-api 34.0.0",
  "sp-inherents 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "sp-blockchain"
 version = "37.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -14528,7 +14517,7 @@ dependencies = [
  "sp-consensus",
  "sp-core 34.0.0",
  "sp-database",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "thiserror 1.0.69",
  "tracing",
@@ -14537,14 +14526,14 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "futures",
  "log",
  "sp-core 34.0.0",
  "sp-inherents 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "thiserror 1.0.69",
 ]
@@ -14552,7 +14541,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14561,7 +14550,7 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-consensus-slots 0.40.1",
  "sp-inherents 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-timestamp 34.0.0",
 ]
 
@@ -14588,7 +14577,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14599,14 +14588,14 @@ dependencies = [
  "sp-consensus-slots 0.40.1",
  "sp-core 34.0.0",
  "sp-inherents 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-timestamp 34.0.0",
 ]
 
 [[package]]
 name = "sp-consensus-beefy"
 version = "22.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -14619,7 +14608,7 @@ dependencies = [
  "sp-io 38.0.0",
  "sp-keystore 0.40.0",
  "sp-mmr-primitives",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
  "strum 0.26.3",
 ]
@@ -14627,7 +14616,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -14638,7 +14627,7 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-core 34.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -14657,7 +14646,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.40.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14668,7 +14657,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#4198dc95b20e7a157fa0d1b8ef4a2e01a223af1b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#5abdc5c34c544aaf21d98778eae31ccc2349c422"
 dependencies = [
  "array-bytes",
  "bandersnatch_vrfs",
@@ -14761,7 +14750,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -14807,7 +14796,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#4198dc95b20e7a157fa0d1b8ef4a2e01a223af1b"
+source = "git+https://github.com/paritytech/polkadot-sdk#5abdc5c34c544aaf21d98778eae31ccc2349c422"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -14841,7 +14830,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#4198dc95b20e7a157fa0d1b8ef4a2e01a223af1b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#5abdc5c34c544aaf21d98778eae31ccc2349c422"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -14854,7 +14843,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -14872,23 +14861,23 @@ checksum = "b85d0f1f1e44bd8617eb2a48203ee854981229e3e79e6f468c7175d5fd37489b"
 dependencies = [
  "quote",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "quote",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -14902,43 +14891,43 @@ checksum = "48d09fa0a5f7299fb81ee25ae3853d26200f7a348148aed6de76be905c007dbe"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#4198dc95b20e7a157fa0d1b8ef4a2e01a223af1b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#5abdc5c34c544aaf21d98778eae31ccc2349c422"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#4198dc95b20e7a157fa0d1b8ef4a2e01a223af1b"
+source = "git+https://github.com/paritytech/polkadot-sdk#5abdc5c34c544aaf21d98778eae31ccc2349c422"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#4198dc95b20e7a157fa0d1b8ef4a2e01a223af1b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#5abdc5c34c544aaf21d98778eae31ccc2349c422"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -14948,7 +14937,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#4198dc95b20e7a157fa0d1b8ef4a2e01a223af1b"
+source = "git+https://github.com/paritytech/polkadot-sdk#5abdc5c34c544aaf21d98778eae31ccc2349c422"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -14970,7 +14959,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -14992,13 +14981,13 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.15.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde_json",
  "sp-api 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -15019,13 +15008,13 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
 ]
 
@@ -15058,7 +15047,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "bytes",
  "docify",
@@ -15084,10 +15073,10 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "strum 0.26.3",
 ]
 
@@ -15107,7 +15096,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -15118,7 +15107,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -15130,7 +15119,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa0b5e87e56c1bb26d9524d48dd127121d630f895bd5914a34f0b017489f7c1d"
 dependencies = [
- "frame-metadata 16.0.0",
+ "frame-metadata",
  "parity-scale-codec",
  "scale-info",
  "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -15139,9 +15128,9 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
- "frame-metadata 16.0.0",
+ "frame-metadata",
  "parity-scale-codec",
  "scale-info",
 ]
@@ -15149,7 +15138,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15160,7 +15149,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "34.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -15170,7 +15159,7 @@ dependencies = [
  "sp-api 34.0.0",
  "sp-core 34.0.0",
  "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
 ]
 
@@ -15192,24 +15181,24 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "sp-offchain"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "sp-api 34.0.0",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -15226,7 +15215,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -15236,7 +15225,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "32.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -15270,8 +15259,8 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "39.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+version = "39.0.5"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "docify",
  "either",
@@ -15297,12 +15286,12 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#4198dc95b20e7a157fa0d1b8ef4a2e01a223af1b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#5abdc5c34c544aaf21d98778eae31ccc2349c422"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "polkavm-derive 0.17.1",
+ "polkavm-derive 0.18.0",
  "primitive-types 0.13.1",
  "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
  "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=master)",
@@ -15316,12 +15305,12 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#4198dc95b20e7a157fa0d1b8ef4a2e01a223af1b"
+source = "git+https://github.com/paritytech/polkadot-sdk#5abdc5c34c544aaf21d98778eae31ccc2349c422"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "polkavm-derive 0.17.1",
+ "polkavm-derive 0.18.0",
  "primitive-types 0.13.1",
  "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk)",
  "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
@@ -15354,7 +15343,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -15381,46 +15370,46 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#4198dc95b20e7a157fa0d1b8ef4a2e01a223af1b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#5abdc5c34c544aaf21d98778eae31ccc2349c422"
 dependencies = [
  "Inflector",
  "expander",
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#4198dc95b20e7a157fa0d1b8ef4a2e01a223af1b"
+source = "git+https://github.com/paritytech/polkadot-sdk#5abdc5c34c544aaf21d98778eae31ccc2349c422"
 dependencies = [
  "Inflector",
  "expander",
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "Inflector",
  "expander",
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -15442,14 +15431,14 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api 34.0.0",
  "sp-core 34.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
 ]
 
@@ -15471,14 +15460,14 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -15506,7 +15495,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "hash-db",
  "log",
@@ -15526,7 +15515,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek 4.1.3",
@@ -15541,7 +15530,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
  "sp-externalities 0.29.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-runtime-interface 28.0.0",
  "thiserror 1.0.69",
  "x25519-dalek",
@@ -15556,22 +15545,22 @@ checksum = "12f8ee986414b0a9ad741776762f4083cd3a5128449b982a3919c4df36874834"
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#4198dc95b20e7a157fa0d1b8ef4a2e01a223af1b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#5abdc5c34c544aaf21d98778eae31ccc2349c422"
 
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#4198dc95b20e7a157fa0d1b8ef4a2e01a223af1b"
+source = "git+https://github.com/paritytech/polkadot-sdk#5abdc5c34c544aaf21d98778eae31ccc2349c422"
 
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#4198dc95b20e7a157fa0d1b8ef4a2e01a223af1b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#5abdc5c34c544aaf21d98778eae31ccc2349c422"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
@@ -15583,7 +15572,7 @@ dependencies = [
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#4198dc95b20e7a157fa0d1b8ef4a2e01a223af1b"
+source = "git+https://github.com/paritytech/polkadot-sdk#5abdc5c34c544aaf21d98778eae31ccc2349c422"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
@@ -15609,7 +15598,7 @@ dependencies = [
 [[package]]
 name = "sp-storage"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "impl-serde 0.4.0",
  "parity-scale-codec",
@@ -15635,12 +15624,12 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "sp-inherents 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
 ]
 
@@ -15660,7 +15649,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#4198dc95b20e7a157fa0d1b8ef4a2e01a223af1b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#5abdc5c34c544aaf21d98778eae31ccc2349c422"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -15671,7 +15660,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#4198dc95b20e7a157fa0d1b8ef4a2e01a223af1b"
+source = "git+https://github.com/paritytech/polkadot-sdk#5abdc5c34c544aaf21d98778eae31ccc2349c422"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -15682,7 +15671,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -15693,30 +15682,30 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "sp-api 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
  "sp-inherents 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-trie 37.0.0",
 ]
 
 [[package]]
 name = "sp-trie"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#4198dc95b20e7a157fa0d1b8ef4a2e01a223af1b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#5abdc5c34c544aaf21d98778eae31ccc2349c422"
 dependencies = [
  "ahash 0.8.11",
  "hash-db",
@@ -15763,7 +15752,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "ahash 0.8.11",
  "hash-db",
@@ -15804,7 +15793,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "impl-serde 0.4.0",
  "parity-scale-codec",
@@ -15812,7 +15801,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
  "sp-version-proc-macro 14.0.0",
  "thiserror 1.0.69",
@@ -15827,18 +15816,18 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "sp-version-proc-macro"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -15858,7 +15847,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#4198dc95b20e7a157fa0d1b8ef4a2e01a223af1b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#5abdc5c34c544aaf21d98778eae31ccc2349c422"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -15869,7 +15858,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#4198dc95b20e7a157fa0d1b8ef4a2e01a223af1b"
+source = "git+https://github.com/paritytech/polkadot-sdk#5abdc5c34c544aaf21d98778eae31ccc2349c422"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -15880,7 +15869,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -15908,7 +15897,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -15974,14 +15963,14 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-parachain-info"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -16006,7 +15995,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "14.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -16017,7 +16006,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
  "xcm-procedural 10.1.0",
 ]
@@ -16047,21 +16036,21 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "17.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+version = "17.0.3"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "impl-trait-for-tuples",
  "log",
  "pallet-asset-conversion",
- "pallet-transaction-payment 38.0.0",
+ "pallet-transaction-payment 38.0.2",
  "parity-scale-codec",
  "polkadot-parachain-primitives 14.0.0",
  "scale-info",
  "sp-arithmetic 26.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
  "staging-xcm 14.2.0",
  "staging-xcm-executor 17.0.0",
@@ -16092,18 +16081,18 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "environmental",
  "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
  "staging-xcm 14.2.0",
  "tracing",
@@ -16132,9 +16121,9 @@ dependencies = [
 
 [[package]]
 name = "static_init_macro"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a2595fc3aa78f2d0e45dd425b22282dd863273761cc77780914b2cf3003acf"
+checksum = "1389c88ddd739ec6d3f8f83343764a0e944cd23cfbf126a9796a714b0b6edd6f"
 dependencies = [
  "cfg_aliases",
  "memchr",
@@ -16168,7 +16157,7 @@ dependencies = [
  "cumulus-relay-chain-interface",
  "frame-benchmarking 38.0.0",
  "frame-benchmarking-cli",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "futures",
  "futures-timer",
@@ -16185,7 +16174,7 @@ dependencies = [
  "pallet-proofs-dealer",
  "pallet-proofs-dealer-runtime-api",
  "pallet-storage-providers",
- "pallet-transaction-payment 38.0.0",
+ "pallet-transaction-payment 38.0.2",
  "pallet-transaction-payment-rpc",
  "parity-scale-codec",
  "polkadot-cli",
@@ -16235,7 +16224,7 @@ dependencies = [
  "sp-io 38.0.0",
  "sp-keyring",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-timestamp 34.0.0",
  "sp-trie 29.0.0",
  "staging-xcm 14.2.0",
@@ -16264,7 +16253,7 @@ dependencies = [
  "frame-benchmarking 38.0.0",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
@@ -16293,7 +16282,7 @@ dependencies = [
  "pallet-storage-providers-runtime-api",
  "pallet-sudo",
  "pallet-timestamp 37.0.0",
- "pallet-transaction-payment 38.0.0",
+ "pallet-transaction-payment 38.0.2",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-xcm",
  "parachains-common",
@@ -16317,7 +16306,7 @@ dependencies = [
  "sp-genesis-builder 0.15.1",
  "sp-inherents 34.0.0",
  "sp-offchain",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session 36.0.0",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
  "sp-transaction-pool",
@@ -16326,7 +16315,7 @@ dependencies = [
  "sp-weights 31.0.0",
  "staging-parachain-info",
  "staging-xcm 14.2.0",
- "staging-xcm-builder 17.0.1",
+ "staging-xcm-builder 17.0.3",
  "staging-xcm-executor 17.0.0",
  "substrate-wasm-builder",
  "xcm-runtime-apis",
@@ -16410,7 +16399,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -16429,7 +16418,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.4.7"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#4198dc95b20e7a157fa0d1b8ef4a2e01a223af1b"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=master#5abdc5c34c544aaf21d98778eae31ccc2349c422"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2 0.12.2",
@@ -16441,7 +16430,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2 0.12.2",
@@ -16453,12 +16442,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -16472,16 +16461,16 @@ dependencies = [
  "sp-block-builder",
  "sp-blockchain",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-util",
  "log",
  "prometheus",
@@ -16492,7 +16481,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -16500,7 +16489,7 @@ dependencies = [
  "sc-rpc-api",
  "serde",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-trie 37.0.0",
  "trie-db 0.29.1",
@@ -16509,14 +16498,14 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "24.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "array-bytes",
  "build-helper",
  "cargo_metadata",
  "console",
  "filetime",
- "frame-metadata 16.0.0",
+ "frame-metadata",
  "jobserver",
  "merkleized-metadata",
  "parity-scale-codec",
@@ -16566,9 +16555,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "9c786062daee0d6db1132800e623df74274a0a87322d8e183338e01b3d98d058"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -16595,7 +16584,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -16665,9 +16654,9 @@ dependencies = [
 
 [[package]]
 name = "termtree"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -16680,11 +16669,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.6"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
+checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
 dependencies = [
- "thiserror-impl 2.0.6",
+ "thiserror-impl 2.0.9",
 ]
 
 [[package]]
@@ -16704,7 +16693,7 @@ checksum = "e4c60d69f36615a077cc7663b9cb8e42275722d23e58a7fa3d2c7f2915d09d04"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -16715,18 +16704,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.6"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
+checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -16840,9 +16829,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -16879,7 +16868,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -16924,7 +16913,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "tokio",
 ]
 
@@ -17075,7 +17064,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -17101,7 +17090,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "coarsetime",
  "polkadot-primitives 16.0.0",
@@ -17112,13 +17101,13 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "expander",
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -17396,9 +17385,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
@@ -17633,7 +17622,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
  "wasm-bindgen-shared",
 ]
 
@@ -17668,7 +17657,7 @@ checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -18026,7 +18015,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "18.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -18034,7 +18023,7 @@ dependencies = [
  "frame-election-provider-support 38.0.0",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
@@ -18084,7 +18073,7 @@ dependencies = [
  "pallet-state-trie-migration",
  "pallet-sudo",
  "pallet-timestamp 37.0.0",
- "pallet-transaction-payment 38.0.0",
+ "pallet-transaction-payment 38.0.2",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-treasury 37.0.0",
  "pallet-utility",
@@ -18117,14 +18106,14 @@ dependencies = [
  "sp-mmr-primitives",
  "sp-npos-elections 34.0.0",
  "sp-offchain",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session 36.0.0",
  "sp-staking 36.0.0",
  "sp-storage 21.0.0",
  "sp-transaction-pool",
  "sp-version 37.0.0",
  "staging-xcm 14.2.0",
- "staging-xcm-builder 17.0.1",
+ "staging-xcm-builder 17.0.3",
  "staging-xcm-executor 17.0.0",
  "substrate-wasm-builder",
  "westend-runtime-constants",
@@ -18134,17 +18123,17 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "polkadot-primitives 16.0.0",
  "polkadot-runtime-common 17.0.0",
  "smallvec",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
  "staging-xcm 14.2.0",
- "staging-xcm-builder 17.0.1",
+ "staging-xcm-builder 17.0.3",
 ]
 
 [[package]]
@@ -18165,7 +18154,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
 dependencies = [
- "redox_syscall 0.5.7",
+ "redox_syscall 0.5.8",
  "wasite",
  "web-sys",
 ]
@@ -18579,26 +18568,26 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "xcm-procedural"
 version = "10.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
 name = "xcm-runtime-apis"
-version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+version = "0.4.2"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "parity-scale-codec",
  "scale-info",
  "sp-api 34.0.0",
@@ -18610,9 +18599,9 @@ dependencies = [
 [[package]]
 name = "xcm-simulator"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#72d463fb00d7524fd0b7a0ba66f8bc03257bd95c"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#c9211527a90f053f9a58be4c1d6001ccfefbfd5f"
 dependencies = [
- "frame-support 38.0.0",
+ "frame-support 38.2.0",
  "frame-system 38.0.0",
  "parity-scale-codec",
  "paste",
@@ -18622,10 +18611,10 @@ dependencies = [
  "polkadot-runtime-parachains 17.0.1",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409)",
  "staging-xcm 14.2.0",
- "staging-xcm-builder 17.0.1",
+ "staging-xcm-builder 17.0.3",
  "staging-xcm-executor 17.0.0",
 ]
 
@@ -18688,7 +18677,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
  "synstructure 0.13.1",
 ]
 
@@ -18710,7 +18699,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -18730,7 +18719,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
  "synstructure 0.13.1",
 ]
 
@@ -18751,7 +18740,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -18773,7 +18762,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.93",
 ]
 
 [[package]]

--- a/test/suites/integration/bsp/onboard.test.ts
+++ b/test/suites/integration/bsp/onboard.test.ts
@@ -9,11 +9,11 @@ import {
 } from "../../../util";
 import { CAPACITY, MAX_STORAGE_CAPACITY } from "../../../util/bspNet/consts.ts";
 
-describeBspNet("BSPNet: Adding new BSPs", ({ before, createBspApi, createApi, it }) => {
-  let api: EnrichedBspApi;
+describeBspNet("BSPNet: Adding new BSPs", ({ before, createUserApi, createApi, it }) => {
+  let userApi: EnrichedBspApi;
 
   before(async () => {
-    api = await createBspApi();
+    userApi = await createUserApi();
   });
 
   it("New BSP can be created", async () => {
@@ -44,11 +44,14 @@ describeBspNet("BSPNet: Adding new BSPs", ({ before, createBspApi, createApi, it
 
       await it("is synced with current block", async () => {
         // Give some time to the BSP to catch up
-        await api.wait.bspCatchUpToChainTip(newApi);
+        await userApi.wait.bspCatchUpToChainTip(newApi);
 
         const syncHeight = (await newApi.rpc.chain.getHeader()).number.toNumber();
-        const currentHeight = (await api.rpc.chain.getHeader()).number.toNumber();
+        const currentHeight = (await userApi.rpc.chain.getHeader()).number.toNumber();
+        const syncHash = (await newApi.rpc.chain.getHeader()).hash.toString();
+        const currentHash = (await userApi.rpc.chain.getHeader()).hash.toString();
         strictEqual(syncHeight, currentHeight);
+        strictEqual(syncHash, currentHash);
       });
 
       await it("is listening on the correct P2P port", async () => {
@@ -65,7 +68,7 @@ describeBspNet("BSPNet: Adding new BSPs", ({ before, createBspApi, createApi, it
     await it("is peer of other nodes", async () => {
       // Give some time to nodes to connect between each other
       await sleep(500);
-      const peers = (await api.rpc.system.peers()).map(({ peerId }) => peerId.toString());
+      const peers = (await userApi.rpc.system.peers()).map(({ peerId }) => peerId.toString());
       strictEqual(peers.includes(peerId), true, `PeerId ${peerId} not found in ${peers}`);
     });
   });

--- a/test/suites/integration/bsp/storage-capacity.test.ts
+++ b/test/suites/integration/bsp/storage-capacity.test.ts
@@ -237,11 +237,11 @@ describeBspNet("BSPNet: Validating max storage", ({ before, it, createUserApi })
       maxStorageCapacity: MAX_STORAGE_CAPACITY,
       additionalArgs: ["--keystore-path=/keystore/bsp-two"]
     });
+    await userApi.assert.eventPresent("providers", "BspSignUpSuccess");
+
     const bspTwoApi = await BspNetTestApi.create(`ws://127.0.0.1:${rpcPort}`);
 
     await userApi.wait.bspCatchUpToChainTip(bspTwoApi);
-
-    await userApi.assert.eventPresent("providers", "BspSignUpSuccess");
 
     // stop other container
     await userApi.docker.pauseBspContainer("docker-sh-bsp-1");

--- a/test/suites/integration/bsp/submit-proofs.test.ts
+++ b/test/suites/integration/bsp/submit-proofs.test.ts
@@ -345,8 +345,8 @@ describeBspNet(
       await userApi.wait.bspCatchUpToChainTip(bspTwoApi);
       await userApi.wait.bspCatchUpToChainTip(bspThreeApi);
 
-      // And give some time to process proofs.
-      await sleep(3000);
+      // And give some time to process the latest blocks.
+      await sleep(1000);
 
       // There shouldn't be any pending volunteer transactions.
       await assert.rejects(

--- a/test/util/bspNet/waits.ts
+++ b/test/util/bspNet/waits.ts
@@ -314,7 +314,7 @@ export const waitForBspToCatchUpToChainTip = async (
     } catch {
       assert(
         i !== blockBuildingIterations,
-        `Failed to detect BSP catch up after ${(i * j * delay) / 1000}s`
+        `Failed to detect BSP catch up after ${(i * iterations * delay) / 1000}s`
       );
       // If they're still not in sync, build a block to trigger gossip between the nodes.
       await syncedApi.rpc.engine.createBlock(true, true);


### PR DESCRIPTION
In this PR:
1. Make Blockchain Service trigger proof submission catch up every 4 blocks (configurable) to further ensure always being up to date with proofs.
2. Solve race condition in integration tests where sometimes the BSP being awaited to catch up to chain tip, would get stuck in a previous block, never syncing until it is gossiped of a new block.
3. Solve race condition in `storage-delete.test.ts` where sometimes it generate a Forest proof before having processed the latest Forest changes.