### PR TITLE
feat: add task for MSP to download file from a BSP

### DIFF
--- a/client/blockchain-service/src/events.rs
+++ b/client/blockchain-service/src/events.rs
@@ -404,6 +404,14 @@ pub struct FinalisedProofSubmittedForPendingFileDeletionRequest {
 
 impl EventBusMessage for FinalisedProofSubmittedForPendingFileDeletionRequest {}
 
+#[derive(Clone)]
+pub struct DownloadRequest {
+    pub file_key: FileKey,
+    pub bucket_id: BucketId,
+}
+
+impl EventBusMessage for DownloadRequest {}
+
 /// The event bus provider for the BlockchainService actor.
 ///
 /// It holds the event buses for the different events that the BlockchainService actor
@@ -438,6 +446,7 @@ pub struct BlockchainServiceEventBusProvider {
     file_deletion_request_event_bus: EventBus<FileDeletionRequest>,
     finalised_file_deletion_request_event_bus:
         EventBus<FinalisedProofSubmittedForPendingFileDeletionRequest>,
+    download_request_event_bus: EventBus<DownloadRequest>,
 }
 
 impl BlockchainServiceEventBusProvider {
@@ -469,6 +478,7 @@ impl BlockchainServiceEventBusProvider {
             notify_period_event_bus: EventBus::new(),
             file_deletion_request_event_bus: EventBus::new(),
             finalised_file_deletion_request_event_bus: EventBus::new(),
+            download_request_event_bus: EventBus::new(),
         }
     }
 }
@@ -630,5 +640,11 @@ impl ProvidesEventBus<FinalisedProofSubmittedForPendingFileDeletionRequest>
 {
     fn event_bus(&self) -> &EventBus<FinalisedProofSubmittedForPendingFileDeletionRequest> {
         &self.finalised_file_deletion_request_event_bus
+    }
+}
+
+impl ProvidesEventBus<DownloadRequest> for BlockchainServiceEventBusProvider {
+    fn event_bus(&self) -> &EventBus<DownloadRequest> {
+        &self.download_request_event_bus
     }
 }

--- a/node/src/tasks/msp_move_bucket.rs
+++ b/node/src/tasks/msp_move_bucket.rs
@@ -122,13 +122,6 @@ where
                 error
             )
         })?;
-        let bucket = event.bucket_id.as_ref().to_vec();
-
-        let forest_storage = self
-            .storage_hub_handler
-            .forest_storage_handler
-            .get_or_create(&bucket)
-            .await;
 
         let file =
             shc_indexer_db::models::File::get_by_file_key(&mut indexer_connection, event.file_key)
@@ -140,7 +133,7 @@ where
             .query_storage_provider_id(None)
             .await?;
 
-        let own_msp_id = match own_provider_id {
+        match own_provider_id {
             Some(StorageProviderId::MainStorageProvider(id)) => id,
             Some(StorageProviderId::BackupStorageProvider(_)) => {
                 return Err(anyhow!("CRITICAL ❗️❗️❗️: Current node account is a Backup Storage Provider. Expected a Main Storage Provider ID."));


### PR DESCRIPTION
In this PR, we add a new task to download a file for a MSP from BSPs that have already accepted the file.

To avoid code redundancy we are mostly re-using the code from MSP move bucket task. Downloading a file is mostly now handle now via the function `handle_downloading_file`.


NOTE: PR #318 is modifying the code from the MSP task to move buckets. It should be merged first.