### PR TITLE
fix: fail when user fail to send file to MSP after several retries

### DIFF
--- a/node/src/tasks/user_sends_file.rs
+++ b/node/src/tasks/user_sends_file.rs
@@ -1,4 +1,4 @@
-use log::{debug, error, info, warn};
+use log::{debug, info, warn};
 use sc_network::{PeerId, RequestFailure};
 use shc_actors_framework::event_bus::EventHandler;
 use shc_blockchain_service::{
@@ -12,6 +12,7 @@ use shc_file_manager::traits::FileStorage;
 use shc_file_transfer_service::commands::{FileTransferServiceInterface, RequestError};
 use shp_constants::FILE_CHUNK_SIZE;
 use shp_file_metadata::ChunkId;
+use sp_core::H256;
 use sp_runtime::AccountId32;
 
 use crate::services::{handler::StorageHubHandler, types::ShNodeType};
@@ -136,7 +137,8 @@ where
             info!(target: LOG_TARGET, "No peers were found to receive file key {:?}", file_key);
         }
 
-        self.send_chunks_to_provider(peer_ids, &file_metadata).await
+        self.send_chunks_to_providers(peer_ids, &file_metadata)
+            .await
     }
 }
 
@@ -182,7 +184,8 @@ where
             info!(target: LOG_TARGET, "No peers were found to receive file key {:?}", file_key);
         }
 
-        self.send_chunks_to_provider(peer_ids, &file_metadata).await
+        self.send_chunks_to_providers(peer_ids, &file_metadata)
+            .await
     }
 }
 
