### PR TITLE
fix: 🔒 Increase events queue size and make `NewStorageRequests` non-critical

### DIFF
--- a/client/actors-framework/src/constants.rs
+++ b/client/actors-framework/src/constants.rs
@@ -1,4 +1,4 @@
-pub const MAX_PENDING_EVENTS: usize = 2000;
-pub const MAX_TASKS_SPAWNED_PER_QUEUE: usize = 2000;
+pub const MAX_PENDING_EVENTS: usize = 10000;
+pub const MAX_TASKS_SPAWNED_PER_QUEUE: usize = 20000;
 
 pub const DEFAULT_ACTOR_COMMAND_QUEUE_WARNING_SIZE: usize = 2000;

--- a/node/src/services/handler.rs
+++ b/node/src/services/handler.rs
@@ -167,10 +167,14 @@ where
         let user_sends_file_task = UserSendsFileTask::new(self.clone());
 
         // Subscribing to NewStorageRequest event from the BlockchainService.
+        // NewStorageRequest event can be used by the user to spam, by spamming the network with new
+        // storage requests. To prevent this from affecting a BSP node, we make this event NOT
+        // critical. This means that if used to spam, some of those spam NewStorageRequest events
+        // will be dropped.
         let new_storage_request_event_bus_listener: EventBusListener<NewStorageRequest, _> =
             user_sends_file_task
                 .clone()
-                .subscribe_to(&self.task_spawner, &self.blockchain, true);
+                .subscribe_to(&self.task_spawner, &self.blockchain, false);
         new_storage_request_event_bus_listener.start();
 
         let accepted_bsp_volunteer_event_bus_listener: EventBusListener<AcceptedBspVolunteer, _> =


### PR DESCRIPTION
This PR:
1. Increases the size of each event queue to 10,000.
2. Increases the max number of spawned tasks per event queue to 20,000.
3. Makes `NewStorageRequest` event not-critical.

1 and 2 are for making it so that if a user manages to spam with blockchain events (like `NewStorageRequests` or `FileDeletionRequest`, the limit is higher.
3 is so that even if a user manages to spam enough with `NewStorageRequests` to reach the limit, the policy will be to just ignore and drop those spamming `NewStorageRequests`.