### PR TITLE
test: :white_check_mark: fix integration tests

### DIFF
--- a/test/suites/integration/bsp/multiple-delete.test.ts
+++ b/test/suites/integration/bsp/multiple-delete.test.ts
@@ -138,8 +138,16 @@ describeBspNet("Single BSP Volunteering", ({ before, createBspApi, it, createUse
     // Wait enough blocks for the deletion to be allowed.
     const currentBlock = await userApi.rpc.chain.getBlock();
     const currentBlockNumber = currentBlock.block.header.number.toNumber();
-    const cooldown =
-      currentBlockNumber + userApi.consts.fileSystem.minWaitForStopStoring.toNumber();
+    const minWaitForStopStoring = (
+      await userApi.query.parameters.parameters({
+        RuntimeConfig: {
+          MinWaitForStopStoring: null
+        }
+      })
+    )
+      .unwrap()
+      .asRuntimeConfig.asMinWaitForStopStoring.toNumber();
+    const cooldown = currentBlockNumber + minWaitForStopStoring;
     await userApi.block.skipTo(cooldown);
 
     for (let i = 0; i < fileKeys.length; i++) {
@@ -281,8 +289,16 @@ describeBspNet("Single BSP Volunteering", ({ before, createBspApi, it, createUse
       // Wait enough blocks for the deletion to be allowed.
       const currentBlock = await userApi.rpc.chain.getBlock();
       const currentBlockNumber = currentBlock.block.header.number.toNumber();
-      const cooldown =
-        currentBlockNumber + userApi.consts.fileSystem.minWaitForStopStoring.toNumber();
+      const minWaitForStopStoring = (
+        await userApi.query.parameters.parameters({
+          RuntimeConfig: {
+            MinWaitForStopStoring: null
+          }
+        })
+      )
+        .unwrap()
+        .asRuntimeConfig.asMinWaitForStopStoring.toNumber();
+      const cooldown = currentBlockNumber + minWaitForStopStoring;
       await userApi.block.skipTo(cooldown);
 
       // Batching the delete confirmation should fail because of the wrong inclusionForestProof for extrinsinc 2 and 3

--- a/test/suites/integration/bsp/reorg-proof.test.ts
+++ b/test/suites/integration/bsp/reorg-proof.test.ts
@@ -353,7 +353,15 @@ describeBspNet(
       // Wait the required time for the BSP to be able to confirm the deletion.
       const currentBlock = await userApi.rpc.chain.getBlock();
       const currentBlockNumber = currentBlock.block.header.number.toNumber();
-      const minWaitForStopStoring = userApi.consts.fileSystem.minWaitForStopStoring.toNumber();
+      const minWaitForStopStoring = (
+        await userApi.query.parameters.parameters({
+          RuntimeConfig: {
+            MinWaitForStopStoring: null
+          }
+        })
+      )
+        .unwrap()
+        .asRuntimeConfig.asMinWaitForStopStoring.toNumber();
       const blockToAdvanceTo = currentBlockNumber + minWaitForStopStoring;
       await userApi.block.skipTo(blockToAdvanceTo, {
         watchForBspProofs: [userApi.shConsts.DUMMY_BSP_ID]

--- a/test/suites/integration/bsp/storage-delete.test.ts
+++ b/test/suites/integration/bsp/storage-delete.test.ts
@@ -109,8 +109,16 @@ describeBspNet(
       // Wait for the right moment to confirm stop storing
       const currentBlock = await userApi.rpc.chain.getBlock();
       const currentBlockNumber = currentBlock.block.header.number.toNumber();
-      const cooldown =
-        currentBlockNumber + userApi.consts.fileSystem.minWaitForStopStoring.toNumber();
+      const minWaitForStopStoring = (
+        await userApi.query.parameters.parameters({
+          RuntimeConfig: {
+            MinWaitForStopStoring: null
+          }
+        })
+      )
+        .unwrap()
+        .asRuntimeConfig.asMinWaitForStopStoring.toNumber();
+      const cooldown = currentBlockNumber + minWaitForStopStoring;
 
       // New storage request does not get fulfilled and therefore gets cleaned up and we enqueue a checkpoint challenge remove mutation
       // Which then the bsp responds to and has the file key get removed from the forest


### PR DESCRIPTION
This PR fixes a few integration tests that were left with possible race conditions. The `MinWaitForStopStoring` was updated to be retrieved from pallet-parameters instead of the constants and an await for a MSP's acceptance response in `submit-proofs` was moved to where the MSP acceptance actually happens.