### PR TITLE
fix: 🐛 Avoid retrying in same tasks

### DIFF
--- a/client/blockchain-service/src/commands.rs
+++ b/client/blockchain-service/src/commands.rs
@@ -29,11 +29,11 @@ use storage_hub_runtime::{AccountId, Balance, StorageDataUnit};
 
 use crate::{
     handler::BlockchainService,
-    transaction::{SubmittedTransaction, WatchTransactionError},
+    transaction::SubmittedTransaction,
     types::{
         ConfirmStoringRequest, Extrinsic, ExtrinsicResult, FileDeletionRequest, MinimalBlockInfo,
         RespondStorageRequest, RetryStrategy, SendExtrinsicOptions,
-        StopStoringForInsolventUserRequest, SubmitProofRequest,
+        StopStoringForInsolventUserRequest, SubmitProofRequest, WatchTransactionError,
     },
 };
 
@@ -852,7 +852,7 @@ where
                     warn!(target: LOG_TARGET, "Transaction failed: {:?}", err);
 
                     if let Some(ref should_retry) = retry_strategy.should_retry {
-                        if !should_retry().await {
+                        if !should_retry(err.clone()).await {
                             return Err(anyhow::anyhow!("Exhausted retry strategy"));
                         }
                     }

--- a/client/blockchain-service/src/events.rs
+++ b/client/blockchain-service/src/events.rs
@@ -140,12 +140,22 @@ impl From<ProcessFileDeletionRequestData> for ForestWriteLockTaskData {
     }
 }
 
+/// Data required to build a proof to submit to the runtime.
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct ProcessSubmitProofRequestData {
+    /// The Provider ID of the BSP that is submitting the proof.
     pub provider_id: ProofsDealerProviderId,
+    /// The tick for which the proof is being built.
+    ///
+    /// This tick should be the tick where [`Self::seed`] was generated.
     pub tick: BlockNumber,
+    /// The seed that was used to generate the challenges for this proof.
     pub seed: RandomnessOutput,
+    /// All the Forest challenges that the proof to generate has to respond to.
+    ///
+    /// This includes the [`Self::checkpoint_challenges`].
     pub forest_challenges: Vec<H256>,
+    /// The checkpoint challenges that the proof to generate has to respond to.
     pub checkpoint_challenges: Vec<CustomChallenge>,
 }
 

