### PR TITLE
style: :art: remove unneeded generics in pallet events

### DIFF
--- a/pallets/payment-streams/src/benchmarking.rs
+++ b/pallets/payment-streams/src/benchmarking.rs
@@ -186,7 +186,7 @@ mod benchmarks {
         /*********** Post-benchmark checks: ***********/
         // Verify the fixed-rate payment stream creation event was emitted.
         let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::FixedRatePaymentStreamCreated {
+            <T as pallet::Config>::RuntimeEvent::from(Event::FixedRatePaymentStreamCreated {
                 user_account: user_account.clone(),
                 provider_id,
                 rate: rate.into(),
@@ -273,18 +273,17 @@ mod benchmarks {
         let amount_charged: BalanceOf<T> = initial_rate_as_balance
             + (amount_provided_as_balance * CurrentPricePerGigaUnitPerTick::<T>::get()
                 / GIGAUNIT.into());
-        let charge_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::PaymentStreamCharged {
-                user_account: user_account.clone(),
-                provider_id,
-                amount: amount_charged,
-                last_tick_charged: frame_system::Pallet::<T>::block_number(),
-                charged_at_tick: frame_system::Pallet::<T>::block_number(),
-            });
+        let charge_event = <T as pallet::Config>::RuntimeEvent::from(Event::PaymentStreamCharged {
+            user_account: user_account.clone(),
+            provider_id,
+            amount: amount_charged,
+            last_tick_charged: frame_system::Pallet::<T>::block_number(),
+            charged_at_tick: frame_system::Pallet::<T>::block_number(),
+        });
         frame_system::Pallet::<T>::assert_has_event(charge_event.into());
         // Verify the fixed-rate payment stream update event was emitted.
         let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::FixedRatePaymentStreamUpdated {
+            <T as pallet::Config>::RuntimeEvent::from(Event::FixedRatePaymentStreamUpdated {
                 user_account: user_account.clone(),
                 provider_id,
                 new_rate: new_rate.into(),
@@ -347,18 +346,17 @@ mod benchmarks {
 
         /*********** Post-benchmark checks: ***********/
         // Verify that the charge event was emitted.
-        let charge_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::PaymentStreamCharged {
-                user_account: user_account.clone(),
-                provider_id,
-                amount: rate.into(),
-                last_tick_charged: frame_system::Pallet::<T>::block_number(),
-                charged_at_tick: frame_system::Pallet::<T>::block_number(),
-            });
+        let charge_event = <T as pallet::Config>::RuntimeEvent::from(Event::PaymentStreamCharged {
+            user_account: user_account.clone(),
+            provider_id,
+            amount: rate.into(),
+            last_tick_charged: frame_system::Pallet::<T>::block_number(),
+            charged_at_tick: frame_system::Pallet::<T>::block_number(),
+        });
         frame_system::Pallet::<T>::assert_has_event(charge_event.into());
         // Verify the fixed-rate payment stream deletion event was emitted.
         let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::FixedRatePaymentStreamDeleted {
+            <T as pallet::Config>::RuntimeEvent::from(Event::FixedRatePaymentStreamDeleted {
                 user_account: user_account.clone(),
                 provider_id,
             });
@@ -403,13 +401,12 @@ mod benchmarks {
 
         /*********** Post-benchmark checks: ***********/
         // Verify the dynamic-rate payment stream creation event was emitted.
-        let expected_event = <T as pallet::Config>::RuntimeEvent::from(
-            Event::<T>::DynamicRatePaymentStreamCreated {
+        let expected_event =
+            <T as pallet::Config>::RuntimeEvent::from(Event::DynamicRatePaymentStreamCreated {
                 user_account: user_account.clone(),
                 provider_id,
                 amount_provided: amount_provided.into(),
-            },
-        );
+            });
         frame_system::Pallet::<T>::assert_last_event(expected_event.into());
 
         // Verify that the newly created payment stream exists in storage
@@ -587,23 +584,21 @@ mod benchmarks {
         let amount_charged: BalanceOf<T> = rate_as_balance
             + (amount_provided_as_balance * CurrentPricePerGigaUnitPerTick::<T>::get()
                 / GIGAUNIT.into());
-        let charge_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::PaymentStreamCharged {
-                user_account: user_account.clone(),
-                provider_id,
-                amount: amount_charged,
-                last_tick_charged: frame_system::Pallet::<T>::block_number(),
-                charged_at_tick: frame_system::Pallet::<T>::block_number(),
-            });
+        let charge_event = <T as pallet::Config>::RuntimeEvent::from(Event::PaymentStreamCharged {
+            user_account: user_account.clone(),
+            provider_id,
+            amount: amount_charged,
+            last_tick_charged: frame_system::Pallet::<T>::block_number(),
+            charged_at_tick: frame_system::Pallet::<T>::block_number(),
+        });
         frame_system::Pallet::<T>::assert_has_event(charge_event.into());
 
         // Verify the dynamic-rate payment stream deletion event was emitted.
-        let expected_event = <T as pallet::Config>::RuntimeEvent::from(
-            Event::<T>::DynamicRatePaymentStreamDeleted {
+        let expected_event =
+            <T as pallet::Config>::RuntimeEvent::from(Event::DynamicRatePaymentStreamDeleted {
                 user_account: user_account.clone(),
                 provider_id,
-            },
-        );
+            });
         frame_system::Pallet::<T>::assert_last_event(expected_event.into());
 
         // Verify that the newly created payment stream was correctly deleted
@@ -676,14 +671,13 @@ mod benchmarks {
         let amount_charged: BalanceOf<T> = rate_as_balance
             + (amount_provided_as_balance * CurrentPricePerGigaUnitPerTick::<T>::get()
                 / GIGAUNIT.into());
-        let charge_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::PaymentStreamCharged {
-                user_account: user_account.clone(),
-                provider_id,
-                amount: amount_charged,
-                last_tick_charged: frame_system::Pallet::<T>::block_number(),
-                charged_at_tick: frame_system::Pallet::<T>::block_number(),
-            });
+        let charge_event = <T as pallet::Config>::RuntimeEvent::from(Event::PaymentStreamCharged {
+            user_account: user_account.clone(),
+            provider_id,
+            amount: amount_charged,
+            last_tick_charged: frame_system::Pallet::<T>::block_number(),
+            charged_at_tick: frame_system::Pallet::<T>::block_number(),
+        });
         frame_system::Pallet::<T>::assert_has_event(charge_event.into());
 
         Ok(())
@@ -766,7 +760,7 @@ mod benchmarks {
                 / GIGAUNIT.into());
         for user_account in user_accounts.iter() {
             let charge_event =
-                <T as pallet::Config>::RuntimeEvent::from(Event::<T>::PaymentStreamCharged {
+                <T as pallet::Config>::RuntimeEvent::from(Event::PaymentStreamCharged {
                     user_account: user_account.clone(),
                     provider_id,
                     amount: amount_charged,
@@ -876,7 +870,7 @@ mod benchmarks {
         /*********** Post-benchmark checks: ***********/
         // Verify that the user paid all debts event was emitted for the user
         let user_paid_debts_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::UserPaidAllDebts {
+            <T as pallet::Config>::RuntimeEvent::from(Event::UserPaidAllDebts {
                 who: user_account.clone(),
             });
         frame_system::Pallet::<T>::assert_has_event(user_paid_debts_event.into());
@@ -919,10 +913,9 @@ mod benchmarks {
         assert!(!UsersWithoutFunds::<T>::contains_key(user_account.clone()));
 
         // Verify that the `UserSolvent` event was emitted
-        let user_solvent_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::UserSolvent {
-                who: user_account.clone(),
-            });
+        let user_solvent_event = <T as pallet::Config>::RuntimeEvent::from(Event::UserSolvent {
+            who: user_account.clone(),
+        });
         frame_system::Pallet::<T>::assert_has_event(user_solvent_event.into());
 
         Ok(())

--- a/pallets/payment-streams/src/lib.rs
+++ b/pallets/payment-streams/src/lib.rs
@@ -466,7 +466,7 @@ pub mod pallet {
             Self::do_create_fixed_rate_payment_stream(&provider_id, &user_account, rate)?;
 
             // Emit the corresponding event
-            Self::deposit_event(Event::<T>::FixedRatePaymentStreamCreated {
+            Self::deposit_event(Event::FixedRatePaymentStreamCreated {
                 user_account,
                 provider_id: provider_id,
                 rate,
@@ -507,7 +507,7 @@ pub mod pallet {
             Self::do_update_fixed_rate_payment_stream(&provider_id, &user_account, new_rate)?;
 
             // Emit the corresponding event
-            Self::deposit_event(Event::<T>::FixedRatePaymentStreamUpdated {
+            Self::deposit_event(Event::FixedRatePaymentStreamUpdated {
                 user_account,
                 provider_id: provider_id,
                 new_rate,
@@ -546,7 +546,7 @@ pub mod pallet {
             Self::do_delete_fixed_rate_payment_stream(&provider_id, &user_account)?;
 
             // Emit the corresponding event
-            Self::deposit_event(Event::<T>::FixedRatePaymentStreamDeleted {
+            Self::deposit_event(Event::FixedRatePaymentStreamDeleted {
                 user_account,
                 provider_id: provider_id,
             });
@@ -592,7 +592,7 @@ pub mod pallet {
             )?;
 
             // Emit the corresponding event
-            Self::deposit_event(Event::<T>::DynamicRatePaymentStreamCreated {
+            Self::deposit_event(Event::DynamicRatePaymentStreamCreated {
                 user_account,
                 provider_id: provider_id,
                 amount_provided,
@@ -637,7 +637,7 @@ pub mod pallet {
             )?;
 
             // Emit the corresponding event
-            Self::deposit_event(Event::<T>::DynamicRatePaymentStreamUpdated {
+            Self::deposit_event(Event::DynamicRatePaymentStreamUpdated {
                 user_account,
                 provider_id,
                 new_amount_provided,
@@ -676,7 +676,7 @@ pub mod pallet {
             Self::do_delete_dynamic_rate_payment_stream(&provider_id, &user_account)?;
 
             // Emit the corresponding event
-            Self::deposit_event(Event::<T>::DynamicRatePaymentStreamDeleted {
+            Self::deposit_event(Event::DynamicRatePaymentStreamDeleted {
                 user_account,
                 provider_id,
             });
@@ -735,7 +735,7 @@ pub mod pallet {
             let charged_at_tick = Self::get_current_tick();
 
             // Emit the corresponding event (we always emit it even if the charged amount was 0)
-            Self::deposit_event(Event::<T>::PaymentStreamCharged {
+            Self::deposit_event(Event::PaymentStreamCharged {
                 user_account,
                 provider_id: provider_id,
                 amount: amount_charged,
@@ -798,7 +798,7 @@ pub mod pallet {
             let charged_at_tick = Self::get_current_tick();
 
             // Emit the corresponding event (we always emit it even if the charged amount was 0)
-            Self::deposit_event(Event::<T>::UsersCharged {
+            Self::deposit_event(Event::UsersCharged {
                 user_accounts,
                 provider_id,
                 charged_at_tick,
@@ -843,9 +843,9 @@ pub mod pallet {
 
             // Emit the corresponding event
             if fully_paid {
-                Self::deposit_event(Event::<T>::UserPaidAllDebts { who: user_account });
+                Self::deposit_event(Event::UserPaidAllDebts { who: user_account });
             } else {
-                Self::deposit_event(Event::<T>::UserPaidSomeDebts { who: user_account });
+                Self::deposit_event(Event::UserPaidSomeDebts { who: user_account });
             }
 
             // Return a successful DispatchResultWithPostInfo
@@ -876,7 +876,7 @@ pub mod pallet {
             Self::do_clear_insolvent_flag(&user_account)?;
 
             // Emit the corresponding event
-            Self::deposit_event(Event::<T>::UserSolvent { who: user_account });
+            Self::deposit_event(Event::UserSolvent { who: user_account });
 
             // Return a successful DispatchResultWithPostInfo
             Ok(().into())

--- a/pallets/payment-streams/src/utils.rs
+++ b/pallets/payment-streams/src/utils.rs
@@ -203,7 +203,7 @@ where
             let charged_at_tick = Self::get_current_tick();
 
             // We emit a payment charged event only if the user had to pay before the payment stream could be updated
-            Self::deposit_event(Event::<T>::PaymentStreamCharged {
+            Self::deposit_event(Event::PaymentStreamCharged {
                 user_account: user_account.clone(),
                 provider_id: *provider_id,
                 amount: amount_charged,
@@ -262,7 +262,7 @@ where
                 let charged_at_tick = Self::get_current_tick();
 
                 // We emit a payment charged event only if the user had to pay before being able to delete the payment stream
-                Self::deposit_event(Event::<T>::PaymentStreamCharged {
+                Self::deposit_event(Event::PaymentStreamCharged {
                     user_account: user_account.clone(),
                     provider_id: *provider_id,
                     amount: amount_charged,
@@ -465,7 +465,7 @@ where
             let charged_at_tick = Self::get_current_tick();
 
             // We emit a payment charged event only if the user had to pay before the payment stream could be updated
-            Self::deposit_event(Event::<T>::PaymentStreamCharged {
+            Self::deposit_event(Event::PaymentStreamCharged {
                 user_account: user_account.clone(),
                 provider_id: *provider_id,
                 amount: amount_charged,
@@ -530,7 +530,7 @@ where
                 let charged_at_tick = Self::get_current_tick();
 
                 // We emit a payment charged event only if the user had to pay before being able to delete the payment stream
-                Self::deposit_event(Event::<T>::PaymentStreamCharged {
+                Self::deposit_event(Event::PaymentStreamCharged {
                     user_account: user_account.clone(),
                     provider_id: *provider_id,
                     amount: amount_charged,
@@ -948,7 +948,7 @@ where
                 Self::do_charge_payment_streams(provider_id, user_account)?;
 
             if amount_charged > Zero::zero() {
-                Self::deposit_event(Event::<T>::PaymentStreamCharged {
+                Self::deposit_event(Event::PaymentStreamCharged {
                     user_account: user_account.clone(),
                     provider_id: *provider_id,
                     amount: amount_charged,
@@ -1213,7 +1213,7 @@ where
         // If it's not greater (which should never happen) nor equal, it has to be exactly one less than the tick to process. If it's not,
         // there's an inconsistency in the tick processing and we emit an event to signal it.
         else if last_processed_tick != tick_to_process.saturating_sub(One::one()) {
-            Self::deposit_event(Event::<T>::InconsistentTickProcessing {
+            Self::deposit_event(Event::InconsistentTickProcessing {
                 last_processed_tick,
                 tick_to_process,
             });
@@ -1241,7 +1241,7 @@ where
                     provider_info.last_chargeable_tick = n;
                     provider_info.price_index = accumulated_price_index;
                 });
-                Self::deposit_event(Event::<T>::LastChargeableInfoUpdated {
+                Self::deposit_event(Event::LastChargeableInfoUpdated {
                     provider_id: *provider_id,
                     last_chargeable_tick: n,
                     last_chargeable_price_index: accumulated_price_index,
@@ -1466,12 +1466,12 @@ where
         // pay it for the user using the payment streams' deposits.
         if !UsersWithoutFunds::<T>::contains_key(user_account) {
             UsersWithoutFunds::<T>::insert(user_account, frame_system::Pallet::<T>::block_number());
-            Self::deposit_event(Event::<T>::UserWithoutFunds {
+            Self::deposit_event(Event::UserWithoutFunds {
                 who: user_account.clone(),
             });
         }
         if user_payment_streams_count == 0 {
-            Self::deposit_event(Event::<T>::UserPaidAllDebts {
+            Self::deposit_event(Event::UserPaidAllDebts {
                 who: user_account.clone(),
             });
         }
@@ -1498,7 +1498,7 @@ impl<T: pallet::Config> PaymentStreamsInterface for pallet::Pallet<T> {
         Self::do_create_fixed_rate_payment_stream(provider_id, user_account, rate)?;
 
         // Emit the corresponding event
-        Self::deposit_event(Event::<T>::FixedRatePaymentStreamCreated {
+        Self::deposit_event(Event::FixedRatePaymentStreamCreated {
             user_account: user_account.clone(),
             provider_id: *provider_id,
             rate,
@@ -1517,7 +1517,7 @@ impl<T: pallet::Config> PaymentStreamsInterface for pallet::Pallet<T> {
         Self::do_update_fixed_rate_payment_stream(provider_id, user_account, new_rate)?;
 
         // Emit the corresponding event
-        Self::deposit_event(Event::<T>::FixedRatePaymentStreamUpdated {
+        Self::deposit_event(Event::FixedRatePaymentStreamUpdated {
             user_account: user_account.clone(),
             provider_id: *provider_id,
             new_rate,
@@ -1535,7 +1535,7 @@ impl<T: pallet::Config> PaymentStreamsInterface for pallet::Pallet<T> {
         Self::do_delete_fixed_rate_payment_stream(provider_id, user_account)?;
 
         // Emit the corresponding event
-        Self::deposit_event(Event::<T>::FixedRatePaymentStreamDeleted {
+        Self::deposit_event(Event::FixedRatePaymentStreamDeleted {
             user_account: user_account.clone(),
             provider_id: *provider_id,
         });
@@ -1575,7 +1575,7 @@ impl<T: pallet::Config> PaymentStreamsInterface for pallet::Pallet<T> {
         Self::do_create_dynamic_rate_payment_stream(provider_id, user_account, *amount_provided)?;
 
         // Emit the corresponding event
-        Self::deposit_event(Event::<T>::DynamicRatePaymentStreamCreated {
+        Self::deposit_event(Event::DynamicRatePaymentStreamCreated {
             user_account: user_account.clone(),
             provider_id: *provider_id,
             amount_provided: *amount_provided,
@@ -1598,7 +1598,7 @@ impl<T: pallet::Config> PaymentStreamsInterface for pallet::Pallet<T> {
         )?;
 
         // Emit the corresponding event
-        Self::deposit_event(Event::<T>::DynamicRatePaymentStreamUpdated {
+        Self::deposit_event(Event::DynamicRatePaymentStreamUpdated {
             user_account: user_account.clone(),
             provider_id: *provider_id,
             new_amount_provided: *new_amount_provided,
@@ -1616,7 +1616,7 @@ impl<T: pallet::Config> PaymentStreamsInterface for pallet::Pallet<T> {
         Self::do_delete_dynamic_rate_payment_stream(&provider_id, &user_account)?;
 
         // Emit the corresponding event
-        Self::deposit_event(Event::<T>::DynamicRatePaymentStreamDeleted {
+        Self::deposit_event(Event::DynamicRatePaymentStreamDeleted {
             user_account: user_account.clone(),
             provider_id: *provider_id,
         });

--- a/pallets/proofs-dealer/src/benchmarking.rs
+++ b/pallets/proofs-dealer/src/benchmarking.rs
@@ -84,7 +84,7 @@ mod benchmarks {
         Pallet::challenge(RawOrigin::Signed(caller.clone()), file_key);
 
         // Verify the challenge event was emitted.
-        let expected_event = <T as pallet::Config>::RuntimeEvent::from(Event::<T>::NewChallenge {
+        let expected_event = <T as pallet::Config>::RuntimeEvent::from(Event::NewChallenge {
             who: caller,
             key_challenged: file_key,
         });

--- a/pallets/providers/src/benchmarking.rs
+++ b/pallets/providers/src/benchmarking.rs
@@ -110,7 +110,7 @@ mod benchmarks {
         /*********** Post-benchmark checks: ***********/
         // Verify that the event of the MSP requesting to sign up was emitted
         let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::MspRequestSignUpSuccess {
+            <T as pallet::Config>::RuntimeEvent::from(Event::MspRequestSignUpSuccess {
                 who: user_account.clone(),
                 capacity: capacity.into(),
                 multiaddresses: multiaddresses.clone(),
@@ -189,7 +189,7 @@ mod benchmarks {
         /*********** Post-benchmark checks: ***********/
         // Verify that the event of the BSP requesting to sign up was emitted
         let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::BspRequestSignUpSuccess {
+            <T as pallet::Config>::RuntimeEvent::from(Event::BspRequestSignUpSuccess {
                 who: user_account.clone(),
                 capacity: capacity.into(),
                 multiaddresses: multiaddresses.clone(),
@@ -266,7 +266,7 @@ mod benchmarks {
 
         // Verify that the event of the BSP requesting to sign up was emitted
         let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::BspRequestSignUpSuccess {
+            <T as pallet::Config>::RuntimeEvent::from(Event::BspRequestSignUpSuccess {
                 who: user_account.clone(),
                 capacity: capacity.into(),
                 multiaddresses: multiaddresses.clone(),
@@ -287,14 +287,13 @@ mod benchmarks {
 
         /*********** Post-benchmark checks: ***********/
         // Verify that the event of the sign up confirmation was emitted
-        let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::BspSignUpSuccess {
-                who: user_account.clone(),
-                bsp_id: AccountIdToBackupStorageProviderId::<T>::get(&user_account).unwrap(),
-                capacity: capacity.into(),
-                multiaddresses: multiaddresses.clone(),
-                root: T::DefaultMerkleRoot::get(),
-            });
+        let expected_event = <T as pallet::Config>::RuntimeEvent::from(Event::BspSignUpSuccess {
+            who: user_account.clone(),
+            bsp_id: AccountIdToBackupStorageProviderId::<T>::get(&user_account).unwrap(),
+            capacity: capacity.into(),
+            multiaddresses: multiaddresses.clone(),
+            root: T::DefaultMerkleRoot::get(),
+        });
         frame_system::Pallet::<T>::assert_last_event(expected_event.into());
 
         // Verify that the BSP is now in the providers' storage
@@ -356,7 +355,7 @@ mod benchmarks {
 
         // Verify that the event of the MSP requesting to sign up was emitted
         let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::MspRequestSignUpSuccess {
+            <T as pallet::Config>::RuntimeEvent::from(Event::MspRequestSignUpSuccess {
                 who: user_account.clone(),
                 capacity: 100000u32.into(),
                 multiaddresses: multiaddresses.clone(),
@@ -386,14 +385,13 @@ mod benchmarks {
             id: value_prop.derive_id(),
             value_prop: value_prop.clone(),
         };
-        let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::MspSignUpSuccess {
-                who: user_account.clone(),
-                msp_id: AccountIdToMainStorageProviderId::<T>::get(&user_account).unwrap(),
-                capacity: 100000u32.into(),
-                multiaddresses: multiaddresses.clone(),
-                value_prop: value_prop_with_id,
-            });
+        let expected_event = <T as pallet::Config>::RuntimeEvent::from(Event::MspSignUpSuccess {
+            who: user_account.clone(),
+            msp_id: AccountIdToMainStorageProviderId::<T>::get(&user_account).unwrap(),
+            capacity: 100000u32.into(),
+            multiaddresses: multiaddresses.clone(),
+            value_prop: value_prop_with_id,
+        });
         frame_system::Pallet::<T>::assert_last_event(expected_event.into());
 
         // Verify that the MSP is now in the providers' storage
@@ -448,7 +446,7 @@ mod benchmarks {
 
         // Verify that the event of the BSP requesting to sign up was emitted
         let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::BspRequestSignUpSuccess {
+            <T as pallet::Config>::RuntimeEvent::from(Event::BspRequestSignUpSuccess {
                 who: user_account.clone(),
                 capacity: capacity.into(),
                 multiaddresses: multiaddresses.clone(),
@@ -462,7 +460,7 @@ mod benchmarks {
         /*********** Post-benchmark checks: ***********/
         // Verify that the event of the sign up cancellation was emitted
         let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::SignUpRequestCanceled {
+            <T as pallet::Config>::RuntimeEvent::from(Event::SignUpRequestCanceled {
                 who: user_account.clone(),
             });
         frame_system::Pallet::<T>::assert_last_event(expected_event.into());
@@ -532,7 +530,7 @@ mod benchmarks {
 
         // Verify that the event of the MSP requesting to sign up was emitted
         let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::MspRequestSignUpSuccess {
+            <T as pallet::Config>::RuntimeEvent::from(Event::MspRequestSignUpSuccess {
                 who: user_account.clone(),
                 capacity: 100000u32.into(),
                 multiaddresses: multiaddresses.clone(),
@@ -562,11 +560,10 @@ mod benchmarks {
 
         /*********** Post-benchmark checks: ***********/
         // Verify that the event of the MSP sign off was emitted
-        let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::MspSignOffSuccess {
-                who: user_account.clone(),
-                msp_id,
-            });
+        let expected_event = <T as pallet::Config>::RuntimeEvent::from(Event::MspSignOffSuccess {
+            who: user_account.clone(),
+            msp_id,
+        });
         frame_system::Pallet::<T>::assert_last_event(expected_event.into());
 
         // Verify that the MSP was removed from the providers' storage
@@ -620,7 +617,7 @@ mod benchmarks {
 
         // Verify that the event of the BSP requesting to sign up was emitted
         let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::BspRequestSignUpSuccess {
+            <T as pallet::Config>::RuntimeEvent::from(Event::BspRequestSignUpSuccess {
                 who: user_account.clone(),
                 capacity: capacity.into(),
                 multiaddresses: multiaddresses.clone(),
@@ -656,11 +653,10 @@ mod benchmarks {
 
         /*********** Post-benchmark checks: ***********/
         // Verify that the event of the BSP sign off was emitted
-        let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::BspSignOffSuccess {
-                who: user_account.clone(),
-                bsp_id,
-            });
+        let expected_event = <T as pallet::Config>::RuntimeEvent::from(Event::BspSignOffSuccess {
+            who: user_account.clone(),
+            bsp_id,
+        });
         frame_system::Pallet::<T>::assert_last_event(expected_event.into());
 
         // Verify that the BSP was removed from the providers' storage
@@ -714,7 +710,7 @@ mod benchmarks {
 
         // Verify that the event of the BSP requesting to sign up was emitted
         let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::BspRequestSignUpSuccess {
+            <T as pallet::Config>::RuntimeEvent::from(Event::BspRequestSignUpSuccess {
                 who: user_account.clone(),
                 capacity: initial_capacity.into(),
                 multiaddresses: multiaddresses.clone(),
@@ -759,15 +755,14 @@ mod benchmarks {
 
         /*********** Post-benchmark checks: ***********/
         // Verify that the event of the capacity change was emitted
-        let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::CapacityChanged {
-                who: user_account.clone(),
-                provider_id: StorageProviderId::BackupStorageProvider(bsp_id),
-                old_capacity: initial_capacity.into(),
-                new_capacity: new_capacity.into(),
-                next_block_when_change_allowed: frame_system::Pallet::<T>::block_number()
-                    + <T as crate::Config>::MinBlocksBetweenCapacityChanges::get(),
-            });
+        let expected_event = <T as pallet::Config>::RuntimeEvent::from(Event::CapacityChanged {
+            who: user_account.clone(),
+            provider_id: StorageProviderId::BackupStorageProvider(bsp_id),
+            old_capacity: initial_capacity.into(),
+            new_capacity: new_capacity.into(),
+            next_block_when_change_allowed: frame_system::Pallet::<T>::block_number()
+                + <T as crate::Config>::MinBlocksBetweenCapacityChanges::get(),
+        });
         frame_system::Pallet::<T>::assert_last_event(expected_event.into());
 
         // Verify that the capacity was changed
@@ -828,7 +823,7 @@ mod benchmarks {
 
         // Verify that the event of the BSP requesting to sign up was emitted
         let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::BspRequestSignUpSuccess {
+            <T as pallet::Config>::RuntimeEvent::from(Event::BspRequestSignUpSuccess {
                 who: user_account.clone(),
                 capacity: initial_capacity.into(),
                 multiaddresses: multiaddresses.clone(),
@@ -873,15 +868,14 @@ mod benchmarks {
 
         /*********** Post-benchmark checks: ***********/
         // Verify that the event of the capacity change was emitted
-        let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::CapacityChanged {
-                who: user_account.clone(),
-                provider_id: StorageProviderId::BackupStorageProvider(bsp_id),
-                old_capacity: initial_capacity.into(),
-                new_capacity: new_capacity.into(),
-                next_block_when_change_allowed: frame_system::Pallet::<T>::block_number()
-                    + <T as crate::Config>::MinBlocksBetweenCapacityChanges::get(),
-            });
+        let expected_event = <T as pallet::Config>::RuntimeEvent::from(Event::CapacityChanged {
+            who: user_account.clone(),
+            provider_id: StorageProviderId::BackupStorageProvider(bsp_id),
+            old_capacity: initial_capacity.into(),
+            new_capacity: new_capacity.into(),
+            next_block_when_change_allowed: frame_system::Pallet::<T>::block_number()
+                + <T as crate::Config>::MinBlocksBetweenCapacityChanges::get(),
+        });
         frame_system::Pallet::<T>::assert_last_event(expected_event.into());
 
         // Verify that the capacity was changed
@@ -949,7 +943,7 @@ mod benchmarks {
 
         // Verify that the event of the MSP requesting to sign up was emitted
         let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::MspRequestSignUpSuccess {
+            <T as pallet::Config>::RuntimeEvent::from(Event::MspRequestSignUpSuccess {
                 who: user_account.clone(),
                 capacity: initial_capacity.into(),
                 multiaddresses: multiaddresses.clone(),
@@ -994,15 +988,14 @@ mod benchmarks {
 
         /*********** Post-benchmark checks: ***********/
         // Verify that the event of the capacity change was emitted
-        let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::CapacityChanged {
-                who: user_account.clone(),
-                provider_id: StorageProviderId::MainStorageProvider(msp_id),
-                old_capacity: initial_capacity.into(),
-                new_capacity: new_capacity.into(),
-                next_block_when_change_allowed: frame_system::Pallet::<T>::block_number()
-                    + <T as crate::Config>::MinBlocksBetweenCapacityChanges::get(),
-            });
+        let expected_event = <T as pallet::Config>::RuntimeEvent::from(Event::CapacityChanged {
+            who: user_account.clone(),
+            provider_id: StorageProviderId::MainStorageProvider(msp_id),
+            old_capacity: initial_capacity.into(),
+            new_capacity: new_capacity.into(),
+            next_block_when_change_allowed: frame_system::Pallet::<T>::block_number()
+                + <T as crate::Config>::MinBlocksBetweenCapacityChanges::get(),
+        });
         frame_system::Pallet::<T>::assert_last_event(expected_event.into());
 
         // Verify that the capacity was changed
@@ -1070,7 +1063,7 @@ mod benchmarks {
 
         // Verify that the event of the MSP requesting to sign up was emitted
         let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::MspRequestSignUpSuccess {
+            <T as pallet::Config>::RuntimeEvent::from(Event::MspRequestSignUpSuccess {
                 who: user_account.clone(),
                 capacity: initial_capacity.into(),
                 multiaddresses: multiaddresses.clone(),
@@ -1115,15 +1108,14 @@ mod benchmarks {
 
         /*********** Post-benchmark checks: ***********/
         // Verify that the event of the capacity change was emitted
-        let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::CapacityChanged {
-                who: user_account.clone(),
-                provider_id: StorageProviderId::MainStorageProvider(msp_id),
-                old_capacity: initial_capacity.into(),
-                new_capacity: new_capacity.into(),
-                next_block_when_change_allowed: frame_system::Pallet::<T>::block_number()
-                    + <T as crate::Config>::MinBlocksBetweenCapacityChanges::get(),
-            });
+        let expected_event = <T as pallet::Config>::RuntimeEvent::from(Event::CapacityChanged {
+            who: user_account.clone(),
+            provider_id: StorageProviderId::MainStorageProvider(msp_id),
+            old_capacity: initial_capacity.into(),
+            new_capacity: new_capacity.into(),
+            next_block_when_change_allowed: frame_system::Pallet::<T>::block_number()
+                + <T as crate::Config>::MinBlocksBetweenCapacityChanges::get(),
+        });
         frame_system::Pallet::<T>::assert_last_event(expected_event.into());
 
         // Verify that the capacity was changed
@@ -1191,7 +1183,7 @@ mod benchmarks {
 
         // Verify that the event of the MSP requesting to sign up was emitted
         let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::MspRequestSignUpSuccess {
+            <T as pallet::Config>::RuntimeEvent::from(Event::MspRequestSignUpSuccess {
                 who: user_account.clone(),
                 capacity: initial_capacity.into(),
                 multiaddresses: multiaddresses.clone(),
@@ -1246,12 +1238,11 @@ mod benchmarks {
             value_prop_max_data_limit.into(),
         );
         let value_prop_id = value_prop.derive_id();
-        let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::ValuePropAdded {
-                msp_id,
-                value_prop_id,
-                value_prop: value_prop.clone(),
-            });
+        let expected_event = <T as pallet::Config>::RuntimeEvent::from(Event::ValuePropAdded {
+            msp_id,
+            value_prop_id,
+            value_prop: value_prop.clone(),
+        });
         frame_system::Pallet::<T>::assert_last_event(expected_event.into());
 
         // Verify that the value proposition was added
@@ -1314,7 +1305,7 @@ mod benchmarks {
 
         // Verify that the event of the MSP requesting to sign up was emitted
         let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::MspRequestSignUpSuccess {
+            <T as pallet::Config>::RuntimeEvent::from(Event::MspRequestSignUpSuccess {
                 who: user_account.clone(),
                 capacity: initial_capacity.into(),
                 multiaddresses: multiaddresses.clone(),
@@ -1360,12 +1351,11 @@ mod benchmarks {
             value_prop_max_data_limit.into(),
         );
         let value_prop_id = value_prop.derive_id();
-        let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::ValuePropAdded {
-                msp_id,
-                value_prop_id,
-                value_prop,
-            });
+        let expected_event = <T as pallet::Config>::RuntimeEvent::from(Event::ValuePropAdded {
+            msp_id,
+            value_prop_id,
+            value_prop,
+        });
         frame_system::Pallet::<T>::assert_last_event(expected_event.into());
 
         /*********** Call the extrinsic to benchmark: ***********/
@@ -1375,7 +1365,7 @@ mod benchmarks {
         /*********** Post-benchmark checks: ***********/
         // Verify that the event of the value proposition being made unavailable was emitted
         let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::ValuePropUnavailable {
+            <T as pallet::Config>::RuntimeEvent::from(Event::ValuePropUnavailable {
                 msp_id,
                 value_prop_id,
             });
@@ -1436,7 +1426,7 @@ mod benchmarks {
 
         // Verify that the event of the BSP requesting to sign up was emitted
         let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::BspRequestSignUpSuccess {
+            <T as pallet::Config>::RuntimeEvent::from(Event::BspRequestSignUpSuccess {
                 who: user_account.clone(),
                 capacity: initial_capacity.into(),
                 multiaddresses: multiaddresses.clone(),
@@ -1481,11 +1471,10 @@ mod benchmarks {
 
         /*********** Post-benchmark checks: ***********/
         // Verify that the event of the added multiaddress was emitted
-        let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::MultiAddressAdded {
-                provider_id: bsp_id,
-                new_multiaddress: new_multiaddress.clone(),
-            });
+        let expected_event = <T as pallet::Config>::RuntimeEvent::from(Event::MultiAddressAdded {
+            provider_id: bsp_id,
+            new_multiaddress: new_multiaddress.clone(),
+        });
         frame_system::Pallet::<T>::assert_last_event(expected_event.into());
 
         // Verify that the multiaddress was added to the BSP
@@ -1541,7 +1530,7 @@ mod benchmarks {
 
         // Verify that the event of the BSP requesting to sign up was emitted
         let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::BspRequestSignUpSuccess {
+            <T as pallet::Config>::RuntimeEvent::from(Event::BspRequestSignUpSuccess {
                 who: user_account.clone(),
                 capacity: initial_capacity.into(),
                 multiaddresses: multiaddresses.clone(),
@@ -1610,7 +1599,7 @@ mod benchmarks {
         /*********** Post-benchmark checks: ***********/
         // Verify that the event of removing a multiaddress was emitted
         let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::MultiAddressRemoved {
+            <T as pallet::Config>::RuntimeEvent::from(Event::MultiAddressRemoved {
                 provider_id: bsp_id,
                 removed_multiaddress: multiaddress_to_remove.clone(),
             });
@@ -1686,7 +1675,7 @@ mod benchmarks {
         /*********** Post-benchmark checks: ***********/
         // Verify that the event of the MSP requesting to sign up was emitted
         let msp_request_sign_up_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::MspRequestSignUpSuccess {
+            <T as pallet::Config>::RuntimeEvent::from(Event::MspRequestSignUpSuccess {
                 who: user_account.clone(),
                 capacity: capacity.into(),
                 multiaddresses: multiaddresses.clone(),
@@ -1695,7 +1684,7 @@ mod benchmarks {
 
         // Verify that the event of the MSP actually signing up was emitted
         let msp_sign_up_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::MspSignUpSuccess {
+            <T as pallet::Config>::RuntimeEvent::from(Event::MspSignUpSuccess {
                 who: user_account.clone(),
                 msp_id: msp_id,
                 multiaddresses: multiaddresses.clone(),
@@ -1765,7 +1754,7 @@ mod benchmarks {
         /*********** Post-benchmark checks: ***********/
         // Verify that the event of the BSP requesting to sign up was emitted
         let bsp_request_sign_up_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::BspRequestSignUpSuccess {
+            <T as pallet::Config>::RuntimeEvent::from(Event::BspRequestSignUpSuccess {
                 who: user_account.clone(),
                 capacity: capacity.into(),
                 multiaddresses: multiaddresses.clone(),
@@ -1774,7 +1763,7 @@ mod benchmarks {
 
         // Verify that the event of the BSP actually signing up was emitted
         let bsp_sign_up_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::BspSignUpSuccess {
+            <T as pallet::Config>::RuntimeEvent::from(Event::BspSignUpSuccess {
                 who: user_account.clone(),
                 bsp_id: bsp_id,
                 multiaddresses: multiaddresses.clone(),
@@ -1838,7 +1827,7 @@ mod benchmarks {
 
         // Verify that the event of the BSP requesting to sign up was emitted
         let expected_event =
-            <T as pallet::Config>::RuntimeEvent::from(Event::<T>::BspRequestSignUpSuccess {
+            <T as pallet::Config>::RuntimeEvent::from(Event::BspRequestSignUpSuccess {
                 who: user_account.clone(),
                 capacity: initial_capacity.into(),
                 multiaddresses: multiaddresses.clone(),
@@ -1896,7 +1885,7 @@ mod benchmarks {
 
         /*********** Post-benchmark checks: ***********/
         // Verify that the event of the provider being slashed was emitted
-        let expected_event = <T as pallet::Config>::RuntimeEvent::from(Event::<T>::Slashed {
+        let expected_event = <T as pallet::Config>::RuntimeEvent::from(Event::Slashed {
             provider_id: bsp_id,
             amount: amount_to_slash,
         });

--- a/pallets/providers/src/lib.rs
+++ b/pallets/providers/src/lib.rs
@@ -851,7 +851,7 @@ pub mod pallet {
             })?;
 
             // Emit the corresponding event
-            Self::deposit_event(Event::<T>::MspRequestSignUpSuccess {
+            Self::deposit_event(Event::MspRequestSignUpSuccess {
                 who,
                 multiaddresses,
                 capacity,
@@ -912,7 +912,7 @@ pub mod pallet {
             Self::do_request_bsp_sign_up(&bsp_info)?;
 
             // Emit the corresponding event
-            Self::deposit_event(Event::<T>::BspRequestSignUpSuccess {
+            Self::deposit_event(Event::BspRequestSignUpSuccess {
                 who,
                 multiaddresses,
                 capacity,
@@ -990,7 +990,7 @@ pub mod pallet {
             Self::do_cancel_sign_up(&who)?;
 
             // Emit the corresponding event
-            Self::deposit_event(Event::<T>::SignUpRequestCanceled { who });
+            Self::deposit_event(Event::SignUpRequestCanceled { who });
 
             Ok(().into())
         }
@@ -1019,7 +1019,7 @@ pub mod pallet {
             let msp_id = Self::do_msp_sign_off(&who)?;
 
             // Emit the corresponding event
-            Self::deposit_event(Event::<T>::MspSignOffSuccess { who, msp_id });
+            Self::deposit_event(Event::MspSignOffSuccess { who, msp_id });
 
             // Return a successful DispatchResultWithPostInfo
             Ok(().into())
@@ -1050,7 +1050,7 @@ pub mod pallet {
             let bsp_id = Self::do_bsp_sign_off(&who)?;
 
             // Emit the corresponding event
-            Self::deposit_event(Event::<T>::BspSignOffSuccess { who, bsp_id });
+            Self::deposit_event(Event::BspSignOffSuccess { who, bsp_id });
 
             // Return a successful DispatchResultWithPostInfo
             Ok(().into())
@@ -1102,7 +1102,7 @@ pub mod pallet {
             let (provider_id, old_capacity) = Self::do_change_capacity(&who, new_capacity)?;
 
             // Emit the corresponding event
-            Self::deposit_event(Event::<T>::CapacityChanged {
+            Self::deposit_event(Event::CapacityChanged {
                 who,
                 provider_id,
                 old_capacity,
@@ -1141,7 +1141,7 @@ pub mod pallet {
             )?;
 
             // Emit event
-            Self::deposit_event(Event::<T>::ValuePropAdded {
+            Self::deposit_event(Event::ValuePropAdded {
                 msp_id,
                 value_prop_id: value_prop.derive_id(),
                 value_prop,
@@ -1167,7 +1167,7 @@ pub mod pallet {
             let msp_id = Self::do_make_value_prop_unavailable(&who, value_prop_id)?;
 
             // Emit event
-            Self::deposit_event(Event::<T>::ValuePropUnavailable {
+            Self::deposit_event(Event::ValuePropUnavailable {
                 msp_id,
                 value_prop_id,
             });
@@ -1204,7 +1204,7 @@ pub mod pallet {
             let provider_id = Self::do_add_multiaddress(&who, &new_multiaddress)?;
 
             // Emit the corresponding event
-            Self::deposit_event(Event::<T>::MultiAddressAdded {
+            Self::deposit_event(Event::MultiAddressAdded {
                 provider_id,
                 new_multiaddress,
             });
@@ -1241,7 +1241,7 @@ pub mod pallet {
             let provider_id = Self::do_remove_multiaddress(&who, &multiaddress)?;
 
             // Emit the corresponding event
-            Self::deposit_event(Event::<T>::MultiAddressRemoved {
+            Self::deposit_event(Event::MultiAddressRemoved {
                 provider_id,
                 removed_multiaddress: multiaddress,
             });
@@ -1312,7 +1312,7 @@ pub mod pallet {
             Self::do_request_msp_sign_up(sign_up_request.clone())?;
 
             // Emit the corresponding event
-            Self::deposit_event(Event::<T>::MspRequestSignUpSuccess {
+            Self::deposit_event(Event::MspRequestSignUpSuccess {
                 who: who.clone(),
                 multiaddresses,
                 capacity,
@@ -1380,7 +1380,7 @@ pub mod pallet {
             Self::do_request_bsp_sign_up(&bsp_info)?;
 
             // Emit the corresponding event
-            Self::deposit_event(Event::<T>::BspRequestSignUpSuccess {
+            Self::deposit_event(Event::BspRequestSignUpSuccess {
                 who: who.clone(),
                 multiaddresses,
                 capacity,

--- a/pallets/providers/src/tests.rs
+++ b/pallets/providers/src/tests.rs
@@ -130,7 +130,7 @@ mod sign_up {
 
                     // Check the event was emitted
                     System::assert_has_event(
-                        Event::<Test>::MspRequestSignUpSuccess {
+                        Event::MspRequestSignUpSuccess {
                             who: alice,
                             multiaddresses: multiaddresses.clone(),
                             capacity: storage_amount,
@@ -247,7 +247,7 @@ mod sign_up {
 
                     // Check that the confirm MSP sign up event was emitted
                     System::assert_last_event(
-                        Event::<Test>::MspSignUpSuccess {
+                        Event::MspSignUpSuccess {
                             who: alice,
                             multiaddresses,
                             capacity: storage_amount,
@@ -344,7 +344,7 @@ mod sign_up {
 
                     // Check that the confirm MSP sign up event was emitted
                     System::assert_last_event(
-                        Event::<Test>::MspSignUpSuccess {
+                        Event::MspSignUpSuccess {
                             who: alice,
                             multiaddresses,
                             capacity: storage_amount,
@@ -461,7 +461,7 @@ mod sign_up {
 
                     // Check that Alice's event was emitted
                     System::assert_has_event(
-                        Event::<Test>::MspRequestSignUpSuccess {
+                        Event::MspRequestSignUpSuccess {
                             who: alice,
                             multiaddresses: multiaddresses.clone(),
                             capacity: storage_amount_alice,
@@ -471,7 +471,7 @@ mod sign_up {
 
                     // Check that Bob's event was emitted
                     System::assert_has_event(
-                        Event::<Test>::MspRequestSignUpSuccess {
+                        Event::MspRequestSignUpSuccess {
                             who: bob,
                             multiaddresses,
                             capacity: storage_amount_bob,
@@ -551,9 +551,7 @@ mod sign_up {
                         .is_err_and(|err| { matches!(err, Error::<Test>::SignUpNotRequested) }));
 
                     // Check that the cancel MSP sign up event was emitted
-                    System::assert_last_event(
-                        Event::<Test>::SignUpRequestCanceled { who: alice }.into(),
-                    );
+                    System::assert_last_event(Event::SignUpRequestCanceled { who: alice }.into());
                 });
             }
         }
@@ -627,7 +625,7 @@ mod sign_up {
 
                     // Check the event was emitted
                     System::assert_has_event(
-                        Event::<Test>::BspRequestSignUpSuccess {
+                        Event::BspRequestSignUpSuccess {
                             who: alice,
                             multiaddresses: multiaddresses.clone(),
                             capacity: storage_amount,
@@ -725,7 +723,7 @@ mod sign_up {
 
                     // Check the event was emitted
                     System::assert_has_event(
-                        Event::<Test>::BspRequestSignUpSuccess {
+                        Event::BspRequestSignUpSuccess {
                             who: alice,
                             multiaddresses: multiaddresses.clone(),
                             capacity: storage_amount,
@@ -755,7 +753,7 @@ mod sign_up {
 
                     // Check that the confirm BSP sign up event was emitted
                     System::assert_last_event(
-                        Event::<Test>::BspSignUpSuccess {
+                        Event::BspSignUpSuccess {
                             who: alice,
                             root: DefaultMerkleRoot::get(),
                             multiaddresses,
@@ -830,7 +828,7 @@ mod sign_up {
 
                     // Check the event was emitted
                     System::assert_has_event(
-                        Event::<Test>::BspRequestSignUpSuccess {
+                        Event::BspRequestSignUpSuccess {
                             who: alice,
                             multiaddresses: multiaddresses.clone(),
                             capacity: storage_amount,
@@ -860,7 +858,7 @@ mod sign_up {
 
                     // Check that the confirm BSP sign up event was emitted
                     System::assert_last_event(
-                        Event::<Test>::BspSignUpSuccess {
+                        Event::BspSignUpSuccess {
                             who: alice,
                             root: DefaultMerkleRoot::get(),
                             multiaddresses,
@@ -966,7 +964,7 @@ mod sign_up {
 
                     // Check that Alice's event was emitted
                     System::assert_has_event(
-                        Event::<Test>::BspRequestSignUpSuccess {
+                        Event::BspRequestSignUpSuccess {
                             who: alice,
                             multiaddresses: multiaddresses.clone(),
                             capacity: storage_amount_alice,
@@ -976,7 +974,7 @@ mod sign_up {
 
                     // Check that Bob's event was emitted
                     System::assert_has_event(
-                        Event::<Test>::BspRequestSignUpSuccess {
+                        Event::BspRequestSignUpSuccess {
                             who: bob,
                             multiaddresses,
                             capacity: storage_amount_bob,
@@ -1051,9 +1049,7 @@ mod sign_up {
                         .is_err_and(|err| { matches!(err, Error::<Test>::SignUpNotRequested) }));
 
                     // Check that the cancel BSP sign up event was emitted
-                    System::assert_last_event(
-                        Event::<Test>::SignUpRequestCanceled { who: alice }.into(),
-                    );
+                    System::assert_last_event(Event::SignUpRequestCanceled { who: alice }.into());
                 });
             }
         }
@@ -1160,7 +1156,7 @@ mod sign_up {
 
                     // Check that Alice's event was emitted
                     System::assert_has_event(
-                        Event::<Test>::MspRequestSignUpSuccess {
+                        Event::MspRequestSignUpSuccess {
                             who: alice,
                             multiaddresses: multiaddresses.clone(),
                             capacity: storage_amount_alice,
@@ -1170,7 +1166,7 @@ mod sign_up {
 
                     // Check that Bob's event was emitted
                     System::assert_has_event(
-                        Event::<Test>::BspRequestSignUpSuccess {
+                        Event::BspRequestSignUpSuccess {
                             who: bob,
                             multiaddresses,
                             capacity: storage_amount_bob,
@@ -1254,7 +1250,7 @@ mod sign_up {
 
                     // Check that the confirm MSP sign up event was emitted
                     System::assert_last_event(
-                        Event::<Test>::MspSignUpSuccess {
+                        Event::MspSignUpSuccess {
                             who: alice,
                             multiaddresses: multiaddresses.clone(),
                             capacity: storage_amount_alice,
@@ -1347,7 +1343,7 @@ mod sign_up {
 
                     // Check that the confirm MSP sign up event was emitted
                     System::assert_last_event(
-                        Event::<Test>::MspSignUpSuccess {
+                        Event::MspSignUpSuccess {
                             who: alice,
                             multiaddresses: multiaddresses.clone(),
                             capacity: storage_amount_alice,
@@ -1373,7 +1369,7 @@ mod sign_up {
 
                     // Check that the confirm BSP sign up event was emitted
                     System::assert_last_event(
-                        Event::<Test>::BspSignUpSuccess {
+                        Event::BspSignUpSuccess {
                             who: bob,
                             multiaddresses,
                             root: DefaultMerkleRoot::get(),
@@ -1459,7 +1455,7 @@ mod sign_up {
 
                     // Check that the confirm MSP sign up event was emitted
                     System::assert_last_event(
-                        Event::<Test>::MspSignUpSuccess {
+                        Event::MspSignUpSuccess {
                             who: alice,
                             multiaddresses: multiaddresses.clone(),
                             capacity: storage_amount_alice,
@@ -1484,9 +1480,7 @@ mod sign_up {
                         .is_err_and(|err| { matches!(err, Error::<Test>::SignUpNotRequested) }));
 
                     // Check that the cancel BSP sign up event was emitted
-                    System::assert_last_event(
-                        Event::<Test>::SignUpRequestCanceled { who: bob }.into(),
-                    );
+                    System::assert_last_event(Event::SignUpRequestCanceled { who: bob }.into());
                 });
             }
 
@@ -1542,7 +1536,7 @@ mod sign_up {
 
                     // Check that the confirm MSP sign up event was emitted
                     System::assert_last_event(
-                        Event::<Test>::MspSignUpSuccess {
+                        Event::MspSignUpSuccess {
                             who: alice,
                             multiaddresses,
                             capacity: storage_amount,
@@ -1692,9 +1686,7 @@ mod sign_up {
                         .is_err_and(|err| { matches!(err, Error::<Test>::SignUpNotRequested) }));
 
                     // Check that the cancel MSP sign up event was emitted
-                    System::assert_last_event(
-                        Event::<Test>::SignUpRequestCanceled { who: alice }.into(),
-                    );
+                    System::assert_last_event(Event::SignUpRequestCanceled { who: alice }.into());
 
                     // Cancel the sign up of Bob as a Backup Storage Provider
                     assert_ok!(StorageProviders::cancel_sign_up(RuntimeOrigin::signed(bob)));
@@ -1712,9 +1704,7 @@ mod sign_up {
                         .is_err_and(|err| { matches!(err, Error::<Test>::SignUpNotRequested) }));
 
                     // Check that the cancel BSP sign up event was emitted
-                    System::assert_last_event(
-                        Event::<Test>::SignUpRequestCanceled { who: bob }.into(),
-                    );
+                    System::assert_last_event(Event::SignUpRequestCanceled { who: bob }.into());
                 });
             }
         }
@@ -2498,7 +2488,7 @@ mod sign_off {
 
                     // Check the MSP Sign Off event was emitted
                     System::assert_has_event(
-                        Event::<Test>::MspSignOffSuccess {
+                        Event::MspSignOffSuccess {
                             who: alice,
                             msp_id: alice_msp_id,
                         }
@@ -2577,7 +2567,7 @@ mod sign_off {
 
                     // Check the BSP Sign Off event was emitted
                     System::assert_has_event(
-                        Event::<Test>::BspSignOffSuccess {
+                        Event::BspSignOffSuccess {
                             who: alice,
                             bsp_id: alice_bsp_id,
                         }
@@ -2656,7 +2646,7 @@ mod sign_off {
 
                     // Check the BSP Sign Off event was emitted
                     System::assert_has_event(
-                        Event::<Test>::BspSignOffSuccess {
+                        Event::BspSignOffSuccess {
                             who: alice,
                             bsp_id: alice_bsp_id,
                         }
@@ -2933,7 +2923,7 @@ mod change_capacity {
 
                     // Check that the capacity changed event was emitted
                     System::assert_has_event(
-                        Event::<Test>::CapacityChanged {
+                        Event::CapacityChanged {
                             who: alice,
                             provider_id: StorageProviderId::MainStorageProvider(alice_sp_id),
                             old_capacity: old_storage_amount,
@@ -3004,7 +2994,7 @@ mod change_capacity {
 
                     // Check that the capacity changed event was emitted
                     System::assert_has_event(
-                        Event::<Test>::CapacityChanged {
+                        Event::CapacityChanged {
                             who: alice,
                             provider_id: StorageProviderId::MainStorageProvider(alice_sp_id),
                             old_capacity: old_storage_amount,
@@ -3071,7 +3061,7 @@ mod change_capacity {
 
                     // Check that the capacity changed event was emitted
                     System::assert_has_event(
-                        Event::<Test>::CapacityChanged {
+                        Event::CapacityChanged {
                             who: alice,
                             provider_id: StorageProviderId::MainStorageProvider(alice_sp_id),
                             old_capacity: old_storage_amount,
@@ -3158,7 +3148,7 @@ mod change_capacity {
 
                     // Check that the capacity changed event was emitted
                     System::assert_has_event(
-                        Event::<Test>::CapacityChanged {
+                        Event::CapacityChanged {
                             who: alice,
                             provider_id: StorageProviderId::BackupStorageProvider(alice_sp_id),
                             old_capacity: old_storage_amount,
@@ -3241,7 +3231,7 @@ mod change_capacity {
 
                     // Check that the capacity changed event was emitted
                     System::assert_has_event(
-                        Event::<Test>::CapacityChanged {
+                        Event::CapacityChanged {
                             who: alice,
                             provider_id: StorageProviderId::BackupStorageProvider(alice_sp_id),
                             old_capacity: old_storage_amount,
@@ -3320,7 +3310,7 @@ mod change_capacity {
 
                     // Check that the capacity changed event was emitted
                     System::assert_has_event(
-                        Event::<Test>::CapacityChanged {
+                        Event::CapacityChanged {
                             who: alice,
                             provider_id: StorageProviderId::BackupStorageProvider(alice_sp_id),
                             old_capacity: old_storage_amount,
@@ -5243,7 +5233,7 @@ mod slash_and_top_up {
                     .iter()
                     .rev()
                     .find_map(|event| {
-                        if let RuntimeEvent::StorageProviders(Event::<Test>::Slashed {
+                        if let RuntimeEvent::StorageProviders(Event::Slashed {
                             provider_id,
                             amount,
                         }) = event.event
@@ -5274,7 +5264,7 @@ mod slash_and_top_up {
                         .iter()
                         .rev()
                         .find_map(|event| {
-                            if let RuntimeEvent::StorageProviders(Event::<Test>::TopUpFulfilled {
+                            if let RuntimeEvent::StorageProviders(Event::TopUpFulfilled {
                                 provider_id: _,
                                 amount,
                             }) = event.event
@@ -5323,7 +5313,7 @@ mod slash_and_top_up {
                     .unwrap();
 
                     System::assert_has_event(
-                        Event::<Test>::AwaitingTopUp {
+                        Event::AwaitingTopUp {
                             provider_id: self.provider_id,
                             top_up_metadata: top_up_metadata.clone(),
                         }
@@ -5418,7 +5408,7 @@ mod slash_and_top_up {
                     .iter()
                     .rev()
                     .find_map(|event| {
-                        if let RuntimeEvent::StorageProviders(Event::<Test>::TopUpFulfilled {
+                        if let RuntimeEvent::StorageProviders(Event::TopUpFulfilled {
                             provider_id: _,
                             amount,
                         }) = event.event
@@ -6107,7 +6097,7 @@ mod add_value_prop {
 
                 // Check event is emitted
                 System::assert_last_event(
-                    Event::<Test>::ValuePropAdded {
+                    Event::ValuePropAdded {
                         msp_id,
                         value_prop_id,
                         value_prop: value_prop.clone(),
@@ -6200,7 +6190,7 @@ mod make_value_prop_unavailable {
 
                 // Check event is emitted
                 System::assert_last_event(
-                    Event::<Test>::ValuePropUnavailable {
+                    Event::ValuePropUnavailable {
                         msp_id,
                         value_prop_id,
                     }
@@ -6487,7 +6477,7 @@ fn register_account_as_msp(
 
     // Check that the request sign up event was emitted
     System::assert_last_event(
-        Event::<Test>::MspRequestSignUpSuccess {
+        Event::MspRequestSignUpSuccess {
             who: account,
             multiaddresses: multiaddresses.clone(),
             capacity: storage_amount,
@@ -6510,7 +6500,7 @@ fn register_account_as_msp(
 
     // Check that the confirm MSP sign up event was emitted
     System::assert_last_event(
-        Event::<Test>::MspSignUpSuccess {
+        Event::MspSignUpSuccess {
             who: account,
             msp_id,
             multiaddresses: multiaddresses.clone(),
@@ -6578,7 +6568,7 @@ fn register_account_as_bsp(
 
     // Check that the request sign up event was emitted
     System::assert_last_event(
-        Event::<Test>::BspRequestSignUpSuccess {
+        Event::BspRequestSignUpSuccess {
             who: account,
             multiaddresses: multiaddresses.clone(),
             capacity: storage_amount,
@@ -6599,7 +6589,7 @@ fn register_account_as_bsp(
 
     // Check that the confirm BSP sign up event was emitted
     System::assert_last_event(
-        Event::<Test>::BspSignUpSuccess {
+        Event::BspSignUpSuccess {
             who: account,
             bsp_id,
             root: DefaultMerkleRoot::get(),

--- a/pallets/providers/src/utils.rs
+++ b/pallets/providers/src/utils.rs
@@ -312,7 +312,7 @@ where
         <T::PaymentStreams as PaymentStreamsInterface>::add_privileged_provider(&msp_id);
 
         // Emit the corresponding event
-        Self::deposit_event(Event::<T>::MspSignUpSuccess {
+        Self::deposit_event(Event::MspSignUpSuccess {
             who: who.clone(),
             msp_id,
             multiaddresses: sign_up_request.msp_info.multiaddresses.clone(),
@@ -375,7 +375,7 @@ where
         });
 
         // Emit the corresponding event
-        Self::deposit_event(Event::<T>::BspSignUpSuccess {
+        Self::deposit_event(Event::BspSignUpSuccess {
             who: who.clone(),
             bsp_id,
             root: bsp_info.root,
@@ -878,7 +878,7 @@ where
         let mut final_capacity = new_decreased_capacity;
 
         // Slash amount could be 0, but this is still emitted as a signal for the provider and users to be aware
-        Self::deposit_event(Event::<T>::Slashed {
+        Self::deposit_event(Event::Slashed {
             provider_id: *provider_id,
             amount: actual_slashed,
         });
@@ -922,7 +922,7 @@ where
             // they will not be slashed
             AwaitingTopUpFromProviders::<T>::remove(&typed_provider_id);
 
-            Self::deposit_event(Event::<T>::TopUpFulfilled {
+            Self::deposit_event(Event::TopUpFulfilled {
                 provider_id: *provider_id,
                 amount: held_deposit_difference,
             });
@@ -946,7 +946,7 @@ where
             );
 
             // Signal to the provider that they need to top up their held deposit to match the current used capacity
-            Self::deposit_event(Event::<T>::AwaitingTopUp {
+            Self::deposit_event(Event::AwaitingTopUp {
                 provider_id: *provider_id,
                 top_up_metadata,
             });
@@ -1052,7 +1052,7 @@ where
         AwaitingTopUpFromProviders::<T>::remove(typed_provider_id);
 
         // Signal that the slashed amount has been topped up
-        Self::deposit_event(Event::<T>::TopUpFulfilled {
+        Self::deposit_event(Event::TopUpFulfilled {
             provider_id,
             amount: held_deposit_difference,
         });
@@ -1140,7 +1140,7 @@ where
             MainStorageProviderIdsToValuePropositions::<T>::drain_prefix(&provider_id);
             MainStorageProviderIdsToBuckets::<T>::drain_prefix(&provider_id);
 
-            Self::deposit_event(Event::<T>::MspDeleted {
+            Self::deposit_event(Event::MspDeleted {
                 provider_id: *provider_id,
             });
         } else if let Some(bsp) = BackupStorageProviders::<T>::get(provider_id) {
@@ -1183,7 +1183,7 @@ where
                 *n = n.saturating_sub(bsp.reputation_weight);
             });
 
-            Self::deposit_event(Event::<T>::BspDeleted {
+            Self::deposit_event(Event::BspDeleted {
                 provider_id: *provider_id,
             });
         }
@@ -1813,7 +1813,7 @@ impl<T: pallet::Config> MutateBucketsInterface for pallet::Pallet<T> {
         Buckets::<T>::try_mutate(&bucket_id, |bucket| {
             let bucket = bucket.as_mut().ok_or(Error::<T>::BucketNotFound)?;
 
-            Self::deposit_event(Event::<T>::BucketRootChanged {
+            Self::deposit_event(Event::BucketRootChanged {
                 bucket_id,
                 old_root: bucket.root,
                 new_root,

--- a/pallets/randomness/src/benchmarking.rs
+++ b/pallets/randomness/src/benchmarking.rs
@@ -46,7 +46,7 @@ mod benchmarks {
                 .saturating_sub(sp_runtime::traits::One::one());
 
         let expected_event = <T as pallet::Config>::RuntimeEvent::from(
-            Event::<T>::NewOneEpochAgoRandomnessAvailable {
+            Event::NewOneEpochAgoRandomnessAvailable {
                 randomness_seed: epoch_randomness,
                 from_epoch: relay_epoch_index,
                 valid_until_block: latest_valid_block_for_randomness,

--- a/pallets/randomness/src/benchmarking.rs
+++ b/pallets/randomness/src/benchmarking.rs
@@ -45,13 +45,12 @@ mod benchmarks {
                 .1
                 .saturating_sub(sp_runtime::traits::One::one());
 
-        let expected_event = <T as pallet::Config>::RuntimeEvent::from(
-            Event::NewOneEpochAgoRandomnessAvailable {
+        let expected_event =
+            <T as pallet::Config>::RuntimeEvent::from(Event::NewOneEpochAgoRandomnessAvailable {
                 randomness_seed: epoch_randomness,
                 from_epoch: relay_epoch_index,
                 valid_until_block: latest_valid_block_for_randomness,
-            },
-        );
+            });
         frame_system::Pallet::<T>::assert_last_event(expected_event.into());
     }
 

--- a/pallets/randomness/src/tests.rs
+++ b/pallets/randomness/src/tests.rs
@@ -48,7 +48,7 @@ fn set_babe_randomness_works() {
 
         // Check that the event was emitted
         System::assert_last_event(
-            Event::<Test>::NewOneEpochAgoRandomnessAvailable {
+            Event::NewOneEpochAgoRandomnessAvailable {
                 randomness_seed: H256::from_slice(&blake2_256(
                     &last_processed_relay_epoch.to_le_bytes(),
                 )),
@@ -103,7 +103,7 @@ fn set_babe_randomness_works_after_a_few_epochs() {
 
             // Check that the event was emitted
             System::assert_last_event(
-                Event::<Test>::NewOneEpochAgoRandomnessAvailable {
+                Event::NewOneEpochAgoRandomnessAvailable {
                     randomness_seed: H256::from_slice(&blake2_256(
                         &last_processed_relay_epoch.to_le_bytes(),
                     )),


### PR DESCRIPTION
This PR removes the now not-needed generics when handling events from each pallet.