@@ -190,7 +193,7 @@ impl<NT> UserSendsFileTask<NT>
 where
     NT: ShNodeType,
 {
-    async fn send_chunks_to_provider(
+    async fn send_chunks_to_providers(
         &mut self,
         peer_ids: Vec<PeerId>,
         file_metadata: &FileMetadata,
@@ -201,212 +204,233 @@ where
         // Iterates and tries to send file to peer.
         // Breaks loop after first successful attempt since all peer ids belong to the same provider.
         for peer_id in peer_ids {
-            debug!(target: LOG_TARGET, "Attempting to send chunks of file key {:?} to peer {:?}", file_key, peer_id);
-
-            let mut current_batch = Vec::new();
-            let mut current_batch_size = 0;
-
-            for chunk_id in 0..chunk_count {
-                // Calculate the size of the current chunk
-                let chunk_size = if chunk_id == chunk_count - 1 {
-                    file_metadata.file_size % FILE_CHUNK_SIZE as u64
-                } else {
-                    FILE_CHUNK_SIZE as u64
-                };
-
-                // Check if adding this chunk would exceed the batch size limit
-                if current_batch_size + (chunk_size as usize) > BATCH_CHUNK_FILE_TRANSFER_MAX_SIZE {
-                    // Send current batch before adding new chunk
-                    debug!(
-                        target: LOG_TARGET,
-                        "Sending batch of {} chunks (total size: {} bytes) for file {:?} to peer {:?}",
-                        current_batch.len(),
-                        current_batch_size,
-                        file_key,
-                        peer_id
-                    );
-
-                    // Generate proof for the entire batch
-                    let proof = match self
-                        .storage_hub_handler
-                        .file_storage
-                        .read()
-                        .await
-                        .generate_proof(&file_key, &current_batch)
-                    {
-                        Ok(proof) => proof,
-                        Err(e) => {
-                            return Err(anyhow::anyhow!(
-                                "Failed to generate proof for batch of file {:?}\n Error: {:?}",
-                                file_key,
-                                e
-                            ));
-                        }
-                    };
-
-                    let mut retry_attempts = 0;
-                    loop {
-                        let upload_response = self
-                            .storage_hub_handler
-                            .file_transfer
-                            .upload_request(peer_id, file_key.as_ref().into(), proof.clone(), None)
-                            .await;
-
-                        match upload_response {
-                            Ok(r) => {
-                                debug!(
-                                    target: LOG_TARGET,
-                                    "Successfully uploaded batch for file {:?} to peer {:?}",
-                                    file_metadata.fingerprint,
-                                    peer_id
-                                );
-
-                                // If the provider signals they have the entire file, we can stop
-                                if r.file_complete {
-                                    info!(
-                                        target: LOG_TARGET,
-                                        "Stopping file upload process. Peer {:?} has the entire file {:?}",
-                                        peer_id,
-                                        file_metadata.fingerprint
-                                    );
-                                    return Ok(());
-                                }
-
-                                break;
-                            }
-                            Err(RequestError::RequestFailure(RequestFailure::Refused))
-                                if retry_attempts < 3 =>
-                            {
-                                warn!(
-                                    target: LOG_TARGET,
-                                    "Batch upload rejected by peer {:?}, retrying... (attempt {})",
-                                    peer_id,
-                                    retry_attempts + 1
-                                );
-                                retry_attempts += 1;
-
-                                // Wait for a short time before retrying
-                                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                            }
-                            Err(RequestError::RequestFailure(RequestFailure::Refused)) => {
-                                // TODO: Handle MSP not receiving file after multiple retries.
-                            }
-                            Err(e) => {
-                                error!(
-                                    target: LOG_TARGET,
-                                    "Failed to upload batch to peer {:?}\n Error: {:?}",
-                                    peer_id,
-                                    e
-                                );
-                                break;
-                            }
-                        }
-                    }
-
-                    // Clear the batch for next iteration
-                    current_batch.clear();
-                    current_batch_size = 0;
+            match self
+                .send_chunks(peer_id, file_metadata, file_key, chunk_count)
+                .await
+            {
+                Err(err) => {
+                    // if sending chunk failed with one peer id, we try with the next one.
+                    warn!(target: LOG_TARGET, "{:?}", err);
+                    continue;
                 }
-
-                // Add chunk to current batch
-                current_batch.push(ChunkId::new(chunk_id));
-                current_batch_size += chunk_size as usize;
-
-                // If this is the last chunk, send the final batch
-                if chunk_id == chunk_count - 1 && !current_batch.is_empty() {
-                    debug!(
-                        target: LOG_TARGET,
-                        "Sending final batch of {} chunks (total size: {} bytes) for file {:?} to peer {:?}",
-                        current_batch.len(),
-                        current_batch_size,
-                        file_key,
-                        peer_id
-                    );
-
-                    // Generate proof for the final batch
-                    let proof = match self
-                        .storage_hub_handler
-                        .file_storage
-                        .read()
-                        .await
-                        .generate_proof(&file_key, &current_batch)
-                    {
-                        Ok(proof) => proof,
-                        Err(e) => {
-                            return Err(anyhow::anyhow!(
-                                "Failed to generate proof for final batch of file {:?}\n Error: {:?}",
-                                file_key,
-                                e
-                            ));
-                        }
-                    };
-
-                    let mut retry_attempts = 0;
-                    loop {
-                        let upload_response = self
-                            .storage_hub_handler
-                            .file_transfer
-                            .upload_request(peer_id, file_key.as_ref().into(), proof.clone(), None)
-                            .await;
-
-                        match upload_response {
-                            Ok(r) => {
-                                debug!(
-                                    target: LOG_TARGET,
-                                    "Successfully uploaded final batch for file {:?} to peer {:?}",
-                                    file_metadata.fingerprint,
-                                    peer_id
-                                );
-
-                                if r.file_complete {
-                                    info!(
-                                        target: LOG_TARGET,
-                                        "File upload complete. Peer {:?} has the entire file {:?}",
-                                        peer_id,
-                                        file_metadata.fingerprint
-                                    );
-                                }
-                                break;
-                            }
-                            Err(RequestError::RequestFailure(RequestFailure::Refused))
-                                if retry_attempts < 3 =>
-                            {
-                                warn!(
-                                    target: LOG_TARGET,
-                                    "Final batch upload rejected by peer {:?}, retrying... (attempt {})",
-                                    peer_id,
-                                    retry_attempts + 1
-                                );
-                                retry_attempts += 1;
-
-                                // Wait for a short time before retrying
-                                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                            }
-                            Err(RequestError::RequestFailure(RequestFailure::Refused)) => {
-                                // If MSP doesnt receive file, the burden of downloading the file will be on the MSP.
-                                return Err(anyhow::anyhow!("Failed to send file {:?}", file_key));
-                            }
-                            Err(e) => {
-                                error!(
-                                    target: LOG_TARGET,
-                                    "Failed to upload final batch to peer {:?}\n Error: {:?}",
-                                    peer_id,
-                                    e
-                                );
-                                break;
-                            }
-                        }
-                    }
+                Ok(()) => {
+                    // if successfull our job is done. No need to try with the next peer id.
+                    return Ok(());
                 }
-            }
-
-            info!(target: LOG_TARGET, "Successfully sent file {:?} to peer {:?}", file_metadata.fingerprint, peer_id);
-            return Ok(());
+            };
         }
 
         Err(anyhow::anyhow!(
             "Failed to send file {:?} to any of the peers",
             file_metadata.fingerprint
         ))
+    }
+
+    async fn send_chunks(
+        &mut self,
+        peer_id: PeerId,
+        file_metadata: &FileMetadata,
+        file_key: H256,
+        chunk_count: u64,
+    ) -> Result<(), anyhow::Error> {
+        debug!(target: LOG_TARGET, "Attempting to send chunks of file key {:?} to peer {:?}", file_key, peer_id);
+
+        let mut current_batch = Vec::new();
+        let mut current_batch_size = 0;
+
+        for chunk_id in 0..chunk_count {
+            // Calculate the size of the current chunk
+            let chunk_size = if chunk_id == chunk_count - 1 {
+                file_metadata.file_size % FILE_CHUNK_SIZE as u64
+            } else {
+                FILE_CHUNK_SIZE as u64
+            };
+
+            // Check if adding this chunk would exceed the batch size limit
+            if current_batch_size + (chunk_size as usize) > BATCH_CHUNK_FILE_TRANSFER_MAX_SIZE {
+                // Send current batch before adding new chunk
+                debug!(
+                    target: LOG_TARGET,
+                    "Sending batch of {} chunks (total size: {} bytes) for file {:?} to peer {:?}",
+                    current_batch.len(),
+                    current_batch_size,
+                    file_key,
+                    peer_id
+                );
+
+                // Generate proof for the entire batch
+                let proof = match self
+                    .storage_hub_handler
+                    .file_storage
+                    .read()
+                    .await
+                    .generate_proof(&file_key, &current_batch)
+                {
+                    Ok(proof) => proof,
+                    Err(e) => {
+                        return Err(anyhow::anyhow!(
+                            "Failed to generate proof for batch of file {:?}\n Error: {:?}",
+                            file_key,
+                            e
+                        ));
+                    }
+                };
+
+                let mut retry_attempts = 0;
+                loop {
+                    let upload_response = self
+                        .storage_hub_handler
+                        .file_transfer
+                        .upload_request(peer_id, file_key.as_ref().into(), proof.clone(), None)
+                        .await;
+
+                    match upload_response {
+                        Ok(r) => {
+                            debug!(
+                                target: LOG_TARGET,
+                                "Successfully uploaded batch for file {:?} to peer {:?}",
+                                file_metadata.fingerprint,
+                                peer_id
+                            );
+
+                            // If the provider signals they have the entire file, we can stop
+                            if r.file_complete {
+                                info!(
+                                    target: LOG_TARGET,
+                                    "Stopping file upload process. Peer {:?} has the entire file {:?}",
+                                    peer_id,
+                                    file_metadata.fingerprint
+                                );
+                                return Ok(());
+                            }
+
+                            break;
+                        }
+                        Err(RequestError::RequestFailure(RequestFailure::Refused))
+                            if retry_attempts < 3 =>
+                        {
+                            warn!(
+                                target: LOG_TARGET,
+                                "Batch upload rejected by peer {:?}, retrying... (attempt {})",
+                                peer_id,
+                                retry_attempts + 1
+                            );
+                            retry_attempts += 1;
+
+                            // Wait for a short time before retrying
+                            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                        }
+                        Err(RequestError::RequestFailure(RequestFailure::Refused)) => {
+                            // If MSP doesn't receive file, the burden of downloading the file will be on the MSP.
+                            return Err(anyhow::anyhow!("Failed to send file {:?}", file_key));
+                        }
+                        Err(e) => {
+                            return Err(anyhow::anyhow!(
+                                "Failed to upload batch to peer {:?} (Error: {:?})",
+                                peer_id,
+                                e
+                            ));
+                        }
+                    }
+                }
+
+                // Clear the batch for next iteration
+                current_batch.clear();
+                current_batch_size = 0;
+            }
+
+            // Add chunk to current batch
+            current_batch.push(ChunkId::new(chunk_id));
+            current_batch_size += chunk_size as usize;
+
+            // If this is the last chunk, send the final batch
+            if chunk_id == chunk_count - 1 && !current_batch.is_empty() {
+                debug!(
+                    target: LOG_TARGET,
+                    "Sending final batch of {} chunks (total size: {} bytes) for file {:?} to peer {:?}",
+                    current_batch.len(),
+                    current_batch_size,
+                    file_key,
+                    peer_id
+                );
+
+                // Generate proof for the final batch
+                let proof = match self
+                    .storage_hub_handler
+                    .file_storage
+                    .read()
+                    .await
+                    .generate_proof(&file_key, &current_batch)
+                {
+                    Ok(proof) => proof,
+                    Err(e) => {
+                        return Err(anyhow::anyhow!(
+                            "Failed to generate proof for final batch of file {:?}\n Error: {:?}",
+                            file_key,
+                            e
+                        ));
+                    }
+                };
+
+                let mut retry_attempts = 0;
+                loop {
+                    let upload_response = self
+                        .storage_hub_handler
+                        .file_transfer
+                        .upload_request(peer_id, file_key.as_ref().into(), proof.clone(), None)
+                        .await;
+
+                    match upload_response {
+                        Ok(r) => {
+                            debug!(
+                                target: LOG_TARGET,
+                                "Successfully uploaded final batch for file {:?} to peer {:?}",
+                                file_metadata.fingerprint,
+                                peer_id
+                            );
+
+                            if r.file_complete {
+                                info!(
+                                    target: LOG_TARGET,
+                                    "File upload complete. Peer {:?} has the entire file {:?}",
+                                    peer_id,
+                                    file_metadata.fingerprint
+                                );
+                            }
+                            break;
+                        }
+                        Err(RequestError::RequestFailure(RequestFailure::Refused))
+                            if retry_attempts < 3 =>
+                        {
+                            warn!(
+                                target: LOG_TARGET,
+                                "Final batch upload rejected by peer {:?}, retrying... (attempt {})",
+                                peer_id,
+                                retry_attempts + 1
+                            );
+                            retry_attempts += 1;
+
+                            // Wait for a short time before retrying
+                            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                        }
+                        Err(RequestError::RequestFailure(RequestFailure::Refused)) => {
+                            // If MSP doesn't receive file, the burden of downloading the file will be on the MSP.
+
+                            return Err(anyhow::anyhow!("Failed to send file {:?}", file_key));
+                        }
+                        Err(e) => {
+                            return Err(anyhow::anyhow!(
+                                "Failed to upload final batch to peer {:?} (Error: {:?})",
+                                peer_id,
+                                e
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        info!(target: LOG_TARGET, "Successfully sent file {:?} to peer {:?}", file_metadata.fingerprint, peer_id);
+        return Ok(());
     }
 }

--- a/node/src/tasks/user_sends_file.rs
+++ b/node/src/tasks/user_sends_file.rs
@@ -383,7 +383,8 @@ where
                                 tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                             }
                             Err(RequestError::RequestFailure(RequestFailure::Refused)) => {
-                                // TODO: Handle MSP not receiving file after multiple retries.
+                                // If MSP doesnt receive file, the burden of downloading the file will be on the MSP.
+                                return Err(anyhow::anyhow!("Failed to send file {:?}", file_key));
                             }
                             Err(e) => {
                                 error!(

--- a/node/src/tasks/user_sends_file.rs
+++ b/node/src/tasks/user_sends_file.rs
@@ -137,8 +137,7 @@ where
             info!(target: LOG_TARGET, "No peers were found to receive file key {:?}", file_key);
         }
 
-        self.send_chunks_to_providers(peer_ids, &file_metadata)
-            .await
+        self.send_chunks_to_provider(peer_ids, &file_metadata).await
     }
 }
 
@@ -184,8 +183,7 @@ where
             info!(target: LOG_TARGET, "No peers were found to receive file key {:?}", file_key);
         }
 
-        self.send_chunks_to_providers(peer_ids, &file_metadata)
-            .await
+        self.send_chunks_to_provider(peer_ids, &file_metadata).await
     }
 }
 
@@ -193,7 +191,7 @@ impl<NT> UserSendsFileTask<NT>
 where
     NT: ShNodeType,
 {
-    async fn send_chunks_to_providers(
+    async fn send_chunks_to_provider(
         &mut self,
         peer_ids: Vec<PeerId>,
         file_metadata: &FileMetadata,
@@ -209,12 +207,12 @@ where
                 .await
             {
                 Err(err) => {
-                    // if sending chunk failed with one peer id, we try with the next one.
+                    // If sending chunk failed with one peer id, we try with the next one.
                     warn!(target: LOG_TARGET, "{:?}", err);
                     continue;
                 }
                 Ok(()) => {
-                    // if successfull our job is done. No need to try with the next peer id.
+                    // If successful our job is done. No need to try with the next peer id.
                     return Ok(());
                 }
             };
@@ -321,12 +319,12 @@ where
                             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                         }
                         Err(RequestError::RequestFailure(RequestFailure::Refused)) => {
-                            // If MSP doesn't receive file, the burden of downloading the file will be on the MSP.
+                            // Return an error if the provider refused to answer.
                             return Err(anyhow::anyhow!("Failed to send file {:?}", file_key));
                         }
                         Err(e) => {
                             return Err(anyhow::anyhow!(
-                                "Failed to upload batch to peer {:?} (Error: {:?})",
+                                "Unexpected error while trying to upload batch to peer {:?} (Error: {:?})",
                                 peer_id,
                                 e
                             ));
@@ -414,13 +412,12 @@ where
                             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                         }
                         Err(RequestError::RequestFailure(RequestFailure::Refused)) => {
-                            // If MSP doesn't receive file, the burden of downloading the file will be on the MSP.
-
+                            // Return an error if the provider refused to answer.
                             return Err(anyhow::anyhow!("Failed to send file {:?}", file_key));
                         }
                         Err(e) => {
                             return Err(anyhow::anyhow!(
-                                "Failed to upload final batch to peer {:?} (Error: {:?})",
+                                "Unexpected error while trying to upload final batch to peer {:?} (Error: {:?})",
                                 peer_id,
                                 e
                             ));

--- a/test/suites/integration/user/send-file-to-provider.test.ts
+++ b/test/suites/integration/user/send-file-to-provider.test.ts
@@ -1,0 +1,144 @@
+import { describeMspNet, shUser, type EnrichedBspApi, getContainerIp, addMspContainer, mspThreeKey, createBucket } from "../../../util";
+import { CAPACITY, MAX_STORAGE_CAPACITY } from "../../../util/bspNet/consts.ts";
+
+describeMspNet("User: Send file to provider", ({ before, createUserApi, it }) => {
+    let userApi: EnrichedBspApi;
+
+    before(async () => {
+        userApi = await createUserApi();
+    });
+
+    it("MSP is down and user should show error logs", async () => {
+        const source = "res/smile.jpg";
+        const destination = "test/smile.jpg";
+        const bucketName = "enron";
+
+        const newBucketEventEvent = await userApi.createBucket(bucketName);
+        const newBucketEventDataBlob =
+            userApi.events.fileSystem.NewBucket.is(newBucketEventEvent) && newBucketEventEvent.data;
+
+        if (!newBucketEventDataBlob) {
+            throw new Error("Event doesn't match Type");
+        }
+
+        await userApi.rpc.storagehubclient.loadFileInStorage(
+            source,
+            destination,
+            userApi.shConsts.NODE_INFOS.user.AddressId,
+            newBucketEventDataBlob.bucketId
+        );
+
+        await userApi.docker.pauseBspContainer(userApi.shConsts.NODE_INFOS.msp1.containerName);
+
+        await userApi.block.seal({
+            calls: [
+                userApi.tx.fileSystem.issueStorageRequest(
+                    newBucketEventDataBlob.bucketId,
+                    destination,
+                    userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].fingerprint,
+                    userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].size,
+                    userApi.shConsts.DUMMY_MSP_ID,
+                    [userApi.shConsts.NODE_INFOS.user.expectedPeerId],
+                    {
+                        Basic: null
+                    }
+                )
+            ],
+            signer: shUser
+        });
+
+        await userApi.assert.eventPresent("fileSystem", "NewStorageRequest");
+
+        await userApi.docker.waitForLog({ searchString: "Failed to send file", containerName: userApi.shConsts.NODE_INFOS.user.containerName });
+    });
+
+    it("MSP first multihash is wrong and second should be correct. User will be able to connect and send file.", async () => {
+        const { containerName, rpcPort, p2pPort, peerId } = await addMspContainer({
+            name: "lola1",
+            additionalArgs: [
+                "--database=rocksdb",
+                `--max-storage-capacity=${MAX_STORAGE_CAPACITY}`,
+                `--jump-capacity=${CAPACITY[1024]}`,
+                "--msp-charging-period=12"
+            ]
+        });
+
+        //Give it some balance.
+        const amount = 10000n * 10n ** 12n;
+        await userApi.block.seal({ calls: [userApi.tx.sudo.sudo(userApi.tx.balances.forceSetBalance(mspThreeKey.address, amount))] });
+
+        const mspIp = await getContainerIp(containerName);
+        const multiAddressMsp = `/ip4/${mspIp}/tcp/${p2pPort}/p2p/${peerId}`;
+        await userApi.block.seal({
+            calls: [
+                userApi.tx.sudo.sudo(
+                    userApi.tx.providers.forceMspSignUp(
+                        mspThreeKey.address,
+                        mspThreeKey.publicKey,
+                        userApi.shConsts.CAPACITY_512,
+                        [`/ip4/51.75.30.194/tcp/30350/p2p/${peerId}`, multiAddressMsp],
+                        100 * 1024 * 1024,
+                        "Terms of Service...",
+                        9999999,
+                        mspThreeKey.address
+                    )
+                )
+            ]
+        });
+
+        const source = "res/smile.jpg";
+        const destination = "test/smile.jpg";
+        const bucketName = "theranos";
+
+        const valueProps = await userApi.call.storageProvidersApi.queryValuePropositionsForMsp(
+            mspThreeKey.publicKey
+        );
+
+        const localValuePropId = valueProps[0].id;
+        const newBucketEventEvent = await createBucket(
+            userApi,
+            bucketName, // Bucket name
+            localValuePropId, // Value proposition ID from MSP
+            `0xc0647914b37034d861ddc3f0750ded6defec0823de5c782f3ca7c64ba29a4a2e`, // We got with cyberchef
+            shUser // Owner (the user)
+        );
+        const newBucketEventDataBlob =
+            userApi.events.fileSystem.NewBucket.is(newBucketEventEvent) && newBucketEventEvent.data;
+
+        if (!newBucketEventDataBlob) {
+            throw new Error("Event doesn't match Type");
+        }
+
+        await userApi.rpc.storagehubclient.loadFileInStorage(
+            source,
+            destination,
+            userApi.shConsts.NODE_INFOS.user.AddressId,
+            newBucketEventDataBlob.bucketId
+        );
+
+        await userApi.block.seal({
+            calls: [
+                userApi.tx.fileSystem.issueStorageRequest(
+                    newBucketEventDataBlob.bucketId,
+                    destination,
+                    userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].fingerprint,
+                    userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].size,
+                    mspThreeKey.publicKey,
+                    [userApi.shConsts.NODE_INFOS.user.expectedPeerId],
+                    {
+                        Basic: null
+                    }
+                )
+            ],
+            signer: shUser
+        });
+
+        await userApi.assert.eventPresent("fileSystem", "NewStorageRequest");
+
+        // Fail to connect to the first libp2p address because it is a phony one.
+        await userApi.docker.waitForLog({ searchString: "Failed to upload batch to peer", containerName: userApi.shConsts.NODE_INFOS.user.containerName });
+
+        // Second libp2p address is the right one so we should successfully send the file through this one.
+        await userApi.docker.waitForLog({ searchString: "File upload complete.", containerName: userApi.shConsts.NODE_INFOS.user.containerName });
+    })
+});

--- a/test/suites/integration/user/send-file-to-provider.test.ts
+++ b/test/suites/integration/user/send-file-to-provider.test.ts
@@ -1,165 +1,165 @@
 import {
-  describeMspNet,
-  shUser,
-  type EnrichedBspApi,
-  getContainerIp,
-  addMspContainer,
-  mspThreeKey,
-  createBucket
+    describeMspNet,
+    shUser,
+    type EnrichedBspApi,
+    getContainerIp,
+    addMspContainer,
+    mspThreeKey,
+    createBucket
 } from "../../../util";
 import { CAPACITY, MAX_STORAGE_CAPACITY } from "../../../util/bspNet/consts.ts";
 
 describeMspNet("User: Send file to provider", ({ before, createUserApi, it }) => {
-  let userApi: EnrichedBspApi;
+    let userApi: EnrichedBspApi;
 
-  before(async () => {
-    userApi = await createUserApi();
-  });
-
-  it("MSP is down and user should show error logs", async () => {
-    const source = "res/smile.jpg";
-    const destination = "test/smile.jpg";
-    const bucketName = "enron";
-
-    const newBucketEventEvent = await userApi.createBucket(bucketName);
-    const newBucketEventDataBlob =
-      userApi.events.fileSystem.NewBucket.is(newBucketEventEvent) && newBucketEventEvent.data;
-
-    if (!newBucketEventDataBlob) {
-      throw new Error("Event doesn't match Type");
-    }
-
-    await userApi.rpc.storagehubclient.loadFileInStorage(
-      source,
-      destination,
-      userApi.shConsts.NODE_INFOS.user.AddressId,
-      newBucketEventDataBlob.bucketId
-    );
-
-    await userApi.docker.pauseBspContainer(userApi.shConsts.NODE_INFOS.msp1.containerName);
-
-    await userApi.block.seal({
-      calls: [
-        userApi.tx.fileSystem.issueStorageRequest(
-          newBucketEventDataBlob.bucketId,
-          destination,
-          userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].fingerprint,
-          userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].size,
-          userApi.shConsts.DUMMY_MSP_ID,
-          [userApi.shConsts.NODE_INFOS.user.expectedPeerId],
-          {
-            Basic: null
-          }
-        )
-      ],
-      signer: shUser
+    before(async () => {
+        userApi = await createUserApi();
     });
 
-    await userApi.assert.eventPresent("fileSystem", "NewStorageRequest");
+    it("MSP is down and user should show error logs", async () => {
+        const source = "res/smile.jpg";
+        const destination = "test/smile.jpg";
+        const bucketName = "enron";
 
-    await userApi.docker.waitForLog({
-      searchString: "Failed to send file",
-      containerName: userApi.shConsts.NODE_INFOS.user.containerName
-    });
-  });
+        const newBucketEventEvent = await userApi.createBucket(bucketName);
+        const newBucketEventDataBlob =
+            userApi.events.fileSystem.NewBucket.is(newBucketEventEvent) && newBucketEventEvent.data;
 
-  it("MSP first multihash is wrong and second should be correct. User will be able to connect and send file.", async () => {
-    const { containerName, rpcPort, p2pPort, peerId } = await addMspContainer({
-      name: "lola1",
-      additionalArgs: [
-        "--database=rocksdb",
-        `--max-storage-capacity=${MAX_STORAGE_CAPACITY}`,
-        `--jump-capacity=${CAPACITY[1024]}`,
-        "--msp-charging-period=12"
-      ]
-    });
+        if (!newBucketEventDataBlob) {
+            throw new Error("Event doesn't match Type");
+        }
 
-    //Give it some balance.
-    const amount = 10000n * 10n ** 12n;
-    await userApi.block.seal({
-      calls: [
-        userApi.tx.sudo.sudo(userApi.tx.balances.forceSetBalance(mspThreeKey.address, amount))
-      ]
-    });
+        await userApi.rpc.storagehubclient.loadFileInStorage(
+            source,
+            destination,
+            userApi.shConsts.NODE_INFOS.user.AddressId,
+            newBucketEventDataBlob.bucketId
+        );
 
-    const mspIp = await getContainerIp(containerName);
-    const multiAddressMsp = `/ip4/${mspIp}/tcp/${p2pPort}/p2p/${peerId}`;
-    await userApi.block.seal({
-      calls: [
-        userApi.tx.sudo.sudo(
-          userApi.tx.providers.forceMspSignUp(
-            mspThreeKey.address,
-            mspThreeKey.publicKey,
-            userApi.shConsts.CAPACITY_512,
-            [`/ip4/51.75.30.194/tcp/30350/p2p/${peerId}`, multiAddressMsp],
-            100 * 1024 * 1024,
-            "Terms of Service...",
-            9999999,
-            mspThreeKey.address
-          )
-        )
-      ]
-    });
+        await userApi.docker.pauseBspContainer(userApi.shConsts.NODE_INFOS.msp1.containerName);
 
-    const source = "res/smile.jpg";
-    const destination = "test/smile.jpg";
-    const bucketName = "theranos";
+        await userApi.block.seal({
+            calls: [
+                userApi.tx.fileSystem.issueStorageRequest(
+                    newBucketEventDataBlob.bucketId,
+                    destination,
+                    userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].fingerprint,
+                    userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].size,
+                    userApi.shConsts.DUMMY_MSP_ID,
+                    [userApi.shConsts.NODE_INFOS.user.expectedPeerId],
+                    {
+                        Basic: null
+                    }
+                )
+            ],
+            signer: shUser
+        });
 
-    const valueProps = await userApi.call.storageProvidersApi.queryValuePropositionsForMsp(
-      mspThreeKey.publicKey
-    );
+        await userApi.assert.eventPresent("fileSystem", "NewStorageRequest");
 
-    const localValuePropId = valueProps[0].id;
-    const newBucketEventEvent = await createBucket(
-      userApi,
-      bucketName, // Bucket name
-      localValuePropId, // Value proposition ID from MSP
-      "0xc0647914b37034d861ddc3f0750ded6defec0823de5c782f3ca7c64ba29a4a2e", // We got with cyberchef
-      shUser // Owner (the user)
-    );
-    const newBucketEventDataBlob =
-      userApi.events.fileSystem.NewBucket.is(newBucketEventEvent) && newBucketEventEvent.data;
-
-    if (!newBucketEventDataBlob) {
-      throw new Error("Event doesn't match Type");
-    }
-
-    await userApi.rpc.storagehubclient.loadFileInStorage(
-      source,
-      destination,
-      userApi.shConsts.NODE_INFOS.user.AddressId,
-      newBucketEventDataBlob.bucketId
-    );
-
-    await userApi.block.seal({
-      calls: [
-        userApi.tx.fileSystem.issueStorageRequest(
-          newBucketEventDataBlob.bucketId,
-          destination,
-          userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].fingerprint,
-          userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].size,
-          mspThreeKey.publicKey,
-          [userApi.shConsts.NODE_INFOS.user.expectedPeerId],
-          {
-            Basic: null
-          }
-        )
-      ],
-      signer: shUser
+        await userApi.docker.waitForLog({
+            searchString: "Failed to send file",
+            containerName: userApi.shConsts.NODE_INFOS.user.containerName
+        });
     });
 
-    await userApi.assert.eventPresent("fileSystem", "NewStorageRequest");
+    it("MSP first multihash is wrong and second should be correct. User will be able to connect and send file.", async () => {
+        const { containerName, p2pPort, peerId } = await addMspContainer({
+            name: "lola1",
+            additionalArgs: [
+                "--database=rocksdb",
+                `--max-storage-capacity=${MAX_STORAGE_CAPACITY}`,
+                `--jump-capacity=${CAPACITY[1024]}`,
+                "--msp-charging-period=12"
+            ]
+        });
 
-    // Fail to connect to the first libp2p address because it is a phony one.
-    await userApi.docker.waitForLog({
-      searchString: "Failed to upload batch to peer",
-      containerName: userApi.shConsts.NODE_INFOS.user.containerName
-    });
+        //Give it some balance.
+        const amount = 10000n * 10n ** 12n;
+        await userApi.block.seal({
+            calls: [
+                userApi.tx.sudo.sudo(userApi.tx.balances.forceSetBalance(mspThreeKey.address, amount))
+            ]
+        });
 
-    // Second libp2p address is the right one so we should successfully send the file through this one.
-    await userApi.docker.waitForLog({
-      searchString: "File upload complete.",
-      containerName: userApi.shConsts.NODE_INFOS.user.containerName
+        const mspIp = await getContainerIp(containerName);
+        const multiAddressMsp = `/ip4/${mspIp}/tcp/${p2pPort}/p2p/${peerId}`;
+        await userApi.block.seal({
+            calls: [
+                userApi.tx.sudo.sudo(
+                    userApi.tx.providers.forceMspSignUp(
+                        mspThreeKey.address,
+                        mspThreeKey.publicKey,
+                        userApi.shConsts.CAPACITY_512,
+                        [`/ip4/51.75.30.194/tcp/30350/p2p/${peerId}`, multiAddressMsp],
+                        100 * 1024 * 1024,
+                        "Terms of Service...",
+                        9999999,
+                        mspThreeKey.address
+                    )
+                )
+            ]
+        });
+
+        const source = "res/smile.jpg";
+        const destination = "test/smile.jpg";
+        const bucketName = "theranos";
+
+        const valueProps = await userApi.call.storageProvidersApi.queryValuePropositionsForMsp(
+            mspThreeKey.publicKey
+        );
+
+        const localValuePropId = valueProps[0].id;
+        const newBucketEventEvent = await createBucket(
+            userApi,
+            bucketName, // Bucket name
+            localValuePropId, // Value proposition ID from MSP
+            "0xc0647914b37034d861ddc3f0750ded6defec0823de5c782f3ca7c64ba29a4a2e", // We got with cyberchef
+            shUser // Owner (the user)
+        );
+        const newBucketEventDataBlob =
+            userApi.events.fileSystem.NewBucket.is(newBucketEventEvent) && newBucketEventEvent.data;
+
+        if (!newBucketEventDataBlob) {
+            throw new Error("Event doesn't match Type");
+        }
+
+        await userApi.rpc.storagehubclient.loadFileInStorage(
+            source,
+            destination,
+            userApi.shConsts.NODE_INFOS.user.AddressId,
+            newBucketEventDataBlob.bucketId
+        );
+
+        await userApi.block.seal({
+            calls: [
+                userApi.tx.fileSystem.issueStorageRequest(
+                    newBucketEventDataBlob.bucketId,
+                    destination,
+                    userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].fingerprint,
+                    userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].size,
+                    mspThreeKey.publicKey,
+                    [userApi.shConsts.NODE_INFOS.user.expectedPeerId],
+                    {
+                        Basic: null
+                    }
+                )
+            ],
+            signer: shUser
+        });
+
+        await userApi.assert.eventPresent("fileSystem", "NewStorageRequest");
+
+        // Fail to connect to the first libp2p address because it is a phony one.
+        await userApi.docker.waitForLog({
+            searchString: "Failed to upload batch to peer",
+            containerName: userApi.shConsts.NODE_INFOS.user.containerName
+        });
+
+        // Second libp2p address is the right one so we should successfully send the file through this one.
+        await userApi.docker.waitForLog({
+            searchString: "File upload complete.",
+            containerName: userApi.shConsts.NODE_INFOS.user.containerName
+        });
     });
-  });
 });

--- a/test/suites/integration/user/send-file-to-provider.test.ts
+++ b/test/suites/integration/user/send-file-to-provider.test.ts
@@ -1,144 +1,165 @@
-import { describeMspNet, shUser, type EnrichedBspApi, getContainerIp, addMspContainer, mspThreeKey, createBucket } from "../../../util";
+import {
+  describeMspNet,
+  shUser,
+  type EnrichedBspApi,
+  getContainerIp,
+  addMspContainer,
+  mspThreeKey,
+  createBucket
+} from "../../../util";
 import { CAPACITY, MAX_STORAGE_CAPACITY } from "../../../util/bspNet/consts.ts";
 
 describeMspNet("User: Send file to provider", ({ before, createUserApi, it }) => {
-    let userApi: EnrichedBspApi;
+  let userApi: EnrichedBspApi;
 
-    before(async () => {
-        userApi = await createUserApi();
+  before(async () => {
+    userApi = await createUserApi();
+  });
+
+  it("MSP is down and user should show error logs", async () => {
+    const source = "res/smile.jpg";
+    const destination = "test/smile.jpg";
+    const bucketName = "enron";
+
+    const newBucketEventEvent = await userApi.createBucket(bucketName);
+    const newBucketEventDataBlob =
+      userApi.events.fileSystem.NewBucket.is(newBucketEventEvent) && newBucketEventEvent.data;
+
+    if (!newBucketEventDataBlob) {
+      throw new Error("Event doesn't match Type");
+    }
+
+    await userApi.rpc.storagehubclient.loadFileInStorage(
+      source,
+      destination,
+      userApi.shConsts.NODE_INFOS.user.AddressId,
+      newBucketEventDataBlob.bucketId
+    );
+
+    await userApi.docker.pauseBspContainer(userApi.shConsts.NODE_INFOS.msp1.containerName);
+
+    await userApi.block.seal({
+      calls: [
+        userApi.tx.fileSystem.issueStorageRequest(
+          newBucketEventDataBlob.bucketId,
+          destination,
+          userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].fingerprint,
+          userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].size,
+          userApi.shConsts.DUMMY_MSP_ID,
+          [userApi.shConsts.NODE_INFOS.user.expectedPeerId],
+          {
+            Basic: null
+          }
+        )
+      ],
+      signer: shUser
     });
 
-    it("MSP is down and user should show error logs", async () => {
-        const source = "res/smile.jpg";
-        const destination = "test/smile.jpg";
-        const bucketName = "enron";
+    await userApi.assert.eventPresent("fileSystem", "NewStorageRequest");
 
-        const newBucketEventEvent = await userApi.createBucket(bucketName);
-        const newBucketEventDataBlob =
-            userApi.events.fileSystem.NewBucket.is(newBucketEventEvent) && newBucketEventEvent.data;
+    await userApi.docker.waitForLog({
+      searchString: "Failed to send file",
+      containerName: userApi.shConsts.NODE_INFOS.user.containerName
+    });
+  });
 
-        if (!newBucketEventDataBlob) {
-            throw new Error("Event doesn't match Type");
-        }
-
-        await userApi.rpc.storagehubclient.loadFileInStorage(
-            source,
-            destination,
-            userApi.shConsts.NODE_INFOS.user.AddressId,
-            newBucketEventDataBlob.bucketId
-        );
-
-        await userApi.docker.pauseBspContainer(userApi.shConsts.NODE_INFOS.msp1.containerName);
-
-        await userApi.block.seal({
-            calls: [
-                userApi.tx.fileSystem.issueStorageRequest(
-                    newBucketEventDataBlob.bucketId,
-                    destination,
-                    userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].fingerprint,
-                    userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].size,
-                    userApi.shConsts.DUMMY_MSP_ID,
-                    [userApi.shConsts.NODE_INFOS.user.expectedPeerId],
-                    {
-                        Basic: null
-                    }
-                )
-            ],
-            signer: shUser
-        });
-
-        await userApi.assert.eventPresent("fileSystem", "NewStorageRequest");
-
-        await userApi.docker.waitForLog({ searchString: "Failed to send file", containerName: userApi.shConsts.NODE_INFOS.user.containerName });
+  it("MSP first multihash is wrong and second should be correct. User will be able to connect and send file.", async () => {
+    const { containerName, rpcPort, p2pPort, peerId } = await addMspContainer({
+      name: "lola1",
+      additionalArgs: [
+        "--database=rocksdb",
+        `--max-storage-capacity=${MAX_STORAGE_CAPACITY}`,
+        `--jump-capacity=${CAPACITY[1024]}`,
+        "--msp-charging-period=12"
+      ]
     });
 
-    it("MSP first multihash is wrong and second should be correct. User will be able to connect and send file.", async () => {
-        const { containerName, rpcPort, p2pPort, peerId } = await addMspContainer({
-            name: "lola1",
-            additionalArgs: [
-                "--database=rocksdb",
-                `--max-storage-capacity=${MAX_STORAGE_CAPACITY}`,
-                `--jump-capacity=${CAPACITY[1024]}`,
-                "--msp-charging-period=12"
-            ]
-        });
+    //Give it some balance.
+    const amount = 10000n * 10n ** 12n;
+    await userApi.block.seal({
+      calls: [
+        userApi.tx.sudo.sudo(userApi.tx.balances.forceSetBalance(mspThreeKey.address, amount))
+      ]
+    });
 
-        //Give it some balance.
-        const amount = 10000n * 10n ** 12n;
-        await userApi.block.seal({ calls: [userApi.tx.sudo.sudo(userApi.tx.balances.forceSetBalance(mspThreeKey.address, amount))] });
+    const mspIp = await getContainerIp(containerName);
+    const multiAddressMsp = `/ip4/${mspIp}/tcp/${p2pPort}/p2p/${peerId}`;
+    await userApi.block.seal({
+      calls: [
+        userApi.tx.sudo.sudo(
+          userApi.tx.providers.forceMspSignUp(
+            mspThreeKey.address,
+            mspThreeKey.publicKey,
+            userApi.shConsts.CAPACITY_512,
+            [`/ip4/51.75.30.194/tcp/30350/p2p/${peerId}`, multiAddressMsp],
+            100 * 1024 * 1024,
+            "Terms of Service...",
+            9999999,
+            mspThreeKey.address
+          )
+        )
+      ]
+    });
 
-        const mspIp = await getContainerIp(containerName);
-        const multiAddressMsp = `/ip4/${mspIp}/tcp/${p2pPort}/p2p/${peerId}`;
-        await userApi.block.seal({
-            calls: [
-                userApi.tx.sudo.sudo(
-                    userApi.tx.providers.forceMspSignUp(
-                        mspThreeKey.address,
-                        mspThreeKey.publicKey,
-                        userApi.shConsts.CAPACITY_512,
-                        [`/ip4/51.75.30.194/tcp/30350/p2p/${peerId}`, multiAddressMsp],
-                        100 * 1024 * 1024,
-                        "Terms of Service...",
-                        9999999,
-                        mspThreeKey.address
-                    )
-                )
-            ]
-        });
+    const source = "res/smile.jpg";
+    const destination = "test/smile.jpg";
+    const bucketName = "theranos";
 
-        const source = "res/smile.jpg";
-        const destination = "test/smile.jpg";
-        const bucketName = "theranos";
+    const valueProps = await userApi.call.storageProvidersApi.queryValuePropositionsForMsp(
+      mspThreeKey.publicKey
+    );
 
-        const valueProps = await userApi.call.storageProvidersApi.queryValuePropositionsForMsp(
-            mspThreeKey.publicKey
-        );
+    const localValuePropId = valueProps[0].id;
+    const newBucketEventEvent = await createBucket(
+      userApi,
+      bucketName, // Bucket name
+      localValuePropId, // Value proposition ID from MSP
+      "0xc0647914b37034d861ddc3f0750ded6defec0823de5c782f3ca7c64ba29a4a2e", // We got with cyberchef
+      shUser // Owner (the user)
+    );
+    const newBucketEventDataBlob =
+      userApi.events.fileSystem.NewBucket.is(newBucketEventEvent) && newBucketEventEvent.data;
 
-        const localValuePropId = valueProps[0].id;
-        const newBucketEventEvent = await createBucket(
-            userApi,
-            bucketName, // Bucket name
-            localValuePropId, // Value proposition ID from MSP
-            `0xc0647914b37034d861ddc3f0750ded6defec0823de5c782f3ca7c64ba29a4a2e`, // We got with cyberchef
-            shUser // Owner (the user)
-        );
-        const newBucketEventDataBlob =
-            userApi.events.fileSystem.NewBucket.is(newBucketEventEvent) && newBucketEventEvent.data;
+    if (!newBucketEventDataBlob) {
+      throw new Error("Event doesn't match Type");
+    }
 
-        if (!newBucketEventDataBlob) {
-            throw new Error("Event doesn't match Type");
-        }
+    await userApi.rpc.storagehubclient.loadFileInStorage(
+      source,
+      destination,
+      userApi.shConsts.NODE_INFOS.user.AddressId,
+      newBucketEventDataBlob.bucketId
+    );
 
-        await userApi.rpc.storagehubclient.loadFileInStorage(
-            source,
-            destination,
-            userApi.shConsts.NODE_INFOS.user.AddressId,
-            newBucketEventDataBlob.bucketId
-        );
+    await userApi.block.seal({
+      calls: [
+        userApi.tx.fileSystem.issueStorageRequest(
+          newBucketEventDataBlob.bucketId,
+          destination,
+          userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].fingerprint,
+          userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].size,
+          mspThreeKey.publicKey,
+          [userApi.shConsts.NODE_INFOS.user.expectedPeerId],
+          {
+            Basic: null
+          }
+        )
+      ],
+      signer: shUser
+    });
 
-        await userApi.block.seal({
-            calls: [
-                userApi.tx.fileSystem.issueStorageRequest(
-                    newBucketEventDataBlob.bucketId,
-                    destination,
-                    userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].fingerprint,
-                    userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].size,
-                    mspThreeKey.publicKey,
-                    [userApi.shConsts.NODE_INFOS.user.expectedPeerId],
-                    {
-                        Basic: null
-                    }
-                )
-            ],
-            signer: shUser
-        });
+    await userApi.assert.eventPresent("fileSystem", "NewStorageRequest");
 
-        await userApi.assert.eventPresent("fileSystem", "NewStorageRequest");
+    // Fail to connect to the first libp2p address because it is a phony one.
+    await userApi.docker.waitForLog({
+      searchString: "Failed to upload batch to peer",
+      containerName: userApi.shConsts.NODE_INFOS.user.containerName
+    });
 
-        // Fail to connect to the first libp2p address because it is a phony one.
-        await userApi.docker.waitForLog({ searchString: "Failed to upload batch to peer", containerName: userApi.shConsts.NODE_INFOS.user.containerName });
-
-        // Second libp2p address is the right one so we should successfully send the file through this one.
-        await userApi.docker.waitForLog({ searchString: "File upload complete.", containerName: userApi.shConsts.NODE_INFOS.user.containerName });
-    })
+    // Second libp2p address is the right one so we should successfully send the file through this one.
+    await userApi.docker.waitForLog({
+      searchString: "File upload complete.",
+      containerName: userApi.shConsts.NODE_INFOS.user.containerName
+    });
+  });
 });