--- a/client/blockchain-service/src/handler.rs
+++ b/client/blockchain-service/src/handler.rs
@@ -450,7 +450,7 @@ where
                         .unwrap_or_else(|_| {
                             error!(target: LOG_TARGET, "Failed to query earliest block to change capacity");
                             Err(QueryEarliestChangeCapacityBlockError::InternalError)
-                        }).into();
+                        });
 
                     match callback.send(earliest_block_to_change_capacity) {
                         Ok(_) => {
@@ -499,8 +499,9 @@ where
                             bsp_id.into(),
                             file_key,
                         )
-                        .unwrap_or_else(|_| Err(QueryFileEarliestVolunteerTickError::InternalError))
-                        .into();
+                        .unwrap_or_else(|_| {
+                            Err(QueryFileEarliestVolunteerTickError::InternalError)
+                        });
 
                     match callback.send(earliest_block_to_volunteer) {
                         Ok(_) => {
@@ -659,8 +660,7 @@ where
                         .client
                         .runtime_api()
                         .get_last_tick_provider_submitted_proof(current_block_hash, &provider_id)
-                        .unwrap_or_else(|_| Err(GetProofSubmissionRecordError::InternalApiError))
-                        .into();
+                        .unwrap_or_else(|_| Err(GetProofSubmissionRecordError::InternalApiError));
 
                     match callback.send(last_tick) {
                         Ok(_) => {
@@ -684,7 +684,7 @@ where
                         .unwrap_or_else(|_| {
                             error!(target: LOG_TARGET, "Failed to query challenge period for provider [{:?}]", provider_id);
                             Err(GetChallengePeriodError::InternalApiError)
-                        }).into();
+                        });
 
                     match callback.send(challenge_period) {
                         Ok(_) => {

--- a/client/blockchain-service/src/handler.rs
+++ b/client/blockchain-service/src/handler.rs
@@ -450,7 +450,7 @@ where
                         .unwrap_or_else(|_| {
                             error!(target: LOG_TARGET, "Failed to query earliest block to change capacity");
                             Err(QueryEarliestChangeCapacityBlockError::InternalError)
-                        });
+                        }).into();
 
                     match callback.send(earliest_block_to_change_capacity) {
                         Ok(_) => {
@@ -499,9 +499,8 @@ where
                             bsp_id.into(),
                             file_key,
                         )
-                        .unwrap_or_else(|_| {
-                            Err(QueryFileEarliestVolunteerTickError::InternalError)
-                        });
+                        .unwrap_or_else(|_| Err(QueryFileEarliestVolunteerTickError::InternalError))
+                        .into();
 
                     match callback.send(earliest_block_to_volunteer) {
                         Ok(_) => {
@@ -660,7 +659,8 @@ where
                         .client
                         .runtime_api()
                         .get_last_tick_provider_submitted_proof(current_block_hash, &provider_id)
-                        .unwrap_or_else(|_| Err(GetProofSubmissionRecordError::InternalApiError));
+                        .unwrap_or_else(|_| Err(GetProofSubmissionRecordError::InternalApiError))
+                        .into();
 
                     match callback.send(last_tick) {
                         Ok(_) => {
@@ -684,7 +684,7 @@ where
                         .unwrap_or_else(|_| {
                             error!(target: LOG_TARGET, "Failed to query challenge period for provider [{:?}]", provider_id);
                             Err(GetChallengePeriodError::InternalApiError)
-                        });
+                        }).into();
 
                     match callback.send(challenge_period) {
                         Ok(_) => {

--- a/client/blockchain-service/src/transaction.rs
+++ b/client/blockchain-service/src/transaction.rs
@@ -12,7 +12,7 @@ use tokio::sync::mpsc::Receiver;
 
 use crate::{
     commands::BlockchainServiceInterface,
-    types::{Extrinsic, ExtrinsicHash, ExtrinsicResult},
+    types::{Extrinsic, ExtrinsicHash, ExtrinsicResult, WatchTransactionError},
     BlockchainService,
 };
 
@@ -267,19 +267,4 @@ impl SubmittedTransaction {
             })?;
         Ok(extrinsic_in_block)
     }
-}
-
-#[derive(thiserror::Error, Debug)]
-pub enum WatchTransactionError {
-    #[error("Timeout waiting for transaction to be included in a block")]
-    Timeout,
-    #[error("Transaction watcher channel closed")]
-    WatcherChannelClosed,
-    #[error("Transaction failed. DispatchError: {dispatch_error}, DispatchInfo: {dispatch_info}")]
-    TransactionFailed {
-        dispatch_error: String,
-        dispatch_info: String,
-    },
-    #[error("Unexpected error: {0}")]
-    Internal(String),
 }

--- a/client/blockchain-service/src/types.rs
+++ b/client/blockchain-service/src/types.rs
@@ -228,6 +228,50 @@ pub type ExtrinsicHash = H256;
 /// Type alias for the tip.
 pub type Tip = pallet_transaction_payment::ChargeTransactionPayment<storage_hub_runtime::Runtime>;
 
+/// Options for [`send_extrinsic`](crate::BlockchainService::send_extrinsic).
+///
+/// You can safely use [`SendExtrinsicOptions::default`] to create a new instance of `SendExtrinsicOptions`.
+#[derive(Debug)]
+pub struct SendExtrinsicOptions {
+    /// Tip to add to the transaction to incentivize the collator to include the transaction in a block.
+    tip: Tip,
+    /// Optionally override the nonce to use when sending the transaction.
+    nonce: Option<u32>,
+}
+
+impl SendExtrinsicOptions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_tip(mut self, tip: u128) -> Self {
+        self.tip = Tip::from(tip);
+        self
+    }
+
+    pub fn with_nonce(mut self, nonce: Option<u32>) -> Self {
+        self.nonce = nonce;
+        self
+    }
+
+    pub fn tip(&self) -> Tip {
+        self.tip.clone()
+    }
+
+    pub fn nonce(&self) -> Option<u32> {
+        self.nonce
+    }
+}
+
+impl Default for SendExtrinsicOptions {
+    fn default() -> Self {
+        Self {
+            tip: Tip::from(0),
+            nonce: None,
+        }
+    }
+}
+
 /// A struct which defines a submit extrinsic retry strategy. This defines a simple strategy when
 /// sending and extrinsic. It will retry a maximum number of times ([Self::max_retries]).
 /// If the extrinsic is not included in a block within a certain time frame [`Self::timeout`] it is
@@ -252,10 +296,16 @@ pub struct RetryStrategy {
     /// A higher value will make tips grow faster.
     pub base_multiplier: f64,
     /// An optional check function to determine if the extrinsic should be retried.
+    ///
     /// If this is provided, the function will be called before each retry to determine if the
     /// extrinsic should be retried or the submission should be considered failed. If this is not
     /// provided, the extrinsic will be retried until [`Self::max_retries`] is reached.
-    pub should_retry: Option<Box<dyn Fn() -> Pin<Box<dyn Future<Output = bool> + Send>> + Send>>,
+    ///
+    /// Additionally, the function will receive the [`WatchTransactionError`] as an argument, to
+    /// help determine if the extrinsic should be retried or not.
+    pub should_retry: Option<
+        Box<dyn Fn(WatchTransactionError) -> Pin<Box<dyn Future<Output = bool> + Send>> + Send>,
+    >,
 }
 
 impl RetryStrategy {
@@ -292,7 +342,9 @@ impl RetryStrategy {
 
     pub fn with_should_retry(
         mut self,
-        should_retry: Option<Box<dyn Fn() -> Pin<Box<dyn Future<Output = bool> + Send>> + Send>>,
+        should_retry: Option<
+            Box<dyn Fn(WatchTransactionError) -> Pin<Box<dyn Future<Output = bool> + Send>> + Send>,
+        >,
     ) -> Self {
         self.should_retry = should_retry;
         self
@@ -328,6 +380,21 @@ impl Default for RetryStrategy {
             should_retry: None,
         }
     }
+}
+
+#[derive(thiserror::Error, Debug, Clone)]
+pub enum WatchTransactionError {
+    #[error("Timeout waiting for transaction to be included in a block")]
+    Timeout,
+    #[error("Transaction watcher channel closed")]
+    WatcherChannelClosed,
+    #[error("Transaction failed. DispatchError: {dispatch_error}, DispatchInfo: {dispatch_info}")]
+    TransactionFailed {
+        dispatch_error: String,
+        dispatch_info: String,
+    },
+    #[error("Unexpected error: {0}")]
+    Internal(String),
 }
 
 /// Minimum block information needed to register what is the current best block
@@ -477,50 +544,6 @@ impl Ord for ForestStorageSnapshotInfo {
                     }
                 }
             }
-        }
-    }
-}
-
-/// Options for [`send_extrinsic`](crate::BlockchainService::send_extrinsic).
-///
-/// You can safely use [`SendExtrinsicOptions::default`] to create a new instance of `SendExtrinsicOptions`.
-#[derive(Debug)]
-pub struct SendExtrinsicOptions {
-    /// Tip to add to the transaction to incentivize the collator to include the transaction in a block.
-    tip: Tip,
-    /// Optionally override the nonce to use when sending the transaction.
-    nonce: Option<u32>,
-}
-
-impl SendExtrinsicOptions {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn with_tip(mut self, tip: u128) -> Self {
-        self.tip = Tip::from(tip);
-        self
-    }
-
-    pub fn with_nonce(mut self, nonce: Option<u32>) -> Self {
-        self.nonce = nonce;
-        self
-    }
-
-    pub fn tip(&self) -> Tip {
-        self.tip.clone()
-    }
-
-    pub fn nonce(&self) -> Option<u32> {
-        self.nonce
-    }
-}
-
-impl Default for SendExtrinsicOptions {
-    fn default() -> Self {
-        Self {
-            tip: Tip::from(0),
-            nonce: None,
         }
     }
 }

