### PR TITLE
fix: Skip BSP confirm file keys that have failed to update or create a payment stream

### DIFF
--- a/pallets/file-system/src/utils.rs
+++ b/pallets/file-system/src/utils.rs
@@ -1382,6 +1382,10 @@ where
 
             // Check if a payment stream between the user and provider already exists.
             // If it does not, create it. If it does, update it.
+            //
+            // We ignore all errors from the payment stream operations (create/update) and add the file key to the skipped_file_keys set.
+            // This operation must be the first one to be executed before we being updating storage elements as to avoid any potential case
+            // where a storage element is updated but should not be.
             match <T::PaymentStreams as PaymentStreamsInterface>::get_dynamic_rate_payment_stream_amount_provided(&bsp_id, &storage_request_metadata.owner) {
 				Some(previous_amount_provided) => {
 					// Update the payment stream.

--- a/pallets/file-system/src/utils.rs
+++ b/pallets/file-system/src/utils.rs
@@ -1380,11 +1380,9 @@ where
                 Error::<T>::InsufficientAvailableCapacity
             );
 
-            // Check if a payment stream between the user and provider already exists.
-            // If it does not, create it. If it does, update it.
-            //
-            // We ignore all errors from the payment stream operations (create/update) and add the file key to the skipped_file_keys set.
-            // This operation must be the first one to be executed before we being updating storage elements as to avoid any potential case
+            // All errors from the payment stream operations (create/update) are ignored, and the file key is added to the `skipped_file_keys` set instead of erroring out.
+            // This is done to avoid a malicious user, owner of one of the files from the batch of confirmations, being able to prevent the BSP from confirming any files by making itself insolvent so payment stream operations fail.
+            // This operation must be executed first, before updating any storage elements, to prevent potential cases
             // where a storage element is updated but should not be.
             match <T::PaymentStreams as PaymentStreamsInterface>::get_dynamic_rate_payment_stream_amount_provided(&bsp_id, &storage_request_metadata.owner) {
 				Some(previous_amount_provided) => {

--- a/pallets/file-system/src/utils.rs
+++ b/pallets/file-system/src/utils.rs
@@ -1380,6 +1380,46 @@ where
                 Error::<T>::InsufficientAvailableCapacity
             );
 
+            // Check if a payment stream between the user and provider already exists.
+            // If it does not, create it. If it does, update it.
+            match <T::PaymentStreams as PaymentStreamsInterface>::get_dynamic_rate_payment_stream_amount_provided(&bsp_id, &storage_request_metadata.owner) {
+				Some(previous_amount_provided) => {
+					// Update the payment stream.
+                    let new_amount_provided = &previous_amount_provided.checked_add(&storage_request_metadata.size).ok_or(ArithmeticError::Overflow)?;
+					if let Err(_) = <T::PaymentStreams as PaymentStreamsInterface>::update_dynamic_rate_payment_stream(
+						&bsp_id,
+						&storage_request_metadata.owner,
+						new_amount_provided,
+					) {
+                        // Skip file key if we could not successfully update the payment stream
+                        expect_or_err!(
+                            skipped_file_keys.try_insert(file_key),
+                            "Failed to push file key to skipped_file_keys",
+                            Error::<T>::TooManyStorageRequestResponses,
+                            result
+                        );
+                        continue;
+                    }
+				},
+				None => {
+					// Create the payment stream.
+					if let Err(_) = <T::PaymentStreams as PaymentStreamsInterface>::create_dynamic_rate_payment_stream(
+						&bsp_id,
+						&storage_request_metadata.owner,
+						&storage_request_metadata.size,
+					) {
+                        // Skip file key if we could not successfully create the payment stream
+                        expect_or_err!(
+                            skipped_file_keys.try_insert(file_key),
+                            "Failed to push file key to skipped_file_keys",
+                            Error::<T>::TooManyStorageRequestResponses,
+                            result
+                        );
+                        continue;
+                    }
+				}
+			}
+
             // Increment the number of BSPs confirmed.
             match storage_request_metadata
                 .bsps_confirmed
@@ -1418,28 +1458,6 @@ where
                 &bsp_id,
                 storage_request_metadata.size,
             )?;
-
-            // Check if a payment stream between the user and provider already exists.
-            // If it does not, create it. If it does, update it.
-            match <T::PaymentStreams as PaymentStreamsInterface>::get_dynamic_rate_payment_stream_amount_provided(&bsp_id, &storage_request_metadata.owner) {
-				Some(previous_amount_provided) => {
-					// Update the payment stream.
-                    let new_amount_provided = &previous_amount_provided.checked_add(&storage_request_metadata.size).ok_or(ArithmeticError::Overflow)?;
-					<T::PaymentStreams as PaymentStreamsInterface>::update_dynamic_rate_payment_stream(
-						&bsp_id,
-						&storage_request_metadata.owner,
-						new_amount_provided,
-					)?;
-				},
-				None => {
-					// Create the payment stream.
-					<T::PaymentStreams as PaymentStreamsInterface>::create_dynamic_rate_payment_stream(
-						&bsp_id,
-						&storage_request_metadata.owner,
-						&storage_request_metadata.size,
-					)?;
-				}
-			}
 
             // Get the file metadata to insert into the Provider's trie under the file key.
             let file_metadata = storage_request_metadata.clone().to_file_metadata();


### PR DESCRIPTION
Moved the payment stream create and update block in `bsp_confirm_storing` to skip file keys if those operations have failed.

Moving these operations at the top avoids any possibility for any storage elements from being updated when they shouldn't if we skipped the file key.

See the audit issue raised for more details.

Resolves [issue #30](https://github.com/Moonsong-Labs/internal-storage-hub-design-audit/issues/30)