### PR TITLE
feat: index user insolvent event

### DIFF
--- a/client/indexer-service/src/handler.rs
+++ b/client/indexer-service/src/handler.rs
@@ -305,7 +305,15 @@ impl IndexerService {
             pallet_file_system::Event::StorageRequestRejected { .. } => {}
             pallet_file_system::Event::BspRequestedToStopStoring { .. } => {}
             pallet_file_system::Event::PriorityChallengeForFileDeletionQueued { .. } => {}
-            pallet_file_system::Event::SpStopStoringInsolventUser { .. } => {}
+            pallet_file_system::Event::SpStopStoringInsolventUser {
+                sp_id,
+                file_key,
+                owner,
+                location,
+                new_root,
+            } => {
+                File::delete(conn, file_key).await?;
+            }
             pallet_file_system::Event::FailedToQueuePriorityChallenge { .. } => {}
             pallet_file_system::Event::FileDeletionRequest { .. } => {}
             pallet_file_system::Event::ProofSubmittedForPendingFileDeletionRequest { .. } => {}

--- a/client/indexer-service/src/handler.rs
+++ b/client/indexer-service/src/handler.rs
@@ -306,13 +306,15 @@ impl IndexerService {
             pallet_file_system::Event::BspRequestedToStopStoring { .. } => {}
             pallet_file_system::Event::PriorityChallengeForFileDeletionQueued { .. } => {}
             pallet_file_system::Event::SpStopStoringInsolventUser {
-                sp_id: _,
+                sp_id,
                 file_key,
                 owner: _,
                 location: _,
                 new_root: _,
             } => {
-                File::delete(conn, file_key).await?;
+                // We are now only deleting for BSP as BSP are associating with files
+                // MSP will handle insolvent user at the level of buckets (an MSP will delete the full bucket for an insolvent user and it will produce a new kind of event)
+                BspFile::delete(conn, file_key, sp_id.to_string()).await?;
             }
             pallet_file_system::Event::FailedToQueuePriorityChallenge { .. } => {}
             pallet_file_system::Event::FileDeletionRequest { .. } => {}

--- a/client/indexer-service/src/handler.rs
+++ b/client/indexer-service/src/handler.rs
@@ -306,11 +306,11 @@ impl IndexerService {
             pallet_file_system::Event::BspRequestedToStopStoring { .. } => {}
             pallet_file_system::Event::PriorityChallengeForFileDeletionQueued { .. } => {}
             pallet_file_system::Event::SpStopStoringInsolventUser {
-                sp_id,
+                sp_id: _,
                 file_key,
-                owner,
-                location,
-                new_root,
+                owner: _,
+                location: _,
+                new_root: _,
             } => {
                 File::delete(conn, file_key).await?;
             }


### PR DESCRIPTION
In this PR, we handle `SpStopStoringInsolventUser` event and update the indexer to remove the file we are stopping to store because the user is insolvent.

see https://github.com/Moonsong-Labs/internal-storage-hub-design-audit/issues/32