--- a/test/suites/integration/user/send-file-to-provider.test.ts
+++ b/test/suites/integration/user/send-file-to-provider.test.ts
@@ -63,7 +63,7 @@ describeMspNet("User: Send file to provider", ({ before, createUserApi, it }) =>
     });
   });
 
-  it("MSP first multihash is wrong and second should be correct. User will be able to connect and send file.", async () => {
+  it("MSP first libp2p multiaddress is wrong and second should be correct. User will be able to connect and send file on the second attempt.", async () => {
     const { containerName, p2pPort, peerId } = await addMspContainer({
       name: "lola1",
       additionalArgs: [

--- a/test/suites/integration/user/send-file-to-provider.test.ts
+++ b/test/suites/integration/user/send-file-to-provider.test.ts
@@ -1,165 +1,165 @@
 import {
-    describeMspNet,
-    shUser,
-    type EnrichedBspApi,
-    getContainerIp,
-    addMspContainer,
-    mspThreeKey,
-    createBucket
+  describeMspNet,
+  shUser,
+  type EnrichedBspApi,
+  getContainerIp,
+  addMspContainer,
+  mspThreeKey,
+  createBucket
 } from "../../../util";
 import { CAPACITY, MAX_STORAGE_CAPACITY } from "../../../util/bspNet/consts.ts";
 
 describeMspNet("User: Send file to provider", ({ before, createUserApi, it }) => {
-    let userApi: EnrichedBspApi;
+  let userApi: EnrichedBspApi;
 
-    before(async () => {
-        userApi = await createUserApi();
+  before(async () => {
+    userApi = await createUserApi();
+  });
+
+  it("MSP is down and user should show error logs", async () => {
+    const source = "res/smile.jpg";
+    const destination = "test/smile.jpg";
+    const bucketName = "enron";
+
+    const newBucketEventEvent = await userApi.createBucket(bucketName);
+    const newBucketEventDataBlob =
+      userApi.events.fileSystem.NewBucket.is(newBucketEventEvent) && newBucketEventEvent.data;
+
+    if (!newBucketEventDataBlob) {
+      throw new Error("Event doesn't match Type");
+    }
+
+    await userApi.rpc.storagehubclient.loadFileInStorage(
+      source,
+      destination,
+      userApi.shConsts.NODE_INFOS.user.AddressId,
+      newBucketEventDataBlob.bucketId
+    );
+
+    await userApi.docker.pauseBspContainer(userApi.shConsts.NODE_INFOS.msp1.containerName);
+
+    await userApi.block.seal({
+      calls: [
+        userApi.tx.fileSystem.issueStorageRequest(
+          newBucketEventDataBlob.bucketId,
+          destination,
+          userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].fingerprint,
+          userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].size,
+          userApi.shConsts.DUMMY_MSP_ID,
+          [userApi.shConsts.NODE_INFOS.user.expectedPeerId],
+          {
+            Basic: null
+          }
+        )
+      ],
+      signer: shUser
     });
 
-    it("MSP is down and user should show error logs", async () => {
-        const source = "res/smile.jpg";
-        const destination = "test/smile.jpg";
-        const bucketName = "enron";
+    await userApi.assert.eventPresent("fileSystem", "NewStorageRequest");
 
-        const newBucketEventEvent = await userApi.createBucket(bucketName);
-        const newBucketEventDataBlob =
-            userApi.events.fileSystem.NewBucket.is(newBucketEventEvent) && newBucketEventEvent.data;
+    await userApi.docker.waitForLog({
+      searchString: "Failed to send file",
+      containerName: userApi.shConsts.NODE_INFOS.user.containerName
+    });
+  });
 
-        if (!newBucketEventDataBlob) {
-            throw new Error("Event doesn't match Type");
-        }
-
-        await userApi.rpc.storagehubclient.loadFileInStorage(
-            source,
-            destination,
-            userApi.shConsts.NODE_INFOS.user.AddressId,
-            newBucketEventDataBlob.bucketId
-        );
-
-        await userApi.docker.pauseBspContainer(userApi.shConsts.NODE_INFOS.msp1.containerName);
-
-        await userApi.block.seal({
-            calls: [
-                userApi.tx.fileSystem.issueStorageRequest(
-                    newBucketEventDataBlob.bucketId,
-                    destination,
-                    userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].fingerprint,
-                    userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].size,
-                    userApi.shConsts.DUMMY_MSP_ID,
-                    [userApi.shConsts.NODE_INFOS.user.expectedPeerId],
-                    {
-                        Basic: null
-                    }
-                )
-            ],
-            signer: shUser
-        });
-
-        await userApi.assert.eventPresent("fileSystem", "NewStorageRequest");
-
-        await userApi.docker.waitForLog({
-            searchString: "Failed to send file",
-            containerName: userApi.shConsts.NODE_INFOS.user.containerName
-        });
+  it("MSP first multihash is wrong and second should be correct. User will be able to connect and send file.", async () => {
+    const { containerName, p2pPort, peerId } = await addMspContainer({
+      name: "lola1",
+      additionalArgs: [
+        "--database=rocksdb",
+        `--max-storage-capacity=${MAX_STORAGE_CAPACITY}`,
+        `--jump-capacity=${CAPACITY[1024]}`,
+        "--msp-charging-period=12"
+      ]
     });
 
-    it("MSP first multihash is wrong and second should be correct. User will be able to connect and send file.", async () => {
-        const { containerName, p2pPort, peerId } = await addMspContainer({
-            name: "lola1",
-            additionalArgs: [
-                "--database=rocksdb",
-                `--max-storage-capacity=${MAX_STORAGE_CAPACITY}`,
-                `--jump-capacity=${CAPACITY[1024]}`,
-                "--msp-charging-period=12"
-            ]
-        });
-
-        //Give it some balance.
-        const amount = 10000n * 10n ** 12n;
-        await userApi.block.seal({
-            calls: [
-                userApi.tx.sudo.sudo(userApi.tx.balances.forceSetBalance(mspThreeKey.address, amount))
-            ]
-        });
-
-        const mspIp = await getContainerIp(containerName);
-        const multiAddressMsp = `/ip4/${mspIp}/tcp/${p2pPort}/p2p/${peerId}`;
-        await userApi.block.seal({
-            calls: [
-                userApi.tx.sudo.sudo(
-                    userApi.tx.providers.forceMspSignUp(
-                        mspThreeKey.address,
-                        mspThreeKey.publicKey,
-                        userApi.shConsts.CAPACITY_512,
-                        [`/ip4/51.75.30.194/tcp/30350/p2p/${peerId}`, multiAddressMsp],
-                        100 * 1024 * 1024,
-                        "Terms of Service...",
-                        9999999,
-                        mspThreeKey.address
-                    )
-                )
-            ]
-        });
-
-        const source = "res/smile.jpg";
-        const destination = "test/smile.jpg";
-        const bucketName = "theranos";
-
-        const valueProps = await userApi.call.storageProvidersApi.queryValuePropositionsForMsp(
-            mspThreeKey.publicKey
-        );
-
-        const localValuePropId = valueProps[0].id;
-        const newBucketEventEvent = await createBucket(
-            userApi,
-            bucketName, // Bucket name
-            localValuePropId, // Value proposition ID from MSP
-            "0xc0647914b37034d861ddc3f0750ded6defec0823de5c782f3ca7c64ba29a4a2e", // We got with cyberchef
-            shUser // Owner (the user)
-        );
-        const newBucketEventDataBlob =
-            userApi.events.fileSystem.NewBucket.is(newBucketEventEvent) && newBucketEventEvent.data;
-
-        if (!newBucketEventDataBlob) {
-            throw new Error("Event doesn't match Type");
-        }
-
-        await userApi.rpc.storagehubclient.loadFileInStorage(
-            source,
-            destination,
-            userApi.shConsts.NODE_INFOS.user.AddressId,
-            newBucketEventDataBlob.bucketId
-        );
-
-        await userApi.block.seal({
-            calls: [
-                userApi.tx.fileSystem.issueStorageRequest(
-                    newBucketEventDataBlob.bucketId,
-                    destination,
-                    userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].fingerprint,
-                    userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].size,
-                    mspThreeKey.publicKey,
-                    [userApi.shConsts.NODE_INFOS.user.expectedPeerId],
-                    {
-                        Basic: null
-                    }
-                )
-            ],
-            signer: shUser
-        });
-
-        await userApi.assert.eventPresent("fileSystem", "NewStorageRequest");
-
-        // Fail to connect to the first libp2p address because it is a phony one.
-        await userApi.docker.waitForLog({
-            searchString: "Failed to upload batch to peer",
-            containerName: userApi.shConsts.NODE_INFOS.user.containerName
-        });
-
-        // Second libp2p address is the right one so we should successfully send the file through this one.
-        await userApi.docker.waitForLog({
-            searchString: "File upload complete.",
-            containerName: userApi.shConsts.NODE_INFOS.user.containerName
-        });
+    //Give it some balance.
+    const amount = 10000n * 10n ** 12n;
+    await userApi.block.seal({
+      calls: [
+        userApi.tx.sudo.sudo(userApi.tx.balances.forceSetBalance(mspThreeKey.address, amount))
+      ]
     });
+
+    const mspIp = await getContainerIp(containerName);
+    const multiAddressMsp = `/ip4/${mspIp}/tcp/${p2pPort}/p2p/${peerId}`;
+    await userApi.block.seal({
+      calls: [
+        userApi.tx.sudo.sudo(
+          userApi.tx.providers.forceMspSignUp(
+            mspThreeKey.address,
+            mspThreeKey.publicKey,
+            userApi.shConsts.CAPACITY_512,
+            [`/ip4/51.75.30.194/tcp/30350/p2p/${peerId}`, multiAddressMsp],
+            100 * 1024 * 1024,
+            "Terms of Service...",
+            9999999,
+            mspThreeKey.address
+          )
+        )
+      ]
+    });
+
+    const source = "res/smile.jpg";
+    const destination = "test/smile.jpg";
+    const bucketName = "theranos";
+
+    const valueProps = await userApi.call.storageProvidersApi.queryValuePropositionsForMsp(
+      mspThreeKey.publicKey
+    );
+
+    const localValuePropId = valueProps[0].id;
+    const newBucketEventEvent = await createBucket(
+      userApi,
+      bucketName, // Bucket name
+      localValuePropId, // Value proposition ID from MSP
+      "0xc0647914b37034d861ddc3f0750ded6defec0823de5c782f3ca7c64ba29a4a2e", // We got with cyberchef
+      shUser // Owner (the user)
+    );
+    const newBucketEventDataBlob =
+      userApi.events.fileSystem.NewBucket.is(newBucketEventEvent) && newBucketEventEvent.data;
+
+    if (!newBucketEventDataBlob) {
+      throw new Error("Event doesn't match Type");
+    }
+
+    await userApi.rpc.storagehubclient.loadFileInStorage(
+      source,
+      destination,
+      userApi.shConsts.NODE_INFOS.user.AddressId,
+      newBucketEventDataBlob.bucketId
+    );
+
+    await userApi.block.seal({
+      calls: [
+        userApi.tx.fileSystem.issueStorageRequest(
+          newBucketEventDataBlob.bucketId,
+          destination,
+          userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].fingerprint,
+          userApi.shConsts.TEST_ARTEFACTS["res/smile.jpg"].size,
+          mspThreeKey.publicKey,
+          [userApi.shConsts.NODE_INFOS.user.expectedPeerId],
+          {
+            Basic: null
+          }
+        )
+      ],
+      signer: shUser
+    });
+
+    await userApi.assert.eventPresent("fileSystem", "NewStorageRequest");
+
+    // Fail to connect to the first libp2p address because it is a phony one.
+    await userApi.docker.waitForLog({
+      searchString: "Failed to upload batch to peer",
+      containerName: userApi.shConsts.NODE_INFOS.user.containerName
+    });
+
+    // Second libp2p address is the right one so we should successfully send the file through this one.
+    await userApi.docker.waitForLog({
+      searchString: "File upload complete.",
+      containerName: userApi.shConsts.NODE_INFOS.user.containerName
+    });
+  });
 });

--- a/test/util/pjsKeyring.ts
+++ b/test/util/pjsKeyring.ts
@@ -36,6 +36,8 @@ export const mspDownSeed = "//Sh-MSP-Down";
 export const mspDownKey = keyring.addFromUri(mspDownSeed, { name: "Sh-MSP-Down" });
 export const mspTwoSeed = "//Sh-MSP-Two";
 export const mspTwoKey = keyring.addFromUri(mspTwoSeed, { name: "Sh-MSP-Two" });
+export const mspThreeSeed = "//Sh-MSP-Three";
+export const mspThreeKey = keyring.addFromUri(mspThreeSeed, { name: "Sh-MSP-Three" });
 
 export const collator = keyring.addFromUri("//Sh-collator", {
   name: "Sh-collator"


### PR DESCRIPTION
This PR is a small refactor of the user sending file task so it improves the logs. It also add 2 integration tests that test two scenarios : 
* The provider is offline and the user cannot connect to it. It will show the proper error message and exit with an error (the previous behavior showed a success log even when the file was not send).
* The provider has 2 libp2p multiaddresses register to its name. The first one is not valid and the user can connect. The second is correct and the user should successfully send the file. 