--- a/node/src/tasks/bsp_submit_proof.rs
+++ b/node/src/tasks/bsp_submit_proof.rs
@@ -12,14 +12,14 @@ use shc_blockchain_service::{
     events::{
         FinalisedTrieRemoveMutationsApplied, MultipleNewChallengeSeeds, ProcessSubmitProofRequest,
     },
-    types::{RetryStrategy, SubmitProofRequest},
+    types::{RetryStrategy, SubmitProofRequest, WatchTransactionError},
     BlockchainService,
 };
 use shc_common::{
     consts::CURRENT_FOREST_KEY,
     types::{
-        BlockNumber, CustomChallenge, FileKey, KeyProof, KeyProofs, ProofsDealerProviderId, Proven,
-        RandomnessOutput, StorageProof,
+        BlockNumber, CustomChallenge, FileKey, ForestRoot, KeyProof, KeyProofs,
+        ProofsDealerProviderId, Proven, RandomnessOutput, StorageProof,
     },
 };
 use shc_forest_manager::traits::{ForestStorage, ForestStorageHandler};
@@ -271,7 +271,7 @@ where
 
         // This function is a check to see if we should continue to retry the submission of the proof.
         // If this proof submission is invalid, we should not retry it, and release the forest write lock.
-        let should_retry = move || {
+        let should_retry = move |error| {
             let cloned_sh_handler = Arc::clone(&cloned_sh_handler);
             let cloned_event = Arc::clone(&cloned_event);
             let cloned_forest_root = Arc::new(cloned_forest_root);
@@ -279,39 +279,12 @@ where
             // Check:
             // - If the proof is outdated.
             // - If the Forest root of the BSP has changed.
-            Box::pin(async move {
-                let current_forest_key = CURRENT_FOREST_KEY.to_vec();
-                let is_proof_outdated =
-                    Self::check_if_proof_is_outdated(&cloned_sh_handler.blockchain, &cloned_event)
-                        .await
-                        .is_err();
-                let has_forest_root_changed = {
-                    let fs = cloned_sh_handler
-                        .forest_storage_handler
-                        .get(&current_forest_key)
-                        .await;
-
-                    match fs {
-                        Some(fs) => fs.read().await.root() != *cloned_forest_root,
-                        None => {
-                            error!(target: LOG_TARGET, "CRITICAL❗️❗️ Failed to get forest storage.");
-                            true
-                        }
-                    }
-                };
-
-                // If the proof is outdated, or the Forest root has changed, we should not retry.
-                if is_proof_outdated {
-                    warn!(target: LOG_TARGET, "❌ Proof to submit is outdated. Stop retrying.");
-                    return false;
-                };
-                if has_forest_root_changed {
-                    warn!(target: LOG_TARGET, "❌ Forest root has changed. Stop retrying.");
-                    return false;
-                };
-
-                true
-            }) as Pin<Box<dyn Future<Output = bool> + Send>>
+            Box::pin(Self::should_retry_submit_proof(
+                cloned_sh_handler.clone(),
+                cloned_event.clone(),
+                cloned_forest_root.clone(),
+                error,
+            )) as Pin<Box<dyn Future<Output = bool> + Send>>
         };
 
         // Attempt to submit the extrinsic with retries and tip increase.
@@ -593,5 +566,58 @@ where
         drop(write_file_storage);
 
         Ok(())
+    }
+
+    /// Function to determine if a proof submission should be retried,
+    /// sending the same proof again.
+    ///
+    /// This function will return `true` if and only if the following conditions are met:
+    /// 1. The error is a timeout. Otherwise, it means that the transaction was not successful,
+    ///    in which case it is safer to let the BlockchainService eventually schedule a new
+    ///    proof submission from scratch.
+    /// 2. The proof is up to date, i.e. the Forest root has not changed, and the tick for
+    ///    which the proof was generated is still the tick this Provider should submit a proof for.
+    async fn should_retry_submit_proof(
+        sh_handler: Arc<StorageHubHandler<NT>>,
+        event: Arc<ProcessSubmitProofRequest>,
+        forest_root: Arc<ForestRoot>,
+        error: WatchTransactionError,
+    ) -> bool {
+        // We only retry sending THE SAME proof, if the error is a timeout.
+        match error {
+            WatchTransactionError::Timeout => {}
+            _ => return false,
+        }
+
+        let current_forest_key = CURRENT_FOREST_KEY.to_vec();
+        let is_proof_outdated = Self::check_if_proof_is_outdated(&sh_handler.blockchain, &event)
+            .await
+            .is_err();
+        let has_forest_root_changed = {
+            let fs = sh_handler
+                .forest_storage_handler
+                .get(&current_forest_key)
+                .await;
+
+            match fs {
+                Some(fs) => fs.read().await.root() != *forest_root,
+                None => {
+                    error!(target: LOG_TARGET, "CRITICAL❗️❗️ Failed to get forest storage.");
+                    true
+                }
+            }
+        };
+
+        // If the proof is outdated, or the Forest root has changed, we should not retry.
+        if is_proof_outdated {
+            warn!(target: LOG_TARGET, "❌ Proof to submit is outdated. Stop retrying.");
+            return false;
+        };
+        if has_forest_root_changed {
+            warn!(target: LOG_TARGET, "❌ Forest root has changed. Stop retrying.");
+            return false;
+        };
+
+        true
     }
 }

