### PR TITLE
refactor: change name for docker utils function in integration tests

### DIFF
--- a/test/suites/integration/bsp/bsp-thresholds.test.ts
+++ b/test/suites/integration/bsp/bsp-thresholds.test.ts
@@ -289,7 +289,7 @@ describeBspNet(
         "Zero reputation BSP should be able to volunteer and be accepted"
       );
       await bspDownApi.disconnect();
-      await userApi.docker.stopBspContainer("sh-bsp-down");
+      await userApi.docker.stopContainer("sh-bsp-down");
     });
 
     it("BSP two eventually volunteers after threshold curve is met", async () => {
@@ -372,7 +372,7 @@ describeBspNet(
       await userApi.wait.bspStored(1);
 
       await bspTwoApi.disconnect();
-      await userApi.docker.stopBspContainer("sh-bsp-two");
+      await userApi.docker.stopContainer("sh-bsp-two");
     });
 
     it("BSP with reputation is prioritised", async () => {
@@ -477,7 +477,7 @@ describeBspNet(
       // Verify that the BSP with reputation is prioritised over the lower reputation BSPs
       assert(filtered.length === 1, "BSP with reputation should be prioritised");
       await bspThreeApi.disconnect();
-      await userApi.docker.stopBspContainer("sh-bsp-three");
+      await userApi.docker.stopContainer("sh-bsp-three");
     });
 
     it(
@@ -549,7 +549,7 @@ describeBspNet(
           "BSP two should not be able to spam the chain and reach his threshold to volunteer"
         );
 
-        await userApi.docker.stopBspContainer("sh-bsp-two");
+        await userApi.docker.stopContainer("sh-bsp-two");
       }
     );
   }

