### PR TITLE
test: MSP move bucket reject on max capacity exceeded

### DIFF
--- a/node/src/tasks/msp_charge_fees.rs
+++ b/node/src/tasks/msp_charge_fees.rs
@@ -79,9 +79,8 @@ where
                 }
             },
             None => {
-                let err_msg = "Failed to get own MSP ID.";
-                error!(target: LOG_TARGET, err_msg);
-                return Err(anyhow!(err_msg));
+                warn!(target: LOG_TARGET, "Provider not registred yet. We can't charge users.");
+                return Ok(());
             }
         };
 

--- a/test/suites/integration/msp/move-bucket-low-capacity.test.ts
+++ b/test/suites/integration/msp/move-bucket-low-capacity.test.ts
@@ -1,0 +1,376 @@
+import { strictEqual } from "node:assert";
+import assert from "node:assert";
+import {
+    assertEventPresent,
+    bspTwoKey,
+    bspThreeKey,
+    bspThreeSeed,
+    bspTwoSeed,
+    ShConsts,
+    describeMspNet,
+    shUser,
+    sleep,
+    getContainerIp,
+    type EnrichedBspApi,
+    mspThreeKey,
+    mspThreeSeed,
+    addMspContainer
+} from "../../../util";
+import type { EventRecord } from "@polkadot/types/interfaces";
+
+describeMspNet(
+    "MSP rejects bucket move requests due to low capacity",
+    { initialised: false, indexer: true },
+    ({ before, createMsp1Api, it, createUserApi, createApi }) => {
+        let userApi: EnrichedBspApi;
+        let mspApi: EnrichedBspApi;
+        let msp3Api: EnrichedBspApi;
+
+        const source = ["res/cloud.jpg", "res/smile.jpg", "res/whatsup.jpg"];
+        const destination = ["test/cloud.jpg", "test/smile.jpg", "test/whatsup.jpg"];
+        const bucketName = "move-bucket";
+        let bucketId: string;
+        const allBucketFiles: string[] = [];
+
+        before(async () => {
+            userApi = await createUserApi();
+            const maybeMspApi = await createMsp1Api();
+            if (!maybeMspApi) {
+                throw new Error("Failed to create MSP API");
+            }
+            mspApi = maybeMspApi;
+        });
+
+        it("postgres DB is ready", async () => {
+            await userApi.docker.waitForLog({
+                containerName: "docker-sh-postgres-1",
+                searchString: "database system is ready to accept connections",
+                timeout: 5000
+            });
+        });
+
+        it("Network launches and can be queried", async () => {
+            const userNodePeerId = await userApi.rpc.system.localPeerId();
+            strictEqual(userNodePeerId.toString(), userApi.shConsts.NODE_INFOS.user.expectedPeerId);
+
+            const mspNodePeerId = await mspApi.rpc.system.localPeerId();
+            strictEqual(mspNodePeerId.toString(), userApi.shConsts.NODE_INFOS.msp1.expectedPeerId);
+        });
+
+        it("Add 2 more BSPs (3 total) and set the replication target to 2", async () => {
+            // Replicate to 2 BSPs, 5 blocks to maxthreshold
+            const newRuntimeParameter = {
+                RuntimeConfig: {
+                    MaxReplicationTarget: [null, 2],
+                    TickRangeToMaximumThreshold: [null, 5]
+                }
+            };
+            await userApi.block.seal({
+                calls: [userApi.tx.sudo.sudo(userApi.tx.parameters.setParameter(newRuntimeParameter))]
+            });
+
+            await userApi.docker.onboardBsp({
+                bspSigner: bspTwoKey,
+                name: "sh-bsp-two",
+                bspKeySeed: bspTwoSeed,
+                bspId: ShConsts.BSP_TWO_ID,
+                additionalArgs: ["--keystore-path=/keystore/bsp-two"],
+                waitForIdle: true
+            });
+
+            await userApi.docker.onboardBsp({
+                bspSigner: bspThreeKey,
+                name: "sh-bsp-three",
+                bspKeySeed: bspThreeSeed,
+                bspId: ShConsts.BSP_THREE_ID,
+                additionalArgs: ["--keystore-path=/keystore/bsp-three"],
+                waitForIdle: true
+            });
+        });
+
+        it("Add new MSP with low capacity", async () => {
+            // const { mspApi: newMspApi } = await onboardMsp(userApi, {
+            //     mspSigner: mspTwoKey,
+            //     name: "sh-msp-2",
+            //     mspId: ShConsts.DUMMY_MSP_ID_2,
+            //     maxStorageCapacity: 1024 * 1024, // 1MB capacity
+            //     jumpCapacity: 1024 * 1024,
+            //     waitForIdle: true,
+            //     nodeKey: ShConsts.NODE_INFOS.msp2.nodeKey,
+            //     keystoreFolder: "msp-two"
+            // });
+
+            const { containerName, p2pPort, peerId, rpcPort } = await addMspContainer({
+                name: "sleepy",
+                additionalArgs: [
+                    "--keystore-path=/tmp/msp-three",
+                    "--node-key=0xe6a9007b119845010c43f68685f7c2065d8cbf596efc3ebc854dc44f05f6530a",
+                    `--max-storage-capacity=${1024 * 1024}`,
+                    `--jump-capacity=${1024 * 1024}`,
+                    "--msp-charging-period=12"
+                ]
+            });
+
+            await userApi.docker.waitForLog({
+                containerName: "sleepy",
+                searchString: "💤 Idle",
+                timeout: 15000
+            });
+
+            msp3Api = await createApi(`ws://127.0.0.1:${rpcPort}`);
+            await msp3Api.rpc.storagehubclient.insertBcsvKeys(mspThreeSeed);
+
+
+            //Give it some balance.
+            const amount = 10000n * 10n ** 12n;
+            await userApi.block.seal({
+                calls: [
+                    userApi.tx.sudo.sudo(userApi.tx.balances.forceSetBalance(mspThreeKey.address, amount))
+                ]
+            });
+
+            await userApi.block.seal()
+
+            const mspIp = await getContainerIp(containerName);
+            const multiAddressMsp = `/ip4/${mspIp}/tcp/${p2pPort}/p2p/${peerId}`;
+            await userApi.block.seal({
+                calls: [
+                    userApi.tx.sudo.sudo(
+                        userApi.tx.providers.forceMspSignUp(
+                            mspThreeKey.address,
+                            mspThreeKey.publicKey,
+                            userApi.shConsts.CAPACITY_512,
+                            [multiAddressMsp],
+                            100 * 1024 * 1024,
+                            "Terms of Service...",
+                            9999999,
+                            mspThreeKey.address
+                        )
+                    )
+                ]
+            });
+
+
+        });
+
+        it("User submits 3 storage requests in the same bucket for first MSP", async () => {
+            // Get value propositions form the MSP to use, and use the first one (can be any).
+            const valueProps = await userApi.call.storageProvidersApi.queryValuePropositionsForMsp(
+                userApi.shConsts.DUMMY_MSP_ID
+            );
+            const valuePropId = valueProps[0].id;
+
+            // Create a new bucket where all the files will be stored.
+            const newBucketEventEvent = await userApi.createBucket(bucketName, valuePropId);
+            const newBucketEventDataBlob =
+                userApi.events.fileSystem.NewBucket.is(newBucketEventEvent) && newBucketEventEvent.data;
+
+            if (!newBucketEventDataBlob) {
+                throw new Error("NewBucket event data does not match expected type");
+            }
+            bucketId = newBucketEventDataBlob.bucketId.toString();
+
+            // Seal block with 3 storage requests.
+            const txs = [];
+            for (let i = 0; i < source.length; i++) {
+                const {
+                    file_metadata: { location, fingerprint, file_size }
+                } = await userApi.rpc.storagehubclient.loadFileInStorage(
+                    source[i],
+                    destination[i],
+                    userApi.shConsts.NODE_INFOS.user.AddressId,
+                    bucketId
+                );
+
+                txs.push(
+                    userApi.tx.fileSystem.issueStorageRequest(
+                        bucketId,
+                        location,
+                        fingerprint,
+                        file_size,
+                        userApi.shConsts.DUMMY_MSP_ID,
+                        [userApi.shConsts.NODE_INFOS.user.expectedPeerId],
+                        {
+                            Custom: 2
+                        })
+                );
+            }
+            await userApi.block.seal({ calls: txs, signer: shUser });
+        });
+
+        it("MSP 1 receives files from user and accepts them", async () => {
+            // Get the events of the storage requests to extract the file keys and check
+            // that the MSP received them.
+            const events = await userApi.assert.eventMany("fileSystem", "NewStorageRequest");
+            const matchedEvents = events.filter((e: EventRecord) =>
+                userApi.events.fileSystem.NewStorageRequest.is(e.event)
+            );
+            if (matchedEvents.length !== source.length) {
+                throw new Error(`Expected ${source.length} NewStorageRequest events`);
+            }
+
+            // Allow time for the MSP to receive and store the files from the user
+            await sleep(3000);
+
+            // Check if the MSP received the files.
+            for (const e of matchedEvents) {
+                const newStorageRequestDataBlob =
+                    userApi.events.fileSystem.NewStorageRequest.is(e.event) && e.event.data;
+
+                if (!newStorageRequestDataBlob) {
+                    throw new Error("Event doesn't match NewStorageRequest type");
+                }
+
+                const result = await mspApi.rpc.storagehubclient.isFileInFileStorage(
+                    newStorageRequestDataBlob.fileKey
+                );
+
+                if (!result.isFileFound) {
+                    throw new Error(
+                        `File not found in storage for ${newStorageRequestDataBlob.location.toHuman()}`
+                    );
+                }
+
+                allBucketFiles.push(newStorageRequestDataBlob.fileKey.toString());
+            }
+
+            // Seal block containing the MSP's first response.
+            await userApi.wait.mspResponseInTxPool();
+            await userApi.block.seal();
+
+            // Give time for the MSP to update the local forest root.
+            await sleep(1000);
+
+            // Check that the local forest root is updated, and matches the on-chain root.
+            const localBucketRoot = await mspApi.rpc.storagehubclient.getForestRoot(bucketId);
+
+            const { event: bucketRootChangedEvent } = await userApi.assert.eventPresent(
+                "providers",
+                "BucketRootChanged"
+            );
+            const bucketRootChangedDataBlob =
+                userApi.events.providers.BucketRootChanged.is(bucketRootChangedEvent) &&
+                bucketRootChangedEvent.data;
+            if (!bucketRootChangedDataBlob) {
+                throw new Error("Expected BucketRootChanged event but received event of different type");
+            }
+
+            strictEqual(bucketRootChangedDataBlob.newRoot.toString(), localBucketRoot.toString());
+
+            // The MSP should have accepted exactly one file.
+            // Register how many were accepted in the last block sealed.
+            const acceptedFileKeys: string[] = [];
+            const mspAcceptedStorageRequestEvents = await userApi.assert.eventMany(
+                "fileSystem",
+                "MspAcceptedStorageRequest"
+            );
+            for (const e of mspAcceptedStorageRequestEvents) {
+                const mspAcceptedStorageRequestDataBlob =
+                    userApi.events.fileSystem.MspAcceptedStorageRequest.is(e.event) && e.event.data;
+                if (mspAcceptedStorageRequestDataBlob) {
+                    acceptedFileKeys.push(mspAcceptedStorageRequestDataBlob.fileKey.toString());
+                }
+            }
+            assert(
+                acceptedFileKeys.length === 1,
+                "Expected 1 file key accepted in first block after storage requests"
+            );
+
+            // An additional block needs to be sealed to accept the rest of the files.
+            // There should be a pending transaction to accept the rest of the files.
+            await userApi.wait.mspResponseInTxPool();
+            await userApi.block.seal();
+
+            // Give time for the MSP to update the local forest root.
+            await sleep(1000);
+
+            // Check that the local forest root is updated, and matches the on-chain root.
+            const localBucketRoot2 = await mspApi.rpc.storagehubclient.getForestRoot(bucketId);
+
+            const { event: bucketRootChangedEvent2 } = await userApi.assert.eventPresent(
+                "providers",
+                "BucketRootChanged"
+            );
+            const bucketRootChangedDataBlob2 =
+                userApi.events.providers.BucketRootChanged.is(bucketRootChangedEvent2) &&
+                bucketRootChangedEvent2.data;
+            if (!bucketRootChangedDataBlob2) {
+                throw new Error("Expected BucketRootChanged event but received event of different type");
+            }
+
+            strictEqual(bucketRootChangedDataBlob2.newRoot.toString(), localBucketRoot2.toString());
+
+            // The MSP should have accepted at least one file.
+            // Register how many were accepted in the last block sealed.
+            const mspAcceptedStorageRequestEvents2 = await userApi.assert.eventMany(
+                "fileSystem",
+                "MspAcceptedStorageRequest"
+            );
+            for (const e of mspAcceptedStorageRequestEvents2) {
+                const mspAcceptedStorageRequestDataBlob =
+                    userApi.events.fileSystem.MspAcceptedStorageRequest.is(e.event) && e.event.data;
+                if (mspAcceptedStorageRequestDataBlob) {
+                    acceptedFileKeys.push(mspAcceptedStorageRequestDataBlob.fileKey.toString());
+                }
+            }
+
+            // Now for sure, the total number of accepted files should be `source.length`.
+            assert(acceptedFileKeys.length === source.length, `Expected ${source.length} file keys`);
+
+            // And they should be in the Forest storage of the MSP, in the Forest corresponding
+            // to the bucket ID.
+            for (const fileKey of acceptedFileKeys) {
+                const isFileInForest = await mspApi.rpc.storagehubclient.isFileInForest(bucketId, fileKey);
+                assert(isFileInForest.isTrue, "File is not in forest");
+                allBucketFiles.push(fileKey);
+            }
+
+            // Seal 5 more blocks to pass maxthreshold and ensure completed upload requests
+            for (let i = 0; i < 5; i++) {
+                await sleep(500);
+                const block = await userApi.block.seal();
+                await userApi.rpc.engine.finalizeBlock(block.blockReceipt.blockHash);
+            }
+        });
+
+        it("New MSP rejects move request due to low capacity", async () => {
+            const valueProps = await userApi.call.storageProvidersApi.queryValuePropositionsForMsp(
+                mspThreeKey.publicKey
+            );
+            const valuePropId = valueProps[0].id;
+
+            // User requests to move bucket to second MSP
+            const requestMoveBucketResult = await userApi.block.seal({
+                calls: [userApi.tx.fileSystem.requestMoveBucket(bucketId, mspThreeKey.publicKey, valuePropId)],
+                signer: shUser
+            });
+
+            assertEventPresent(
+                userApi,
+                "fileSystem",
+                "MoveBucketRequested",
+                requestMoveBucketResult.events
+            );
+
+            // Finalising the block in the BSP node as well, to trigger the reorg in the BSP node too.
+            const finalisedBlockHash = await userApi.rpc.chain.getFinalizedHead();
+
+            // Wait for BSP node to have imported the finalised block built by the user node.
+            await msp3Api.wait.blockImported(finalisedBlockHash.toString());
+            await msp3Api.block.finaliseBlock(finalisedBlockHash.toString());
+
+            // Wait for the rejection response from Sleepy
+            await userApi.wait.waitForTxInPool({
+                module: "fileSystem",
+                method: "mspRespondMoveBucketRequest"
+            });
+
+            const { events } = await userApi.block.seal();
+
+            // Verify that the move request was rejected
+            assertEventPresent(userApi, "fileSystem", "MoveBucketRejected", events);
+
+            msp3Api.disconnect();
+        });
+    }
+);

