### PR TITLE
ci: remove unnecessary action for rustfmt

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,11 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1.8
-        with:
-          components: rustfmt
       - name: Rustfmt Check
-        uses: actions-rust-lang/rustfmt@v1
+        uses: cargo fmt --all -- --check
 
   check-rust-lint:
     name: "Check lint with clippy"


### PR DESCRIPTION
In this PR we remove `actions-rust-lang/setup-rust-toolchain@v1.8` and `actions-rust-lang/rustfmt@v1` as rustfmt is already installed on ubuntu runner.
