### PR TITLE
fix: replace file ID from i32 to i64

### DIFF
--- a/client/indexer-db/src/models/bsp.rs
+++ b/client/indexer-db/src/models/bsp.rs
@@ -166,14 +166,14 @@ impl Bsp {
 #[diesel(table_name = bsp_file)]
 pub struct BspFile {
     pub bsp_id: i32,
-    pub file_id: i32,
+    pub file_id: i64,
 }
 
 impl BspFile {
     pub async fn create<'a>(
         conn: &mut DbConnection<'a>,
         bsp_id: i32,
-        file_id: i32,
+        file_id: i64,
     ) -> Result<(), diesel::result::Error> {
         diesel::insert_into(bsp_file::table)
             .values((bsp_file::bsp_id.eq(bsp_id), bsp_file::file_id.eq(file_id)))

--- a/client/indexer-db/src/models/file.rs
+++ b/client/indexer-db/src/models/file.rs
@@ -22,7 +22,7 @@ pub enum FileStorageRequestStep {
 #[diesel(table_name = file)]
 pub struct File {
     /// The ID of the file as stored in the database. For the runtime id, use `onchain_bsp_id`.
-    pub id: i32,
+    pub id: i64,
     pub account: Vec<u8>,
     pub file_key: Vec<u8>,
     pub bucket_id: i32,
@@ -41,7 +41,7 @@ pub struct File {
 #[diesel(belongs_to(File, foreign_key = file_id))]
 #[diesel(belongs_to(crate::models::PeerId, foreign_key = peer_id))]
 pub struct FilePeerId {
-    pub file_id: i32,
+    pub file_id: i64,
     pub peer_id: i32,
 }
 

--- a/client/indexer-db/src/schema.rs
+++ b/client/indexer-db/src/schema.rs
@@ -17,7 +17,7 @@ diesel::table! {
 diesel::table! {
     bsp_file (bsp_id, file_id) {
         bsp_id -> Int4,
-        file_id -> Int4,
+        file_id -> Int8,
     }
 }
 
@@ -45,7 +45,7 @@ diesel::table! {
 
 diesel::table! {
     file (id) {
-        id -> Int4,
+        id -> Int8,
         account -> Bytea,
         file_key -> Bytea,
         bucket_id -> Int4,
@@ -60,7 +60,7 @@ diesel::table! {
 
 diesel::table! {
     file_peer_id (file_id, peer_id) {
-        file_id -> Int4,
+        file_id -> Int8,
         peer_id -> Int4,
     }
 }


### PR DESCRIPTION
Replacing file ID from i32 type to i64 type to allow producing IDs for a bigger number of files. Instead of limited the database to containing 2 billions files we can now have a lot more.