--- a/test/suites/integration/msp/move-bucket-low-capacity.test.ts
+++ b/test/suites/integration/msp/move-bucket-low-capacity.test.ts
@@ -21,7 +21,7 @@ import type { EventRecord } from "@polkadot/types/interfaces";
 describeMspNet(
   "MSP rejects bucket move requests due to low capacity",
   { initialised: false, indexer: true },
-  ({ before, createMsp1Api, it, createUserApi, createApi }) => {
+  ({ before, after, createMsp1Api, it, createUserApi, createApi }) => {
     let userApi: EnrichedBspApi;
     let mspApi: EnrichedBspApi;
     let msp3Api: EnrichedBspApi;
@@ -39,6 +39,10 @@ describeMspNet(
         throw new Error("Failed to create MSP API");
       }
       mspApi = maybeMspApi;
+    });
+
+    after(async () => {
+      msp3Api.disconnect();
     });
 
     it("postgres DB is ready", async () => {
@@ -89,17 +93,6 @@ describeMspNet(
     });
 
     it("Add new MSP with low capacity", async () => {
-      // const { mspApi: newMspApi } = await onboardMsp(userApi, {
-      //     mspSigner: mspTwoKey,
-      //     name: "sh-msp-2",
-      //     mspId: ShConsts.DUMMY_MSP_ID_2,
-      //     maxStorageCapacity: 1024 * 1024, // 1MB capacity
-      //     jumpCapacity: 1024 * 1024,
-      //     waitForIdle: true,
-      //     nodeKey: ShConsts.NODE_INFOS.msp2.nodeKey,
-      //     keystoreFolder: "msp-two"
-      // });
-
       const { containerName, p2pPort, peerId, rpcPort } = await addMspContainer({
         name: "sleepy",
         additionalArgs: [
@@ -369,8 +362,6 @@ describeMspNet(
 
       // Verify that the move request was rejected
       assertEventPresent(userApi, "fileSystem", "MoveBucketRejected", events);
-
-      msp3Api.disconnect();
     });
   }
 );

--- a/test/suites/integration/msp/move-bucket-low-capacity.test.ts
+++ b/test/suites/integration/msp/move-bucket-low-capacity.test.ts
@@ -1,376 +1,376 @@
 import { strictEqual } from "node:assert";
 import assert from "node:assert";
 import {
-    assertEventPresent,
-    bspTwoKey,
-    bspThreeKey,
-    bspThreeSeed,
-    bspTwoSeed,
-    ShConsts,
-    describeMspNet,
-    shUser,
-    sleep,
-    getContainerIp,
-    type EnrichedBspApi,
-    mspThreeKey,
-    mspThreeSeed,
-    addMspContainer
+  assertEventPresent,
+  bspTwoKey,
+  bspThreeKey,
+  bspThreeSeed,
+  bspTwoSeed,
+  ShConsts,
+  describeMspNet,
+  shUser,
+  sleep,
+  getContainerIp,
+  type EnrichedBspApi,
+  mspThreeKey,
+  mspThreeSeed,
+  addMspContainer
 } from "../../../util";
 import type { EventRecord } from "@polkadot/types/interfaces";
 
 describeMspNet(
-    "MSP rejects bucket move requests due to low capacity",
-    { initialised: false, indexer: true },
-    ({ before, createMsp1Api, it, createUserApi, createApi }) => {
-        let userApi: EnrichedBspApi;
-        let mspApi: EnrichedBspApi;
-        let msp3Api: EnrichedBspApi;
+  "MSP rejects bucket move requests due to low capacity",
+  { initialised: false, indexer: true },
+  ({ before, createMsp1Api, it, createUserApi, createApi }) => {
+    let userApi: EnrichedBspApi;
+    let mspApi: EnrichedBspApi;
+    let msp3Api: EnrichedBspApi;
 
-        const source = ["res/cloud.jpg", "res/smile.jpg", "res/whatsup.jpg"];
-        const destination = ["test/cloud.jpg", "test/smile.jpg", "test/whatsup.jpg"];
-        const bucketName = "move-bucket";
-        let bucketId: string;
-        const allBucketFiles: string[] = [];
+    const source = ["res/cloud.jpg", "res/smile.jpg", "res/whatsup.jpg"];
+    const destination = ["test/cloud.jpg", "test/smile.jpg", "test/whatsup.jpg"];
+    const bucketName = "move-bucket";
+    let bucketId: string;
+    const allBucketFiles: string[] = [];
 
-        before(async () => {
-            userApi = await createUserApi();
-            const maybeMspApi = await createMsp1Api();
-            if (!maybeMspApi) {
-                throw new Error("Failed to create MSP API");
+    before(async () => {
+      userApi = await createUserApi();
+      const maybeMspApi = await createMsp1Api();
+      if (!maybeMspApi) {
+        throw new Error("Failed to create MSP API");
+      }
+      mspApi = maybeMspApi;
+    });
+
+    it("postgres DB is ready", async () => {
+      await userApi.docker.waitForLog({
+        containerName: "docker-sh-postgres-1",
+        searchString: "database system is ready to accept connections",
+        timeout: 5000
+      });
+    });
+
+    it("Network launches and can be queried", async () => {
+      const userNodePeerId = await userApi.rpc.system.localPeerId();
+      strictEqual(userNodePeerId.toString(), userApi.shConsts.NODE_INFOS.user.expectedPeerId);
+
+      const mspNodePeerId = await mspApi.rpc.system.localPeerId();
+      strictEqual(mspNodePeerId.toString(), userApi.shConsts.NODE_INFOS.msp1.expectedPeerId);
+    });
+
+    it("Add 2 more BSPs (3 total) and set the replication target to 2", async () => {
+      // Replicate to 2 BSPs, 5 blocks to maxthreshold
+      const newRuntimeParameter = {
+        RuntimeConfig: {
+          MaxReplicationTarget: [null, 2],
+          TickRangeToMaximumThreshold: [null, 5]
+        }
+      };
+      await userApi.block.seal({
+        calls: [userApi.tx.sudo.sudo(userApi.tx.parameters.setParameter(newRuntimeParameter))]
+      });
+
+      await userApi.docker.onboardBsp({
+        bspSigner: bspTwoKey,
+        name: "sh-bsp-two",
+        bspKeySeed: bspTwoSeed,
+        bspId: ShConsts.BSP_TWO_ID,
+        additionalArgs: ["--keystore-path=/keystore/bsp-two"],
+        waitForIdle: true
+      });
+
+      await userApi.docker.onboardBsp({
+        bspSigner: bspThreeKey,
+        name: "sh-bsp-three",
+        bspKeySeed: bspThreeSeed,
+        bspId: ShConsts.BSP_THREE_ID,
+        additionalArgs: ["--keystore-path=/keystore/bsp-three"],
+        waitForIdle: true
+      });
+    });
+
+    it("Add new MSP with low capacity", async () => {
+      // const { mspApi: newMspApi } = await onboardMsp(userApi, {
+      //     mspSigner: mspTwoKey,
+      //     name: "sh-msp-2",
+      //     mspId: ShConsts.DUMMY_MSP_ID_2,
+      //     maxStorageCapacity: 1024 * 1024, // 1MB capacity
+      //     jumpCapacity: 1024 * 1024,
+      //     waitForIdle: true,
+      //     nodeKey: ShConsts.NODE_INFOS.msp2.nodeKey,
+      //     keystoreFolder: "msp-two"
+      // });
+
+      const { containerName, p2pPort, peerId, rpcPort } = await addMspContainer({
+        name: "sleepy",
+        additionalArgs: [
+          "--keystore-path=/tmp/msp-three",
+          "--node-key=0xe6a9007b119845010c43f68685f7c2065d8cbf596efc3ebc854dc44f05f6530a",
+          `--max-storage-capacity=${1024 * 1024}`,
+          `--jump-capacity=${1024 * 1024}`,
+          "--msp-charging-period=12"
+        ]
+      });
+
+      await userApi.docker.waitForLog({
+        containerName: "sleepy",
+        searchString: "💤 Idle",
+        timeout: 15000
+      });
+
+      msp3Api = await createApi(`ws://127.0.0.1:${rpcPort}`);
+      await msp3Api.rpc.storagehubclient.insertBcsvKeys(mspThreeSeed);
+
+      //Give it some balance.
+      const amount = 10000n * 10n ** 12n;
+      await userApi.block.seal({
+        calls: [
+          userApi.tx.sudo.sudo(userApi.tx.balances.forceSetBalance(mspThreeKey.address, amount))
+        ]
+      });
+
+      await userApi.block.seal();
+
+      const mspIp = await getContainerIp(containerName);
+      const multiAddressMsp = `/ip4/${mspIp}/tcp/${p2pPort}/p2p/${peerId}`;
+      await userApi.block.seal({
+        calls: [
+          userApi.tx.sudo.sudo(
+            userApi.tx.providers.forceMspSignUp(
+              mspThreeKey.address,
+              mspThreeKey.publicKey,
+              userApi.shConsts.CAPACITY_512,
+              [multiAddressMsp],
+              100 * 1024 * 1024,
+              "Terms of Service...",
+              9999999,
+              mspThreeKey.address
+            )
+          )
+        ]
+      });
+    });
+
+    it("User submits 3 storage requests in the same bucket for first MSP", async () => {
+      // Get value propositions form the MSP to use, and use the first one (can be any).
+      const valueProps = await userApi.call.storageProvidersApi.queryValuePropositionsForMsp(
+        userApi.shConsts.DUMMY_MSP_ID
+      );
+      const valuePropId = valueProps[0].id;
+
+      // Create a new bucket where all the files will be stored.
+      const newBucketEventEvent = await userApi.createBucket(bucketName, valuePropId);
+      const newBucketEventDataBlob =
+        userApi.events.fileSystem.NewBucket.is(newBucketEventEvent) && newBucketEventEvent.data;
+
+      if (!newBucketEventDataBlob) {
+        throw new Error("NewBucket event data does not match expected type");
+      }
+      bucketId = newBucketEventDataBlob.bucketId.toString();
+
+      // Seal block with 3 storage requests.
+      const txs = [];
+      for (let i = 0; i < source.length; i++) {
+        const {
+          file_metadata: { location, fingerprint, file_size }
+        } = await userApi.rpc.storagehubclient.loadFileInStorage(
+          source[i],
+          destination[i],
+          userApi.shConsts.NODE_INFOS.user.AddressId,
+          bucketId
+        );
+
+        txs.push(
+          userApi.tx.fileSystem.issueStorageRequest(
+            bucketId,
+            location,
+            fingerprint,
+            file_size,
+            userApi.shConsts.DUMMY_MSP_ID,
+            [userApi.shConsts.NODE_INFOS.user.expectedPeerId],
+            {
+              Custom: 2
             }
-            mspApi = maybeMspApi;
-        });
+          )
+        );
+      }
+      await userApi.block.seal({ calls: txs, signer: shUser });
+    });
 
-        it("postgres DB is ready", async () => {
-            await userApi.docker.waitForLog({
-                containerName: "docker-sh-postgres-1",
-                searchString: "database system is ready to accept connections",
-                timeout: 5000
-            });
-        });
+    it("MSP 1 receives files from user and accepts them", async () => {
+      // Get the events of the storage requests to extract the file keys and check
+      // that the MSP received them.
+      const events = await userApi.assert.eventMany("fileSystem", "NewStorageRequest");
+      const matchedEvents = events.filter((e: EventRecord) =>
+        userApi.events.fileSystem.NewStorageRequest.is(e.event)
+      );
+      if (matchedEvents.length !== source.length) {
+        throw new Error(`Expected ${source.length} NewStorageRequest events`);
+      }
 
-        it("Network launches and can be queried", async () => {
-            const userNodePeerId = await userApi.rpc.system.localPeerId();
-            strictEqual(userNodePeerId.toString(), userApi.shConsts.NODE_INFOS.user.expectedPeerId);
+      // Allow time for the MSP to receive and store the files from the user
+      await sleep(3000);
 
-            const mspNodePeerId = await mspApi.rpc.system.localPeerId();
-            strictEqual(mspNodePeerId.toString(), userApi.shConsts.NODE_INFOS.msp1.expectedPeerId);
-        });
+      // Check if the MSP received the files.
+      for (const e of matchedEvents) {
+        const newStorageRequestDataBlob =
+          userApi.events.fileSystem.NewStorageRequest.is(e.event) && e.event.data;
 
-        it("Add 2 more BSPs (3 total) and set the replication target to 2", async () => {
-            // Replicate to 2 BSPs, 5 blocks to maxthreshold
-            const newRuntimeParameter = {
-                RuntimeConfig: {
-                    MaxReplicationTarget: [null, 2],
-                    TickRangeToMaximumThreshold: [null, 5]
-                }
-            };
-            await userApi.block.seal({
-                calls: [userApi.tx.sudo.sudo(userApi.tx.parameters.setParameter(newRuntimeParameter))]
-            });
+        if (!newStorageRequestDataBlob) {
+          throw new Error("Event doesn't match NewStorageRequest type");
+        }
 
-            await userApi.docker.onboardBsp({
-                bspSigner: bspTwoKey,
-                name: "sh-bsp-two",
-                bspKeySeed: bspTwoSeed,
-                bspId: ShConsts.BSP_TWO_ID,
-                additionalArgs: ["--keystore-path=/keystore/bsp-two"],
-                waitForIdle: true
-            });
+        const result = await mspApi.rpc.storagehubclient.isFileInFileStorage(
+          newStorageRequestDataBlob.fileKey
+        );
 
-            await userApi.docker.onboardBsp({
-                bspSigner: bspThreeKey,
-                name: "sh-bsp-three",
-                bspKeySeed: bspThreeSeed,
-                bspId: ShConsts.BSP_THREE_ID,
-                additionalArgs: ["--keystore-path=/keystore/bsp-three"],
-                waitForIdle: true
-            });
-        });
+        if (!result.isFileFound) {
+          throw new Error(
+            `File not found in storage for ${newStorageRequestDataBlob.location.toHuman()}`
+          );
+        }
 
-        it("Add new MSP with low capacity", async () => {
-            // const { mspApi: newMspApi } = await onboardMsp(userApi, {
-            //     mspSigner: mspTwoKey,
-            //     name: "sh-msp-2",
-            //     mspId: ShConsts.DUMMY_MSP_ID_2,
-            //     maxStorageCapacity: 1024 * 1024, // 1MB capacity
-            //     jumpCapacity: 1024 * 1024,
-            //     waitForIdle: true,
-            //     nodeKey: ShConsts.NODE_INFOS.msp2.nodeKey,
-            //     keystoreFolder: "msp-two"
-            // });
+        allBucketFiles.push(newStorageRequestDataBlob.fileKey.toString());
+      }
 
-            const { containerName, p2pPort, peerId, rpcPort } = await addMspContainer({
-                name: "sleepy",
-                additionalArgs: [
-                    "--keystore-path=/tmp/msp-three",
-                    "--node-key=0xe6a9007b119845010c43f68685f7c2065d8cbf596efc3ebc854dc44f05f6530a",
-                    `--max-storage-capacity=${1024 * 1024}`,
-                    `--jump-capacity=${1024 * 1024}`,
-                    "--msp-charging-period=12"
-                ]
-            });
+      // Seal block containing the MSP's first response.
+      await userApi.wait.mspResponseInTxPool();
+      await userApi.block.seal();
 
-            await userApi.docker.waitForLog({
-                containerName: "sleepy",
-                searchString: "💤 Idle",
-                timeout: 15000
-            });
+      // Give time for the MSP to update the local forest root.
+      await sleep(1000);
 
-            msp3Api = await createApi(`ws://127.0.0.1:${rpcPort}`);
-            await msp3Api.rpc.storagehubclient.insertBcsvKeys(mspThreeSeed);
+      // Check that the local forest root is updated, and matches the on-chain root.
+      const localBucketRoot = await mspApi.rpc.storagehubclient.getForestRoot(bucketId);
 
+      const { event: bucketRootChangedEvent } = await userApi.assert.eventPresent(
+        "providers",
+        "BucketRootChanged"
+      );
+      const bucketRootChangedDataBlob =
+        userApi.events.providers.BucketRootChanged.is(bucketRootChangedEvent) &&
+        bucketRootChangedEvent.data;
+      if (!bucketRootChangedDataBlob) {
+        throw new Error("Expected BucketRootChanged event but received event of different type");
+      }
 
-            //Give it some balance.
-            const amount = 10000n * 10n ** 12n;
-            await userApi.block.seal({
-                calls: [
-                    userApi.tx.sudo.sudo(userApi.tx.balances.forceSetBalance(mspThreeKey.address, amount))
-                ]
-            });
+      strictEqual(bucketRootChangedDataBlob.newRoot.toString(), localBucketRoot.toString());
 
-            await userApi.block.seal()
+      // The MSP should have accepted exactly one file.
+      // Register how many were accepted in the last block sealed.
+      const acceptedFileKeys: string[] = [];
+      const mspAcceptedStorageRequestEvents = await userApi.assert.eventMany(
+        "fileSystem",
+        "MspAcceptedStorageRequest"
+      );
+      for (const e of mspAcceptedStorageRequestEvents) {
+        const mspAcceptedStorageRequestDataBlob =
+          userApi.events.fileSystem.MspAcceptedStorageRequest.is(e.event) && e.event.data;
+        if (mspAcceptedStorageRequestDataBlob) {
+          acceptedFileKeys.push(mspAcceptedStorageRequestDataBlob.fileKey.toString());
+        }
+      }
+      assert(
+        acceptedFileKeys.length === 1,
+        "Expected 1 file key accepted in first block after storage requests"
+      );
 
-            const mspIp = await getContainerIp(containerName);
-            const multiAddressMsp = `/ip4/${mspIp}/tcp/${p2pPort}/p2p/${peerId}`;
-            await userApi.block.seal({
-                calls: [
-                    userApi.tx.sudo.sudo(
-                        userApi.tx.providers.forceMspSignUp(
-                            mspThreeKey.address,
-                            mspThreeKey.publicKey,
-                            userApi.shConsts.CAPACITY_512,
-                            [multiAddressMsp],
-                            100 * 1024 * 1024,
-                            "Terms of Service...",
-                            9999999,
-                            mspThreeKey.address
-                        )
-                    )
-                ]
-            });
+      // An additional block needs to be sealed to accept the rest of the files.
+      // There should be a pending transaction to accept the rest of the files.
+      await userApi.wait.mspResponseInTxPool();
+      await userApi.block.seal();
 
+      // Give time for the MSP to update the local forest root.
+      await sleep(1000);
 
-        });
+      // Check that the local forest root is updated, and matches the on-chain root.
+      const localBucketRoot2 = await mspApi.rpc.storagehubclient.getForestRoot(bucketId);
 
-        it("User submits 3 storage requests in the same bucket for first MSP", async () => {
-            // Get value propositions form the MSP to use, and use the first one (can be any).
-            const valueProps = await userApi.call.storageProvidersApi.queryValuePropositionsForMsp(
-                userApi.shConsts.DUMMY_MSP_ID
-            );
-            const valuePropId = valueProps[0].id;
+      const { event: bucketRootChangedEvent2 } = await userApi.assert.eventPresent(
+        "providers",
+        "BucketRootChanged"
+      );
+      const bucketRootChangedDataBlob2 =
+        userApi.events.providers.BucketRootChanged.is(bucketRootChangedEvent2) &&
+        bucketRootChangedEvent2.data;
+      if (!bucketRootChangedDataBlob2) {
+        throw new Error("Expected BucketRootChanged event but received event of different type");
+      }
 
-            // Create a new bucket where all the files will be stored.
-            const newBucketEventEvent = await userApi.createBucket(bucketName, valuePropId);
-            const newBucketEventDataBlob =
-                userApi.events.fileSystem.NewBucket.is(newBucketEventEvent) && newBucketEventEvent.data;
+      strictEqual(bucketRootChangedDataBlob2.newRoot.toString(), localBucketRoot2.toString());
 
-            if (!newBucketEventDataBlob) {
-                throw new Error("NewBucket event data does not match expected type");
-            }
-            bucketId = newBucketEventDataBlob.bucketId.toString();
+      // The MSP should have accepted at least one file.
+      // Register how many were accepted in the last block sealed.
+      const mspAcceptedStorageRequestEvents2 = await userApi.assert.eventMany(
+        "fileSystem",
+        "MspAcceptedStorageRequest"
+      );
+      for (const e of mspAcceptedStorageRequestEvents2) {
+        const mspAcceptedStorageRequestDataBlob =
+          userApi.events.fileSystem.MspAcceptedStorageRequest.is(e.event) && e.event.data;
+        if (mspAcceptedStorageRequestDataBlob) {
+          acceptedFileKeys.push(mspAcceptedStorageRequestDataBlob.fileKey.toString());
+        }
+      }
 
-            // Seal block with 3 storage requests.
-            const txs = [];
-            for (let i = 0; i < source.length; i++) {
-                const {
-                    file_metadata: { location, fingerprint, file_size }
-                } = await userApi.rpc.storagehubclient.loadFileInStorage(
-                    source[i],
-                    destination[i],
-                    userApi.shConsts.NODE_INFOS.user.AddressId,
-                    bucketId
-                );
+      // Now for sure, the total number of accepted files should be `source.length`.
+      assert(acceptedFileKeys.length === source.length, `Expected ${source.length} file keys`);
 
-                txs.push(
-                    userApi.tx.fileSystem.issueStorageRequest(
-                        bucketId,
-                        location,
-                        fingerprint,
-                        file_size,
-                        userApi.shConsts.DUMMY_MSP_ID,
-                        [userApi.shConsts.NODE_INFOS.user.expectedPeerId],
-                        {
-                            Custom: 2
-                        })
-                );
-            }
-            await userApi.block.seal({ calls: txs, signer: shUser });
-        });
+      // And they should be in the Forest storage of the MSP, in the Forest corresponding
+      // to the bucket ID.
+      for (const fileKey of acceptedFileKeys) {
+        const isFileInForest = await mspApi.rpc.storagehubclient.isFileInForest(bucketId, fileKey);
+        assert(isFileInForest.isTrue, "File is not in forest");
+        allBucketFiles.push(fileKey);
+      }
 
-        it("MSP 1 receives files from user and accepts them", async () => {
-            // Get the events of the storage requests to extract the file keys and check
-            // that the MSP received them.
-            const events = await userApi.assert.eventMany("fileSystem", "NewStorageRequest");
-            const matchedEvents = events.filter((e: EventRecord) =>
-                userApi.events.fileSystem.NewStorageRequest.is(e.event)
-            );
-            if (matchedEvents.length !== source.length) {
-                throw new Error(`Expected ${source.length} NewStorageRequest events`);
-            }
+      // Seal 5 more blocks to pass maxthreshold and ensure completed upload requests
+      for (let i = 0; i < 5; i++) {
+        await sleep(500);
+        const block = await userApi.block.seal();
+        await userApi.rpc.engine.finalizeBlock(block.blockReceipt.blockHash);
+      }
+    });
 
-            // Allow time for the MSP to receive and store the files from the user
-            await sleep(3000);
+    it("New MSP rejects move request due to low capacity", async () => {
+      const valueProps = await userApi.call.storageProvidersApi.queryValuePropositionsForMsp(
+        mspThreeKey.publicKey
+      );
+      const valuePropId = valueProps[0].id;
 
-            // Check if the MSP received the files.
-            for (const e of matchedEvents) {
-                const newStorageRequestDataBlob =
-                    userApi.events.fileSystem.NewStorageRequest.is(e.event) && e.event.data;
+      // User requests to move bucket to second MSP
+      const requestMoveBucketResult = await userApi.block.seal({
+        calls: [
+          userApi.tx.fileSystem.requestMoveBucket(bucketId, mspThreeKey.publicKey, valuePropId)
+        ],
+        signer: shUser
+      });
 
-                if (!newStorageRequestDataBlob) {
-                    throw new Error("Event doesn't match NewStorageRequest type");
-                }
+      assertEventPresent(
+        userApi,
+        "fileSystem",
+        "MoveBucketRequested",
+        requestMoveBucketResult.events
+      );
 
-                const result = await mspApi.rpc.storagehubclient.isFileInFileStorage(
-                    newStorageRequestDataBlob.fileKey
-                );
+      // Finalising the block in the BSP node as well, to trigger the reorg in the BSP node too.
+      const finalisedBlockHash = await userApi.rpc.chain.getFinalizedHead();
 
-                if (!result.isFileFound) {
-                    throw new Error(
-                        `File not found in storage for ${newStorageRequestDataBlob.location.toHuman()}`
-                    );
-                }
+      // Wait for BSP node to have imported the finalised block built by the user node.
+      await msp3Api.wait.blockImported(finalisedBlockHash.toString());
+      await msp3Api.block.finaliseBlock(finalisedBlockHash.toString());
 
-                allBucketFiles.push(newStorageRequestDataBlob.fileKey.toString());
-            }
+      // Wait for the rejection response from Sleepy
+      await userApi.wait.waitForTxInPool({
+        module: "fileSystem",
+        method: "mspRespondMoveBucketRequest"
+      });
 
-            // Seal block containing the MSP's first response.
-            await userApi.wait.mspResponseInTxPool();
-            await userApi.block.seal();
+      const { events } = await userApi.block.seal();
 
-            // Give time for the MSP to update the local forest root.
-            await sleep(1000);
+      // Verify that the move request was rejected
+      assertEventPresent(userApi, "fileSystem", "MoveBucketRejected", events);
 
-            // Check that the local forest root is updated, and matches the on-chain root.
-            const localBucketRoot = await mspApi.rpc.storagehubclient.getForestRoot(bucketId);
-
-            const { event: bucketRootChangedEvent } = await userApi.assert.eventPresent(
-                "providers",
-                "BucketRootChanged"
-            );
-            const bucketRootChangedDataBlob =
-                userApi.events.providers.BucketRootChanged.is(bucketRootChangedEvent) &&
-                bucketRootChangedEvent.data;
-            if (!bucketRootChangedDataBlob) {
-                throw new Error("Expected BucketRootChanged event but received event of different type");
-            }
-
-            strictEqual(bucketRootChangedDataBlob.newRoot.toString(), localBucketRoot.toString());
-
-            // The MSP should have accepted exactly one file.
-            // Register how many were accepted in the last block sealed.
-            const acceptedFileKeys: string[] = [];
-            const mspAcceptedStorageRequestEvents = await userApi.assert.eventMany(
-                "fileSystem",
-                "MspAcceptedStorageRequest"
-            );
-            for (const e of mspAcceptedStorageRequestEvents) {
-                const mspAcceptedStorageRequestDataBlob =
-                    userApi.events.fileSystem.MspAcceptedStorageRequest.is(e.event) && e.event.data;
-                if (mspAcceptedStorageRequestDataBlob) {
-                    acceptedFileKeys.push(mspAcceptedStorageRequestDataBlob.fileKey.toString());
-                }
-            }
-            assert(
-                acceptedFileKeys.length === 1,
-                "Expected 1 file key accepted in first block after storage requests"
-            );
-
-            // An additional block needs to be sealed to accept the rest of the files.
-            // There should be a pending transaction to accept the rest of the files.
-            await userApi.wait.mspResponseInTxPool();
-            await userApi.block.seal();
-
-            // Give time for the MSP to update the local forest root.
-            await sleep(1000);
-
-            // Check that the local forest root is updated, and matches the on-chain root.
-            const localBucketRoot2 = await mspApi.rpc.storagehubclient.getForestRoot(bucketId);
-
-            const { event: bucketRootChangedEvent2 } = await userApi.assert.eventPresent(
-                "providers",
-                "BucketRootChanged"
-            );
-            const bucketRootChangedDataBlob2 =
-                userApi.events.providers.BucketRootChanged.is(bucketRootChangedEvent2) &&
-                bucketRootChangedEvent2.data;
-            if (!bucketRootChangedDataBlob2) {
-                throw new Error("Expected BucketRootChanged event but received event of different type");
-            }
-
-            strictEqual(bucketRootChangedDataBlob2.newRoot.toString(), localBucketRoot2.toString());
-
-            // The MSP should have accepted at least one file.
-            // Register how many were accepted in the last block sealed.
-            const mspAcceptedStorageRequestEvents2 = await userApi.assert.eventMany(
-                "fileSystem",
-                "MspAcceptedStorageRequest"
-            );
-            for (const e of mspAcceptedStorageRequestEvents2) {
-                const mspAcceptedStorageRequestDataBlob =
-                    userApi.events.fileSystem.MspAcceptedStorageRequest.is(e.event) && e.event.data;
-                if (mspAcceptedStorageRequestDataBlob) {
-                    acceptedFileKeys.push(mspAcceptedStorageRequestDataBlob.fileKey.toString());
-                }
-            }
-
-            // Now for sure, the total number of accepted files should be `source.length`.
-            assert(acceptedFileKeys.length === source.length, `Expected ${source.length} file keys`);
-
-            // And they should be in the Forest storage of the MSP, in the Forest corresponding
-            // to the bucket ID.
-            for (const fileKey of acceptedFileKeys) {
-                const isFileInForest = await mspApi.rpc.storagehubclient.isFileInForest(bucketId, fileKey);
-                assert(isFileInForest.isTrue, "File is not in forest");
-                allBucketFiles.push(fileKey);
-            }
-
-            // Seal 5 more blocks to pass maxthreshold and ensure completed upload requests
-            for (let i = 0; i < 5; i++) {
-                await sleep(500);
-                const block = await userApi.block.seal();
-                await userApi.rpc.engine.finalizeBlock(block.blockReceipt.blockHash);
-            }
-        });
-
-        it("New MSP rejects move request due to low capacity", async () => {
-            const valueProps = await userApi.call.storageProvidersApi.queryValuePropositionsForMsp(
-                mspThreeKey.publicKey
-            );
-            const valuePropId = valueProps[0].id;
-
-            // User requests to move bucket to second MSP
-            const requestMoveBucketResult = await userApi.block.seal({
-                calls: [userApi.tx.fileSystem.requestMoveBucket(bucketId, mspThreeKey.publicKey, valuePropId)],
-                signer: shUser
-            });
-
-            assertEventPresent(
-                userApi,
-                "fileSystem",
-                "MoveBucketRequested",
-                requestMoveBucketResult.events
-            );
-
-            // Finalising the block in the BSP node as well, to trigger the reorg in the BSP node too.
-            const finalisedBlockHash = await userApi.rpc.chain.getFinalizedHead();
-
-            // Wait for BSP node to have imported the finalised block built by the user node.
-            await msp3Api.wait.blockImported(finalisedBlockHash.toString());
-            await msp3Api.block.finaliseBlock(finalisedBlockHash.toString());
-
-            // Wait for the rejection response from Sleepy
-            await userApi.wait.waitForTxInPool({
-                module: "fileSystem",
-                method: "mspRespondMoveBucketRequest"
-            });
-
-            const { events } = await userApi.block.seal();
-
-            // Verify that the move request was rejected
-            assertEventPresent(userApi, "fileSystem", "MoveBucketRejected", events);
-
-            msp3Api.disconnect();
-        });
-    }
+      msp3Api.disconnect();
+    });
+  }
 );

--- a/test/suites/integration/user/send-file-to-provider.test.ts
+++ b/test/suites/integration/user/send-file-to-provider.test.ts
@@ -58,7 +58,7 @@ describeMspNet("User: Send file to provider", ({ before, createUserApi, it }) =>
     await userApi.assert.eventPresent("fileSystem", "NewStorageRequest");
 
     await userApi.docker.waitForLog({
-      searchString: "Failed to send file",
+      searchString: "Unable to upload final batch to peer",
       containerName: userApi.shConsts.NODE_INFOS.user.containerName
     });
   });

--- a/test/util/bspNet/docker.ts
+++ b/test/util/bspNet/docker.ts
@@ -72,8 +72,15 @@ const addContainer = async (
 
   assert(containerCount > 0, `No existing ${providerType.toUpperCase()} containers`);
 
+  const allContainersCount = (
+    await docker.listContainers({
+      filters: { ancestor: [DOCKER_IMAGE] }
+    })
+  )
+    .flatMap(({ Command }) => Command).length
+
   const p2pPort = 30350 + containerCount;
-  const rpcPort = 9888 + containerCount * 7;
+  const rpcPort = 9888 + allContainersCount * 7;
   const containerName = options?.name || `docker-sh-${providerType}-${containerCount + 1}`;
 
   // Get bootnode from docker args

--- a/test/util/bspNet/docker.ts
+++ b/test/util/bspNet/docker.ts
@@ -76,8 +76,7 @@ const addContainer = async (
     await docker.listContainers({
       filters: { ancestor: [DOCKER_IMAGE] }
     })
-  )
-    .flatMap(({ Command }) => Command).length
+  ).flatMap(({ Command }) => Command).length;
 
   const p2pPort = 30350 + containerCount;
   const rpcPort = 9888 + allContainersCount * 7;

--- a/test/util/netLaunch/index.ts
+++ b/test/util/netLaunch/index.ts
@@ -46,7 +46,7 @@ export class NetworkLauncher {
   constructor(
     private readonly type: NetworkType,
     private readonly config: NetLaunchConfig
-  ) {}
+  ) { }
 
   private loadComposeFile() {
     assert(this.type, "Network type has not been set yet");

--- a/test/util/netLaunch/index.ts
+++ b/test/util/netLaunch/index.ts
@@ -46,7 +46,7 @@ export class NetworkLauncher {
   constructor(
     private readonly type: NetworkType,
     private readonly config: NetLaunchConfig
-  ) { }
+  ) {}
 
   private loadComposeFile() {
     assert(this.type, "Network type has not been set yet");


### PR DESCRIPTION
This PR is a replacement for https://github.com/Moonsong-Labs/storage-hub/pull/328

> In order to test proper rejection of move bucket request on low capacity, a refactor and addition of onboardMsp (similar to onboardBsp) was needed.