--- a/node/src/tasks/bsp_upload_file.rs
+++ b/node/src/tasks/bsp_upload_file.rs
@@ -440,7 +440,8 @@ where
                         self.storage_hub_handler
                             .provider_config
                             .extrinsic_retry_timeout,
-                    )),
+                    ))
+                    .retry_only_if_timeout(),
                 true,
             )
             .await

--- a/node/src/tasks/msp_delete_file.rs
+++ b/node/src/tasks/msp_delete_file.rs
@@ -194,7 +194,8 @@ where
                         self.storage_hub_handler
                             .provider_config
                             .extrinsic_retry_timeout,
-                    )),
+                    ))
+                    .retry_only_if_timeout(),
                 false,
             )
             .await

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 channel = "1.83.0"
-components = ["rustfmt", "clippy", "rust-src"]
+components = ["rustfmt", "clippy", "rust-src", "rust-analyzer"]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"

--- a/test/scripts/generateFileSystemBenchmarkProofs.ts
+++ b/test/scripts/generateFileSystemBenchmarkProofs.ts
@@ -178,7 +178,7 @@ async function generateBenchmarkProofs() {
       await userApi.block.seal();
       await mspApi.wait.fileStorageComplete(fileMetadata.fileKey);
       await bspApi.wait.fileStorageComplete(fileMetadata.fileKey);
-      await userApi.wait.bspStored(1);
+      await userApi.wait.bspStored({ expectedExts: 1 });
     }
 
     // Save the bucket ID for later use.
