### PR TITLE
test: MSP move bucket reject on max capacity exceeded

### DIFF
--- a/docker/fullnet-base-template.yml
+++ b/docker/fullnet-base-template.yml
@@ -55,35 +55,6 @@ services:
         "--base-path=/data",
         "--msp-charging-period=12",
       ]
-  sh-msp-2:
-    image: storage-hub:local
-    container_name: docker-sh-msp-2
-    platform: linux/amd64
-    ports:
-      - "9778:9944"
-      - "30556:30350"
-    volumes:
-      - ./dev-keystores/msp-two:/keystore:rw
-    command:
-      [
-        "--dev",
-        "--provider",
-        "--provider-type=msp",
-        "--max-storage-capacity=4294967295",
-        "--jump-capacity=1073741824",
-        "--name=sh-msp-2",
-        "--no-hardware-benchmarks",
-        "--unsafe-rpc-external",
-        "--rpc-methods=unsafe",
-        "--port=30350",
-        "--rpc-cors=all",
-        "--node-key=${NODE_KEY}",
-        "--bootnodes=/ip4/${BSP_IP:-default_bsp_ip}/tcp/30350/p2p/${BSP_PEER_ID:-default_bsp_peer_id}",
-        "--keystore-path=/keystore",
-        "--sealing=manual",
-        "--base-path=/data",
-        "--msp-charging-period=12",
-      ]
   sh-user:
     image: storage-hub:local
     platform: linux/amd64
@@ -111,7 +82,6 @@ services:
         "--sealing=manual",
         "--base-path=/data",
       ]
-
   sh-postgres:
     image: postgres:15
     container_name: docker-sh-postgres-1

--- a/node/src/tasks/msp_move_bucket.rs
+++ b/node/src/tasks/msp_move_bucket.rs
@@ -131,12 +131,6 @@ where
             },
         );
 
-        info!(
-            target: LOG_TARGET,
-            "MSP: accepting move bucket request for bucket {:?}",
-            bucket_id.as_ref(),
-        );
-
         self.storage_hub_handler
             .blockchain
             .send_extrinsic(call, Tip::from(0))

--- a/test/suites/integration/msp/debt-collection.test.ts
+++ b/test/suites/integration/msp/debt-collection.test.ts
@@ -4,15 +4,17 @@ import { DUMMY_MSP_ID, MSP_CHARGING_PERIOD } from "../../../util/bspNet/consts";
 import type { H256 } from "@polkadot/types/interfaces";
 import type { Option } from "@polkadot/types";
 
