### PR TITLE
lint: fix clippy warnings

### DIFF
--- a/client/blockchain-service/src/utils.rs
+++ b/client/blockchain-service/src/utils.rs
@@ -1146,10 +1146,8 @@ where
         }
     }
 
-    pub(crate) fn process_common_finality_events(&self, event: RuntimeEvent) {
-        match event {
-            _ => {}
-        }
+    pub(crate) fn process_common_finality_events(&self, _event: RuntimeEvent) {
+        {}
     }
 
     pub(crate) fn process_test_user_events(&self, event: RuntimeEvent) {

--- a/client/src/file_download_manager.rs
+++ b/client/src/file_download_manager.rs
@@ -549,7 +549,6 @@ impl FileDownloadManager {
             .map(|chunk_ids| {
                 let semaphore = Arc::clone(&chunk_semaphore);
                 let file_metadata = file_metadata.clone();
-                let bucket = bucket.clone();
                 let file_transfer = file_transfer.clone();
                 let file_storage = Arc::clone(&file_storage);
                 let manager = manager.clone();
@@ -716,9 +715,7 @@ impl FileDownloadManager {
         // Mark bucket as downloading
         {
             let mut locks = self.bucket_locks.write().await;
-            let lock_info = locks
-                .entry(bucket_id)
-                .or_insert_with(BucketLockInfo::new);
+            let lock_info = locks.entry(bucket_id).or_insert_with(BucketLockInfo::new);
 
             // Check again in case it became downloading while we were waiting
             if lock_info.is_downloading {
@@ -804,21 +801,24 @@ impl FileDownloadManager {
         // Always mark the bucket inactive at the end
         self.mark_bucket_inactive(&bucket_id).await;
 
-        // If download was successful, mark it as completed
-        if download_result.is_ok() {
-            // Update persistent state
-            let context = self.download_state_store.open_rw_context();
-            context.mark_bucket_download_completed(&bucket_id);
-            context.commit();
+        // Handle download result
+        match download_result {
+            Ok(()) => {
+                // Update persistent state
+                let context = self.download_state_store.open_rw_context();
+                context.mark_bucket_download_completed(&bucket_id);
+                context.commit();
 
-            info!(
-                target: LOG_TARGET,
-                "Completed download of bucket {:?}", bucket_id
-            );
-            Ok(())
-        } else {
-            // Propagate the error
-            Err(download_result.unwrap_err().into())
+                info!(
+                    target: LOG_TARGET,
+                    "Completed download of bucket {:?}", bucket_id
+                );
+                Ok(())
+            }
+            Err(error) => {
+                // Propagate the error
+                Err(error.into())
+            }
         }
     }
 }

--- a/client/src/file_download_manager.rs
+++ b/client/src/file_download_manager.rs
@@ -552,7 +552,6 @@ impl FileDownloadManager {
                 let bucket = bucket.clone();
                 let file_transfer = file_transfer.clone();
                 let file_storage = Arc::clone(&file_storage);
-                let file_key = file_key;
                 let manager = manager.clone();
                 let chunk_batch: HashSet<ChunkId> = chunk_ids.iter().copied().collect();
 
@@ -718,7 +717,7 @@ impl FileDownloadManager {
         {
             let mut locks = self.bucket_locks.write().await;
             let lock_info = locks
-                .entry(bucket_id.clone())
+                .entry(bucket_id)
                 .or_insert_with(BucketLockInfo::new);
 
             // Check again in case it became downloading while we were waiting
@@ -766,7 +765,6 @@ impl FileDownloadManager {
                 .map(|file_metadata| {
                     let file_transfer = file_transfer.clone();
                     let file_storage = Arc::clone(&file_storage);
-                    let bucket_id = bucket_id.clone();
                     let manager = self.clone();
 
                     // Spawn a task for each file download

--- a/pallets/file-system/src/utils.rs
+++ b/pallets/file-system/src/utils.rs
@@ -72,6 +72,7 @@ macro_rules! expect_or_err {
     }};
     // Handle boolean type
     ($condition:expr, $error_msg:expr, $error_type:path, bool) => {{
+        #[allow(clippy::neg_cmp_op_on_partial_ord)]
         if !$condition {
             #[cfg(test)]
             unreachable!($error_msg);

--- a/pallets/file-system/src/utils.rs
+++ b/pallets/file-system/src/utils.rs
@@ -2855,7 +2855,6 @@ where
                     false
                 }
             })
-            .map(|(file_key, metadata)| (file_key, metadata))
             .collect()
     }
 }


### PR DESCRIPTION
 This PR addresses various clippy warnings through the codebase making `cargo clippy` run without warnings