@@ -220,7 +220,7 @@ async function generateBenchmarkProofs() {
 
       await userApi.wait.bspVolunteer(1);
       await bspApi.wait.fileStorageComplete(fileMetadata.fileKey);
-      await userApi.wait.bspStored(1);
+      await userApi.wait.bspStored({ expectedExts: 1 });
     }
 
     // Save the non-stored file keys for the MSP's bucket.

--- a/test/scripts/generateProofsDealerBenchmarkProofs.ts
+++ b/test/scripts/generateProofsDealerBenchmarkProofs.ts
@@ -193,7 +193,7 @@ async function generateBenchmarkProofs() {
 
     await userApi.wait.bspVolunteer(1);
     await bspApi.wait.fileStorageComplete(fileMetadata.fileKey);
-    await userApi.wait.bspStored(1);
+    await userApi.wait.bspStored({ expectedExts: 1 });
   }
 
   // Sort the file keys.

--- a/test/suites/integration/bsp/automatic-tipping.test.ts
+++ b/test/suites/integration/bsp/automatic-tipping.test.ts
@@ -18,9 +18,10 @@ describeBspNet(
       );
       await userApi.wait.bspVolunteer(1);
 
-      await userApi.wait.bspStoredInTxPool({
+      await userApi.wait.bspStored({
         expectedExts: 1,
-        timeoutMs: 12000
+        timeoutMs: 12000,
+        sealBlock: false
       });
 
       await assertDockerLog(

--- a/test/suites/integration/bsp/bsp-thresholds.test.ts
+++ b/test/suites/integration/bsp/bsp-thresholds.test.ts
@@ -269,7 +269,7 @@ describeBspNet(
       // Checking volunteering and confirming for the high reputation BSP
       await userApi.wait.bspVolunteer(1);
       await bspApi.wait.fileStorageComplete(fileKey);
-      await userApi.wait.bspStored(1);
+      await userApi.wait.bspStored({ expectedExts: 1 });
 
       // Checking volunteering and confirming for the low reputation BSP
       // If a BSP can volunteer in tick X, it sends the extrinsic once it imports block with tick X - 1, so it gets included directly in tick X
@@ -361,7 +361,7 @@ describeBspNet(
 
       await userApi.wait.bspVolunteer(1);
       await bspApi.wait.fileStorageComplete(fileKey);
-      await userApi.wait.bspStored(1);
+      await userApi.wait.bspStored({ expectedExts: 1 });
 
       // Then wait for the second BSP to volunteer and confirm storing the file
       // If a BSP can volunteer in tick X, it sends the extrinsic once it imports block with tick X - 1, so it gets included directly in tick X
@@ -369,7 +369,7 @@ describeBspNet(
 
       await userApi.wait.bspVolunteer(1);
       await bspTwoApi.wait.fileStorageComplete(fileKey);
-      await userApi.wait.bspStored(1);
+      await userApi.wait.bspStored({ expectedExts: 1 });
 
       await bspTwoApi.disconnect();
       await userApi.docker.stopContainer("sh-bsp-two");

--- a/test/suites/integration/bsp/debt-collection.test.ts
+++ b/test/suites/integration/bsp/debt-collection.test.ts
@@ -264,7 +264,7 @@ describeBspNet(
       await bspApi.wait.fileStorageComplete(cloudFileMetadata.fileKey);
       await bspTwoApi.wait.fileStorageComplete(cloudFileMetadata.fileKey);
       await bspThreeApi.wait.fileStorageComplete(cloudFileMetadata.fileKey);
-      await userApi.wait.bspStored(3);
+      await userApi.wait.bspStored({ expectedExts: 3 });
 
       const adolphusFileMetadata = await userApi.file.createBucketAndSendNewStorageRequest(
         "res/adolphus.jpg",
@@ -279,7 +279,7 @@ describeBspNet(
       await bspApi.wait.fileStorageComplete(adolphusFileMetadata.fileKey);
       await bspTwoApi.wait.fileStorageComplete(adolphusFileMetadata.fileKey);
       await bspThreeApi.wait.fileStorageComplete(adolphusFileMetadata.fileKey);
-      await userApi.wait.bspStored(3);
+      await userApi.wait.bspStored({ expectedExts: 3 });
 
       // Check the payment stream info after adding the new files
       const paymentStreamInfoAfterAddingFiles =

--- a/test/suites/integration/bsp/debt-collection.test.ts
+++ b/test/suites/integration/bsp/debt-collection.test.ts
@@ -5,7 +5,7 @@ import { BN } from "@polkadot/util";
 
 describeBspNet(
   "BSPNet: Collect users debt",
-  { initialised: "multi", networkConfig: "standard" },
+  { initialised: "multi", networkConfig: "standard", only: true },
   ({ before, it, createUserApi, createBspApi, getLaunchResponse, createApi }) => {
     let userApi: EnrichedBspApi;
     let bspApi: EnrichedBspApi;
@@ -194,7 +194,8 @@ describeBspNet(
         method: "chargeMultipleUsersPaymentStreams",
         module: "paymentStreams",
         checkTxPool: true,
-        assertLength: 3
+        assertLength: 3,
+        exactLength: false
       });
 
       // Seal a block to allow BSPs to charge the payment stream

--- a/test/suites/integration/bsp/debt-collection.test.ts
+++ b/test/suites/integration/bsp/debt-collection.test.ts
@@ -5,7 +5,7 @@ import { BN } from "@polkadot/util";
 
 describeBspNet(
   "BSPNet: Collect users debt",
-  { initialised: "multi", networkConfig: "standard", only: true },
+  { initialised: "multi", networkConfig: "standard" },
   ({ before, it, createUserApi, createBspApi, getLaunchResponse, createApi }) => {
     let userApi: EnrichedBspApi;
     let bspApi: EnrichedBspApi;

--- a/test/suites/integration/bsp/multiple-delete.test.ts
+++ b/test/suites/integration/bsp/multiple-delete.test.ts
@@ -92,10 +92,10 @@ describeBspNet("Single BSP Volunteering", ({ before, createBspApi, it, createUse
     }
 
     // Waiting for a confirmation of the first file to be stored
-    await userApi.wait.bspStored(1);
+    await userApi.wait.bspStored({ expectedExts: 1 });
 
     // Here we expect the 2 others files to be batched
-    await userApi.wait.bspStored(1);
+    await userApi.wait.bspStored({ expectedExts: 1 });
 
     // Wait for BSP to update its local Forest root before starting to generate the inclusion proofs
     await waitFor({
@@ -243,10 +243,10 @@ describeBspNet("Single BSP Volunteering", ({ before, createBspApi, it, createUse
       }
 
       // Waiting for a confirmation of the first file to be stored
-      await userApi.wait.bspStored(1);
+      await userApi.wait.bspStored({ expectedExts: 1 });
 
       // Here we expect the 2 others files to be batched
-      await userApi.wait.bspStored(1);
+      await userApi.wait.bspStored({ expectedExts: 1 });
 
       // Wait for BSP to update its local Forest root before starting to generate the inclusion proofs
       await waitFor({

--- a/test/suites/integration/bsp/reorg-proof.test.ts
+++ b/test/suites/integration/bsp/reorg-proof.test.ts
@@ -14,7 +14,7 @@ import {
 
 describeBspNet(
   "BSP proofs resubmitted on chain re-org ♻️",
-  { initialised: true, networkConfig: "standard", only: true },
+  { initialised: true, networkConfig: "standard" },
   ({ before, createUserApi, createBspApi, it }) => {
     let userApi: EnrichedBspApi;
     let bspApi: EnrichedBspApi;

--- a/test/suites/integration/bsp/reorg-proof.test.ts
+++ b/test/suites/integration/bsp/reorg-proof.test.ts
@@ -14,7 +14,7 @@ import {
 
 describeBspNet(
   "BSP proofs resubmitted on chain re-org ♻️",
-  { initialised: true, networkConfig: "standard" },
+  { initialised: true, networkConfig: "standard", only: true },
   ({ before, createUserApi, createBspApi, it }) => {
     let userApi: EnrichedBspApi;
     let bspApi: EnrichedBspApi;
@@ -191,7 +191,7 @@ describeBspNet(
 
       // Wait for the BSP to send the confirm storage extrinsic, and then seal a block,
       // without finalising it, to be able to reorg it out.
-      await userApi.wait.bspStored(undefined, undefined, false);
+      await userApi.wait.bspStored({ sealBlock: false });
       await userApi.block.seal({ finaliseBlock: false });
 
       // Saving Forest root after confirming the storage request.
@@ -391,7 +391,7 @@ describeBspNet(
 
       // Wait for the BSP to send the confirm storage extrinsic, and then seal a block,
       // without finalising it, to be able to reorg it out.
-      await userApi.wait.bspStored(undefined, undefined, false);
+      await userApi.wait.bspStored({ sealBlock: false });
       await userApi.block.seal({ finaliseBlock: false });
 
       // Check that the BSP confirm storing extrinsic is successfully included in the block.
@@ -452,7 +452,7 @@ describeBspNet(
       // Then build a block with it, on top of the above finalised block.
       // Still, this won't trigger a reorg in the BSP. This block will be at the same height
       // of the current best block for the BSP.
-      await userApi.wait.bspStored(undefined, undefined, false);
+      await userApi.wait.bspStored({ sealBlock: false });
       await userApi.block.seal({ finaliseBlock: false });
 
       // Seal another block with the confirm deletion transaction.

--- a/test/suites/integration/bsp/single-volunteer.test.ts
+++ b/test/suites/integration/bsp/single-volunteer.test.ts
@@ -121,8 +121,9 @@ describeBspNet("Single BSP Volunteering", ({ before, createBspApi, it, createUse
     });
 
     // Wait for the BSP confirm extrinsic to be submitted to the TX pool
-    await userApi.wait.bspStoredInTxPool({
-      expectedExts: 1
+    await userApi.wait.bspStored({
+      expectedExts: 1,
+      sealBlock: false
     });
 
     // Seal the block with the confirm TX
@@ -281,7 +282,7 @@ describeBspNet("Single BSP multi-volunteers", ({ before, createBspApi, createUse
     // and send the `bspConfirmStoring` extrinsic. The other two files will be queued.
     // Here we wait for the first `bspConfirmStoring` extrinsic to be submitted to the tx pool,
     // we seal the block and check for the `BspConfirmedStoring` event.
-    await userApi.wait.bspStored(1);
+    await userApi.wait.bspStored({ expectedExts: 1 });
 
     const {
       data: { confirmedFileKeys: bspConfirmRes_fileKeys, newRoot: bspConfirmRes_newRoot }
@@ -305,7 +306,7 @@ describeBspNet("Single BSP multi-volunteers", ({ before, createBspApi, createUse
 
     // After the previous block is processed by the BSP, the forest write lock is released and
     // the other pending `bspConfirmStoring` extrinsics are processed and batched into one extrinsic.
-    await userApi.wait.bspStored(1);
+    await userApi.wait.bspStored({ expectedExts: 1 });
 
     const {
       data: { confirmedFileKeys: bspConfirm2Res_fileKeys, newRoot: bspConfirm2Res_newRoot }

--- a/test/suites/integration/bsp/storage-capacity.test.ts
+++ b/test/suites/integration/bsp/storage-capacity.test.ts
@@ -208,7 +208,7 @@ describeBspNet("BSPNet: Change capacity tests.", ({ before, it, createUserApi })
 
       // Wait until the BSP stores the file.
       const bspAddress = userApi.createType("Address", bspKey.address);
-      await userApi.wait.bspStored(1, bspAddress);
+      await userApi.wait.bspStored({ expectedExts: 1, bspAccount: bspAddress });
 
       // Update the used capacity of the BSP.
       capacityUsed = (
@@ -325,7 +325,7 @@ describeBspNet("BSPNet: Change capacity tests.", ({ before, it, createUserApi })
 
     // Wait until the BSP stores both files
     const bspAddress = userApi.createType("Address", bspKey.address);
-    await userApi.wait.bspStored(1, bspAddress);
+    await userApi.wait.bspStored({ expectedExts: 2, bspAccount: bspAddress });
   });
 
   it("BSP does not increase its capacity over its configured maximum (and skips volunteering if that would be needed).", async () => {
@@ -381,7 +381,7 @@ describeBspNet("BSPNet: Change capacity tests.", ({ before, it, createUserApi })
 
     // Wait until the BSP confirms storing the file.
     const bspTwpAddress = userApi.createType("Address", bspTwoKey.address);
-    await userApi.wait.bspStored(1, bspTwpAddress);
+    await userApi.wait.bspStored({ expectedExts: 1, bspAccount: bspTwpAddress });
 
     // Issue the second storage request. The BSP shouldn't be able to volunteer for this one since
     // it would have to increase its capacity over its configured maximum.

--- a/test/suites/integration/bsp/storage-capacity.test.ts
+++ b/test/suites/integration/bsp/storage-capacity.test.ts
@@ -325,7 +325,7 @@ describeBspNet("BSPNet: Change capacity tests.", ({ before, it, createUserApi })
 
     // Wait until the BSP stores both files
     const bspAddress = userApi.createType("Address", bspKey.address);
-    await userApi.wait.bspStored({ expectedExts: 2, bspAccount: bspAddress });
+    await userApi.wait.bspStored({ expectedExts: 1, bspAccount: bspAddress });
   });
 
   it("BSP does not increase its capacity over its configured maximum (and skips volunteering if that would be needed).", async () => {

--- a/test/suites/integration/bsp/storage-delete.test.ts
+++ b/test/suites/integration/bsp/storage-delete.test.ts
@@ -47,7 +47,7 @@ describeBspNet(
 
       // Wait for the two BSP to volunteer
       await userApi.wait.bspVolunteer(2);
-      await userApi.wait.bspStored(2);
+      await userApi.wait.bspStored({ expectedExts: 2 });
 
       // Revoke the storage request otherwise the new storage request event is not being triggered
       await userApi.block.seal({

--- a/test/suites/integration/bsp/submit-proofs.test.ts
+++ b/test/suites/integration/bsp/submit-proofs.test.ts
@@ -302,7 +302,7 @@ describeBspNet(
 
       // Finally, wait for the BSP to confirm storing the file and seal the block
       const address = userApi.createType("Address", NODE_INFOS.bsp.AddressId);
-      await userApi.wait.bspStored(1, address);
+      await userApi.wait.bspStored({ expectedExts: 1, bspAccount: address });
     });
 
     it("BSP correctly responds to challenge with new forest root", async () => {

--- a/test/util/bspNet/types.ts
+++ b/test/util/bspNet/types.ts
@@ -1,7 +1,7 @@
 import type { ApiPromise } from "@polkadot/api";
 import type { SubmittableExtrinsic } from "@polkadot/api/types";
 import type { KeyringPair } from "@polkadot/keyring/types";
-import type { Event, EventRecord } from "@polkadot/types/interfaces";
+import type { Address, Event, EventRecord } from "@polkadot/types/interfaces";
 import type { Codec, IEventData, ISubmittableResult } from "@polkadot/types/types";
 import type { HexString } from "@polkadot/util/types";
 import type { after, afterEach, before, beforeEach, it } from "node:test";
@@ -404,4 +404,30 @@ export type SealBlockOptions = {
    * Defaults to true if not specified.
    */
   failOnExtrinsicNonInclusion?: boolean;
+};
+
+/**
+ * Options for the BSP Stored waiting utility function
+ */
+export type BspStoredOptions = {
+  /**
+   * The number of expected extrinsics.
+   */
+  expectedExts?: number;
+
+  /**
+   * The BSP Account ID that may be sending submit proof extrinsics.
+   */
+  bspAccount?: Address;
+
+  /**
+   * The timeout in milliseconds for the wait.
+   */
+  timeoutMs?: number;
+
+  /**
+   * Whether to seal a block after waiting for the transaction.
+   * Defaults to true if not specified.
+   */
+  sealBlock?: boolean;
 };

--- a/test/util/bspNet/waits.ts
+++ b/test/util/bspNet/waits.ts
@@ -135,10 +135,12 @@ export const waitForBspStored = async (
   api: ApiPromise,
   checkQuantity?: number,
   bspAccount?: Address,
+  timeoutMs?: number,
   shouldSealBlock = true
 ) => {
-  // To allow time for local file transfer to complete (10s)
-  const iterations = 100;
+  // To allow time for local file transfer to complete.
+  // Default is 10s, with iterations of 100ms delay.
+  const iterations = timeoutMs ? Math.ceil(timeoutMs / 100) : 100;
   const delay = 100;
 
   // This check is because a BSP cannot confirm storing a file in the same block in which it has to submit a proof,
@@ -190,31 +192,6 @@ export const waitForBspStored = async (
       );
     }
   }
-};
-
-/**
- * Waits for a BSP to send to the tx pool the extrinsic to confirm storing a file.
- *
- * This function performs the following steps:
- * 1. Waits for a longer period to allow for local file transfer.
- * 2. Checks for the presence of a 'bspConfirmStoring' extrinsic in the transaction pool.
- *
- * @param api - The ApiPromise instance to interact with the blockchain.
- * @param checkQuantity - Optional param to specify the number of expected extrinsics.
- * @returns A Promise that resolves when a BSP has submitted to the tx pool the extrinsic to confirm storing a file.
- *
- * @throws Will throw an error if the expected extrinsic is not found.
- */
-export const waitForBspStoredWithoutSealing = async (
-  api: ApiPromise,
-  options?: { checkQuantity?: number; timeout?: number }
-) => {
-  await waitForTxInPool(api, {
-    module: "fileSystem",
-    method: "bspConfirmStoring",
-    checkQuantity: options?.checkQuantity,
-    timeout: options?.timeout ?? 10_000
-  });
 };
 
 /**

--- a/test/util/netLaunch/index.ts
+++ b/test/util/netLaunch/index.ts
@@ -679,7 +679,7 @@ export class NetworkLauncher {
       null
     );
     await api.wait.bspVolunteer(4);
-    await api.wait.bspStored(4);
+    await api.wait.bspStored({ expectedExts: 4 });
 
     // Stop BSP that is supposed to be down
     await api.docker.stopContainer(bspDownContainerName);


### PR DESCRIPTION
In this PR:
1. Add functionalities to `RetrySrategy`:
    1. Now `should_retry` takes `WatchTransactionError` as an argument, to provide more information for deciding to retry or not.
    2. There is a `retry_only_with_timout` that sets `should_retry` to return `true` only if the extrinsic timed out.
2. `bsp_submit_proof` task only retries sending the same transaction if the extrinsic timed out. It also checks if the proof is still up to date. If it fails beyond the retries (or it is outdated) it finishes the task with an error, trusting that the BlockchainService will check for proof submissions frequently and spawn new tasks to take care of it.
3. `bsp_upload_file` task only retries confirmation extrinsic if it times out.
4. `msp_delete_file` task only retries confirmation of deletion if it times out.