-describeMspNet("Single MSP collecting debt", ({ before, createMsp1Api, it, createUserApi }) => {
+describeMspNet("Single MSP collecting debt", ({ before, createMspApi, it, createUserApi }) => {
   let userApi: EnrichedBspApi;
   let mspApi: EnrichedBspApi;
   let bucketId: H256;
 
   before(async () => {
     userApi = await createUserApi();
-    const maybeMspApi = await createMsp1Api();
-    assert(maybeMspApi, "MSP API not available");
+    const maybeMspApi = await createMspApi();
+    if (!maybeMspApi) {
+      throw new Error("Failed to create MSP API");
+    }
     mspApi = maybeMspApi;
   });
 

--- a/test/suites/integration/msp/reject-request.test.ts
+++ b/test/suites/integration/msp/reject-request.test.ts
@@ -4,15 +4,16 @@ import { describeMspNet, shUser, sleep, type EnrichedBspApi } from "../../../uti
 describeMspNet(
   "Single MSP rejecting storage request",
   { initialised: true },
-  ({ before, createMsp1Api, it, createUserApi, getLaunchResponse }) => {
+  ({ before, createMspApi, it, createUserApi, getLaunchResponse }) => {
     let userApi: EnrichedBspApi;
     let mspApi: EnrichedBspApi;
 
     before(async () => {
       userApi = await createUserApi();
-      const maybeMspApi = await createMsp1Api();
-
-      assert(maybeMspApi, "MSP API not available");
+      const maybeMspApi = await createMspApi();
+      if (!maybeMspApi) {
+        throw new Error("Failed to create MSP API");
+      }
       mspApi = maybeMspApi;
     });
 

--- a/test/suites/integration/msp/respond-multi-requests.test.ts
+++ b/test/suites/integration/msp/respond-multi-requests.test.ts
@@ -2,8 +2,9 @@ import assert, { strictEqual } from "node:assert";
 import { describeMspNet, shUser, waitFor, type EnrichedBspApi } from "../../../util";
 
 describeMspNet(
-  "Single MSP accepting multiple storage requests",
-  ({ before, createMsp1Api, it, createUserApi }) => {
+  "MSP responds to multiple storage requests",
+  { initialised: false, indexer: true },
+  ({ before, createMspApi, it, createUserApi }) => {
     let userApi: EnrichedBspApi;
     let mspApi: EnrichedBspApi;
     const source = ["res/whatsup.jpg", "res/adolphus.jpg", "res/smile.jpg"];
@@ -13,8 +14,10 @@ describeMspNet(
 
     before(async () => {
       userApi = await createUserApi();
-      const maybeMspApi = await createMsp1Api();
-      assert(maybeMspApi, "MSP API not available");
+      const maybeMspApi = await createMspApi();
+      if (!maybeMspApi) {
+        throw new Error("Failed to create MSP API");
+      }
       mspApi = maybeMspApi;
     });
 

--- a/test/suites/integration/msp/respond-single-request.test.ts
+++ b/test/suites/integration/msp/respond-single-request.test.ts
@@ -2,16 +2,18 @@ import assert, { strictEqual } from "node:assert";
 import { describeMspNet, shUser, sleep, type EnrichedBspApi } from "../../../util";
 
 describeMspNet(
-  "Single MSP accepting storage request",
-  { networkConfig: "standard" },
-  ({ before, createMsp1Api, it, createUserApi }) => {
+  "MSP responds to single storage request",
+  { initialised: false, indexer: true },
+  ({ before, createMspApi, it, createUserApi }) => {
     let userApi: EnrichedBspApi;
     let mspApi: EnrichedBspApi;
 
     before(async () => {
       userApi = await createUserApi();
-      const maybeMspApi = await createMsp1Api();
-      assert(maybeMspApi, "MSP API not available");
+      const maybeMspApi = await createMspApi();
+      if (!maybeMspApi) {
+        throw new Error("Failed to create MSP API");
+      }
       mspApi = maybeMspApi;
     });
 

--- a/test/suites/integration/msp/stop-storing-bucket.test.ts
+++ b/test/suites/integration/msp/stop-storing-bucket.test.ts
@@ -4,14 +4,14 @@ import type { H256 } from "@polkadot/types/interfaces";
 
 describeMspNet(
   "MSP deleting bucket when stop storing bucket is called",
-  ({ before, createMsp1Api, it, createUserApi }) => {
+  ({ before, createMspApi, it, createUserApi }) => {
     let userApi: EnrichedBspApi;
     let mspApi: EnrichedBspApi;
     let bucketId: H256;
 
     before(async () => {
       userApi = await createUserApi();
-      const maybeMspApi = await createMsp1Api();
+      const maybeMspApi = await createMspApi();
       assert(maybeMspApi, "MSP API not available");
       mspApi = maybeMspApi;
     });

--- a/test/util/bspNet/helpers.ts
+++ b/test/util/bspNet/helpers.ts
@@ -152,6 +152,35 @@ export const forceSignupBsp = async (options: {
   return Object.assign(bspId, blockResults);
 };
 
+export const forceSignupMsp = async (options: {
+  api: EnrichedBspApi;
+  who: string | Uint8Array;
+  mspId?: string;
+  capacity?: number;
+  multiaddress: string;
+  pricePerGigaUnitOfDataPerBlock?: number;
+  commitment?: string;
+  maxDataLimit?: number;
+  paymentAccount?: string;
+}) => {
+  return options.api.block.seal({
+    calls: [
+      options.api.tx.sudo.sudo(
+        options.api.tx.providers.forceMspSignUp(
+          options.who,
+          options.mspId ?? options.who,
+          options.capacity ?? 4294967295,
+          [options.multiaddress],
+          options.pricePerGigaUnitOfDataPerBlock ?? 100 * 1024 * 1024,
+          options.commitment ?? "Terms of Service...",
+          options.maxDataLimit ?? 9999999,
+          options.paymentAccount ?? options.who
+        )
+      )
+    ]
+  });
+};
+
 export const createCheckBucket = async (api: EnrichedBspApi, bucketName: string) => {
   const newBucketEventEvent = await api.createBucket(bucketName);
   const newBucketEventDataBlob =

--- a/test/util/bspNet/testrunner.ts
+++ b/test/util/bspNet/testrunner.ts
@@ -136,8 +136,7 @@ export async function describeMspNet<
     describeFunc(`FullNet: ${title} (${fullNetConfig.rocksdb ? "RocksDB" : "MemoryDB"})`, () => {
       let userApiPromise: Promise<EnrichedBspApi>;
       let bspApiPromise: Promise<EnrichedBspApi>;
-      let msp1ApiPromise: Promise<EnrichedBspApi>;
-      let msp2ApiPromise: Promise<EnrichedBspApi>;
+      let mspApiPromise: Promise<EnrichedBspApi>;
       let responseListenerPromise: ReturnType<typeof NetworkLauncher.create>;
 
       before(async () => {
@@ -155,18 +154,12 @@ export async function describeMspNet<
 
         userApiPromise = BspNetTestApi.create(`ws://127.0.0.1:${ShConsts.NODE_INFOS.user.port}`);
         bspApiPromise = BspNetTestApi.create(`ws://127.0.0.1:${ShConsts.NODE_INFOS.bsp.port}`);
-        msp1ApiPromise = BspNetTestApi.create(`ws://127.0.0.1:${ShConsts.NODE_INFOS.msp1.port}`);
-        msp2ApiPromise = BspNetTestApi.create(`ws://127.0.0.1:${ShConsts.NODE_INFOS.msp2.port}`);
+        mspApiPromise = BspNetTestApi.create(`ws://127.0.0.1:${ShConsts.NODE_INFOS.msp1.port}`);
       });
 
       after(async () => {
         await cleardownTest({
-          api: [
-            await userApiPromise,
-            await bspApiPromise,
-            await msp1ApiPromise,
-            await msp2ApiPromise
-          ],
+          api: [await userApiPromise, await bspApiPromise, await mspApiPromise],
           keepNetworkAlive: options?.keepAlive
         });
 
@@ -188,8 +181,7 @@ export async function describeMspNet<
         it,
         createUserApi: () => userApiPromise,
         createBspApi: () => bspApiPromise,
-        createMsp1Api: () => msp1ApiPromise,
-        createMsp2Api: () => msp2ApiPromise,
+        createMspApi: () => mspApiPromise,
         createApi: (endpoint) => BspNetTestApi.create(endpoint),
         createSqlClient: () => createSqlClient(),
         bspNetConfig: fullNetConfig,

--- a/test/util/bspNet/types.ts
+++ b/test/util/bspNet/types.ts
@@ -236,13 +236,7 @@ export type FullNetContext = {
    * Creates and returns a connected API instance for the first MSP node.
    * @returns A promise that resolves to an enriched api instance for MSP operations.
    */
-  createMsp1Api: () => ReturnType<typeof BspNetTestApi.create> | undefined;
-
-  /**
-   * Creates and returns a connected API instance for the second MSP node.
-   * @returns A promise that resolves to an enriched api instance for MSP operations.
-   */
-  createMsp2Api: () => ReturnType<typeof BspNetTestApi.create> | undefined;
+  createMspApi: () => ReturnType<typeof BspNetTestApi.create> | undefined;
 
   /**
    * Creates and returns a connected API instance for a BSP node.
@@ -337,6 +331,8 @@ export type TestOptions = {
   extrinsicRetryTimeout?: number;
   /** If true, runs launched userNode has attached indexer service enabled. */
   indexer?: boolean;
+  /** Set a custom max storage capacity for MSP2 */
+  msp2MaxStorageCapacity?: number;
 };
 
 /**


### PR DESCRIPTION
In order to test proper rejection of move bucket request on low capacity, a refactor and addition of onboardMsp (similar to onboardBsp) was needed.