--- a/test/suites/integration/bsp/challenge-cycle.test.ts
+++ b/test/suites/integration/bsp/challenge-cycle.test.ts
@@ -63,7 +63,7 @@ describeBspNet(
 
     it("BSP fails to submit proof and is marked as slashable", async () => {
       // Stop BSP.
-      await userApi.docker.pauseBspContainer(userApi.shConsts.NODE_INFOS.bsp.containerName);
+      await userApi.docker.pauseContainer(userApi.shConsts.NODE_INFOS.bsp.containerName);
 
       // Calculate the next deadline tick for the BSP. That is `ChallengeTicksTolerance`
       // after the next challenge tick for this BSP.
@@ -113,7 +113,7 @@ describeBspNet(
       },
       async () => {
         // Resume BSP.
-        await userApi.docker.resumeBspContainer({
+        await userApi.docker.resumeContainer({
           containerName: userApi.shConsts.NODE_INFOS.bsp.containerName
         });
 

--- a/test/suites/integration/bsp/storage-capacity.test.ts
+++ b/test/suites/integration/bsp/storage-capacity.test.ts
@@ -348,7 +348,7 @@ describeBspNet("BSPNet: Change capacity tests.", ({ before, it, createUserApi })
     await userApi.wait.bspCatchUpToChainTip(bspTwoApi);
 
     // Stop the other BSP so it doesn't volunteer for the files.
-    await userApi.docker.pauseBspContainer("docker-sh-bsp-1");
+    await userApi.docker.pauseContainer("docker-sh-bsp-1");
 
     // Issue the first storage request. The new BSP should have enough capacity to volunteer for it.
     const source1 = "res/cloud.jpg";
@@ -425,7 +425,7 @@ describeBspNet("BSPNet: Change capacity tests.", ({ before, it, createUserApi })
     );
 
     // Disconnect and stop the new BSP.
-    await userApi.docker.stopBspContainer("sh-bsp-two");
+    await userApi.docker.stopContainer("sh-bsp-two");
     await bspTwoApi.disconnect();
   });
 });

--- a/test/suites/integration/bsp/storage-delete.test.ts
+++ b/test/suites/integration/bsp/storage-delete.test.ts
@@ -40,7 +40,7 @@ describeBspNet(
       const bucketName = "tastytest";
 
       // Pause BSP-Three.
-      await userApi.docker.pauseBspContainer("sh-bsp-three");
+      await userApi.docker.pauseContainer("sh-bsp-three");
 
       const { fileKey, location, fingerprint, fileSize, bucketId } =
         await userApi.file.createBucketAndSendNewStorageRequest(source, destination, bucketName);
@@ -58,7 +58,7 @@ describeBspNet(
       await userApi.assert.eventPresent("fileSystem", "StorageRequestRevoked");
 
       // Unpause BSP Three
-      await userApi.docker.resumeBspContainer({
+      await userApi.docker.resumeContainer({
         containerName: "sh-bsp-three"
       });
       await userApi.wait.bspCatchUpToChainTip(bspThreeApi);

--- a/test/suites/integration/bsp/submit-proofs.test.ts
+++ b/test/suites/integration/bsp/submit-proofs.test.ts
@@ -269,8 +269,8 @@ describeBspNet(
 
     it("New storage request sent by user, to only one BSP", async () => {
       // Pause BSP-Two and BSP-Three.
-      await userApi.docker.pauseBspContainer("sh-bsp-two");
-      await userApi.docker.pauseBspContainer("sh-bsp-three");
+      await userApi.docker.pauseContainer("sh-bsp-two");
+      await userApi.docker.pauseContainer("sh-bsp-three");
 
       // Send transaction to create new storage request.
       const source = "res/adolphus.jpg";
@@ -365,10 +365,10 @@ describeBspNet(
       });
 
       // Resume BSP-Two and BSP-Three.
-      await userApi.docker.resumeBspContainer({
+      await userApi.docker.resumeContainer({
         containerName: "sh-bsp-two"
       });
-      await userApi.docker.resumeBspContainer({
+      await userApi.docker.resumeContainer({
         containerName: "sh-bsp-three"
       });
 

--- a/test/suites/integration/user/send-file-to-provider.test.ts
+++ b/test/suites/integration/user/send-file-to-provider.test.ts
@@ -36,7 +36,7 @@ describeMspNet("User: Send file to provider", ({ before, createUserApi, it }) =>
       newBucketEventDataBlob.bucketId
     );
 
-    await userApi.docker.pauseBspContainer(userApi.shConsts.NODE_INFOS.msp1.containerName);
+    await userApi.docker.pauseContainer(userApi.shConsts.NODE_INFOS.msp1.containerName);
 
     await userApi.block.seal({
       calls: [

--- a/test/util/bspNet/docker.ts
+++ b/test/util/bspNet/docker.ts
@@ -150,13 +150,13 @@ const addContainer = async (
 };
 
 // Make this a rusty style OO function with api contexts
-export const pauseBspContainer = async (containerName: string) => {
+export const pauseContainer = async (containerName: string) => {
   const docker = new Docker();
   const container = docker.getContainer(containerName);
   await container.pause();
 };
 
-export const stopBspContainer = async (containerName: string) => {
+export const stopContainer = async (containerName: string) => {
   const docker = new Docker();
   const containersToStop = await docker.listContainers({
     filters: { name: [containerName] }
@@ -166,7 +166,7 @@ export const stopBspContainer = async (containerName: string) => {
   await docker.getContainer(containersToStop[0].Id).remove({ force: true });
 };
 
-export const startBspContainer = async (options: {
+export const startContainer = async (options: {
   containerName: string;
 }) => {
   const docker = new Docker();
@@ -174,7 +174,7 @@ export const startBspContainer = async (options: {
   await container.start();
 };
 
-export const restartBspContainer = async (options: {
+export const restartContainer = async (options: {
   containerName: string;
 }) => {
   const docker = new Docker();
@@ -182,7 +182,7 @@ export const restartBspContainer = async (options: {
   await container.restart();
 };
 
-export const resumeBspContainer = async (options: {
+export const resumeContainer = async (options: {
   containerName: string;
 }) => {
   const docker = new Docker();

--- a/test/util/netLaunch/index.ts
+++ b/test/util/netLaunch/index.ts
@@ -682,7 +682,7 @@ export class NetworkLauncher {
     await api.wait.bspStored(4);
 
     // Stop BSP that is supposed to be down
-    await api.docker.stopBspContainer(bspDownContainerName);
+    await api.docker.stopContainer(bspDownContainerName);
 
     // Attempt to debounce and stabilise
     await sleep(1500);


### PR DESCRIPTION
The docker helper functions don't differentiate between BSP and MSP. In this PR we rename it to a more general name as it can be used for any kind of container.

e.g. 
Changing name `stopBspContainer` to `stopContainer`