### PR TITLE
feat: Add fisherman integration tests

### DIFF
--- a/client/fisherman-service/src/lib.rs
+++ b/client/fisherman-service/src/lib.rs
@@ -15,6 +15,7 @@ pub mod handler;
 
 use std::sync::Arc;
 
+use log::info;
 use shc_actors_framework::actor::{ActorHandle, ActorSpawner, TaskSpawner};
 use shc_common::traits::{StorageEnableApiCollection, StorageEnableRuntimeApi};
 use shc_common::types::ParachainClient;
@@ -46,5 +47,8 @@ where
     let fisherman_service = FishermanService::new(client);
 
     // Spawn the actor and return the handle
-    task_spawner.spawn_actor(fisherman_service)
+    let actor = task_spawner.spawn_actor(fisherman_service);
+
+    info!("🎣 Fisherman service started successfully");
+    actor
 }

--- a/test/package.json
+++ b/test/package.json
@@ -46,6 +46,8 @@
 		"test:bspnet:only": "NODE_OPTIONS='--no-deprecation' pnpm tsx scripts/checkRunning.ts && node --no-deprecation --import tsx --test-concurrency 1 --test --test-only ./suites/integration/bsp/**.test.ts",
 		"test:user": "NODE_OPTIONS='--no-deprecation' pnpm tsx scripts/checkRunning.ts && node --no-deprecation --test-concurrency 1 --import tsx --test ./suites/integration/user/**.test.ts",
 		"test:user:only": "NODE_OPTIONS='--no-deprecation' pnpm tsx scripts/checkRunning.ts && node --no-deprecation --test-concurrency 1 --import tsx --test --test-only ./suites/integration/user/**.test.ts",
+		"test:fisherman": "NODE_OPTIONS='--no-deprecation' pnpm tsx scripts/checkRunning.ts && node --no-deprecation --test-concurrency 1 --import tsx --test ./suites/integration/fisherman/**.test.ts",
+		"test:fisherman:only": "NODE_OPTIONS='--no-deprecation' pnpm tsx scripts/checkRunning.ts && node --no-deprecation --test-concurrency 1 --import tsx --test --test-only ./suites/integration/fisherman/**.test.ts",
 		"test:node": "node --no-deprecation --import tsx --test ./suites/solo-node/**/**.test.ts",
 		"test:node:only": "node --no-deprecation --import tsx --test --test-only ./suites/solo-node/**/**.test.ts",
 		"test:node:single": "node --no-deprecation --import tsx --test --test-name-pattern=$FILTER ./suites/solo-node/**/**.test.ts"

--- a/test/suites/integration/fisherman/fisherman-default-mode.test.ts
+++ b/test/suites/integration/fisherman/fisherman-default-mode.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert";
+import {
+  describeMspNet,
+  type EnrichedBspApi,
+  type SqlClient,
+  ShConsts,
+  sleep
+} from "../../../util";
+
+describeMspNet(
+  "Fisherman Default Indexer Mode",
+  {
+    initialised: false,
+    indexer: true,
+    fisherman: true,
+    fishermanIndexerMode: "fishing"
+  },
+  ({ before, it, createFishermanApi, createSqlClient, createUserApi }) => {
+    let fishermanApi: EnrichedBspApi;
+    let userApi: EnrichedBspApi;
+    let sql: SqlClient;
+
+    before(async () => {
+      userApi = await createUserApi();
+
+      assert(createFishermanApi, "Fisherman API should be available when fisherman is enabled");
+
+      // Wait for fisherman node to be ready before trying to connect
+      await userApi.docker.waitForLog({
+        containerName: ShConsts.NODE_INFOS.fisherman.containerName,
+        searchString: "💤 Idle",
+        timeout: 30000
+      });
+
+      fishermanApi = await createFishermanApi() as EnrichedBspApi;
+      assert(fishermanApi, "Fisherman API should be created successfully");
+      sql = createSqlClient();
+
+      // Initialize blockchain state using direct RPC call for first block
+      await userApi.rpc.engine.createBlock(true, true);
+
+      // Small delay to ensure nodes are synced
+      await sleep(1000);
+
+      // Seal additional blocks to ensure stable state
+      await userApi.block.seal();
+      await userApi.block.seal();
+    });
+
+    it("fisherman node automatically enables indexer in fishing mode", async () => {
+      // Check logs to verify fishing mode is active on the fisherman node
+      await fishermanApi.docker.waitForLog({
+        containerName: ShConsts.NODE_INFOS.fisherman.containerName,
+        searchString: "IndexerService starting up in Fishing mode!",
+        timeout: 10000
+      });
+    });
+
+    it("fisherman node connects to postgres database", async () => {
+      // Wait for fisherman indexer to start
+      await fishermanApi.docker.waitForLog({
+        containerName: ShConsts.NODE_INFOS.fisherman.containerName,
+        searchString: "IndexerService starting up",
+        timeout: 10000
+      });
+
+      // Verify database connection by checking service_state table
+      const serviceState = await sql`SELECT * FROM service_state WHERE id = 1`;
+      assert(serviceState.length > 0, "Service state should be initialized in database");
+    });
+
+    it("fisherman node syncs with network", async () => {
+      // Verify fisherman node is syncing blocks
+      await fishermanApi.docker.waitForLog({
+        containerName: ShConsts.NODE_INFOS.fisherman.containerName,
+        searchString: "💤 Idle",
+        timeout: 30000
+      });
+
+      // Verify fisherman node is at a reasonable block height
+      const header = await fishermanApi.rpc.chain.getHeader();
+      assert(header.number.toNumber() > 0, "Fisherman node should be syncing blocks");
+
+      // Create some activity for the indexer to process
+      await userApi.block.seal();
+      await userApi.block.seal();
+
+      // Verify indexer is processing blocks
+      const serviceState = await sql`SELECT last_processed_block FROM service_state WHERE id = 1`;
+      assert(serviceState[0]?.last_processed_block >= 0, "Indexer should be processing blocks");
+    });
+  }
+);

--- a/test/suites/integration/msp/indexer-modes-comparison.test.ts
+++ b/test/suites/integration/msp/indexer-modes-comparison.test.ts
@@ -1,0 +1,232 @@
+import assert from "node:assert";
+import { describeMspNet, type EnrichedBspApi, type SqlClient, bspKey } from "../../../util";
+
+describeMspNet("Indexer Modes Comparison", { initialised: false, skip: true }, () => {
+  // Test Full Mode
+  describeMspNet(
+    "Full Indexer Mode",
+    { initialised: false, indexer: true, userIndexerMode: "full" },
+    ({ before, it, createUserApi, createBspApi, createSqlClient }) => {
+      let userApi: EnrichedBspApi;
+      let bspApi: EnrichedBspApi;
+      let sql: SqlClient;
+
+      before(async () => {
+        userApi = await createUserApi();
+        bspApi = await createBspApi();
+        sql = createSqlClient();
+
+        // Initialize blockchain state to prevent Aura consensus errors
+        await userApi.block.seal();
+        await userApi.block.seal();
+        await userApi.block.seal();
+      });
+
+      it("indexes all event types in full mode", async () => {
+        const bucketName = "test-full-mode";
+
+        // Create various events
+        await userApi.file.newBucket(bucketName);
+
+        // Trigger capacity change (should be indexed in full mode)
+        await bspApi.block.seal({
+          calls: [bspApi.tx.providers.changeCapacity(2000000)],
+          signer: bspKey
+        });
+
+        // Create payment stream (should be indexed in full mode)
+        await userApi.block.seal({
+          calls: [
+            userApi.tx.paymentStreams.createFixedRatePaymentStream(
+              bspApi.shConsts.DUMMY_BSP_ID,
+              bspKey.address,
+              100
+            )
+          ]
+        });
+
+        await userApi.block.seal();
+        await userApi.block.seal();
+        await userApi.block.seal();
+
+        // Verify all events are indexed
+        const buckets = await sql`SELECT * FROM bucket WHERE name = ${bucketName}`;
+        assert.equal(buckets.length, 1, "Bucket should be indexed");
+
+        const bsp = await sql`SELECT capacity FROM bsp WHERE id = ${bspApi.shConsts.DUMMY_BSP_ID}`;
+        assert.equal(bsp[0].capacity, 2000000, "Capacity change should be indexed in full mode");
+
+        const streams = await sql`SELECT COUNT(*) FROM paymentstream`;
+        assert(streams[0].count > 0, "Payment streams should be indexed in full mode");
+      });
+    }
+  );
+
+  // Test Lite Mode
+  describeMspNet(
+    "Lite Indexer Mode",
+    { initialised: false, indexer: true, userIndexerMode: "lite" },
+    ({ before, it, createUserApi, createBspApi, createSqlClient }) => {
+      let userApi: EnrichedBspApi;
+      let bspApi: EnrichedBspApi;
+      let sql: SqlClient;
+
+      before(async () => {
+        userApi = await createUserApi();
+        bspApi = await createBspApi();
+        sql = createSqlClient();
+
+        // Initialize blockchain state to prevent Aura consensus errors
+        await userApi.block.seal();
+        await userApi.block.seal();
+        await userApi.block.seal();
+      });
+
+      it("indexes MSP-specific events in lite mode", async () => {
+        const bucketName = "test-lite-mode";
+        const mspId = userApi.shConsts.DUMMY_MSP_ID;
+
+        // Get value proposition for MSP
+        const valueProps =
+          await userApi.call.storageProvidersApi.queryValuePropositionsForMsp(mspId);
+        const valuePropId = valueProps[0].id;
+
+        // Create MSP bucket
+        await userApi.block.seal({
+          calls: [userApi.tx.fileSystem.createBucket(mspId, bucketName, true, valuePropId)]
+        });
+
+        // Create storage request (MSP should accept it)
+        const bucketEvent = await userApi.assert.eventPresent("fileSystem", "NewBucket");
+        const bucketId = (bucketEvent.data as any).bucketId;
+        const fileMetadata = await userApi.file.newStorageRequest(
+          "/res/smile.jpg",
+          "test/lite-file.txt",
+          bucketId
+        );
+
+        // Trigger non-MSP event (should NOT be indexed in lite mode)
+        await bspApi.block.seal({
+          calls: [bspApi.tx.providers.changeCapacity(3000000)],
+          signer: bspKey
+        });
+
+        await userApi.block.seal();
+        await userApi.block.seal();
+        await userApi.block.seal();
+
+        // Verify MSP events are indexed
+        const mspFiles = await sql`
+            SELECT * FROM msp_file 
+            WHERE file_id = (
+              SELECT id FROM file WHERE file_key = ${fileMetadata.fileKey}
+            )
+          `;
+        assert(mspFiles.length > 0, "MSP file associations should be indexed in lite mode");
+
+        // Verify non-MSP events are NOT indexed
+        const bsp = await sql`SELECT capacity FROM bsp WHERE id = ${bspApi.shConsts.DUMMY_BSP_ID}`;
+        assert.notEqual(
+          bsp[0].capacity,
+          3000000,
+          "BSP capacity changes should NOT be indexed in lite mode"
+        );
+      });
+    }
+  );
+
+  // Test Fishing Mode
+  describeMspNet(
+    "Fishing Indexer Mode",
+    { initialised: false, indexer: true, userIndexerMode: "fishing" },
+    ({ before, it, createUserApi, createBspApi, createSqlClient }) => {
+      let userApi: EnrichedBspApi;
+      let bspApi: EnrichedBspApi;
+      let sql: SqlClient;
+
+      before(async () => {
+        userApi = await createUserApi();
+        bspApi = await createBspApi();
+        sql = createSqlClient();
+
+        // Initialize blockchain state to prevent Aura consensus errors
+        await userApi.block.seal();
+        await userApi.block.seal();
+        await userApi.block.seal();
+      });
+
+      it("indexes only file-related events in fishing mode", async () => {
+        const bucketName = "test-fishing-mode";
+
+        // Create file events
+        const newBucketEvent = await userApi.file.newBucket(bucketName);
+        const newBucketEventData =
+          userApi.events.fileSystem.NewBucket.is(newBucketEvent) && newBucketEvent.data;
+
+        if (!newBucketEventData) {
+          throw new Error("NewBucket event data not found");
+        }
+
+        const bucketId = newBucketEventData.bucketId;
+        const fileMetadata = await userApi.file.newStorageRequest(
+          "/res/smile.jpg",
+          "test/fishing-file.txt",
+          bucketId
+        );
+
+        // BSP volunteers (should be indexed)
+        await userApi.block.seal({
+          calls: [bspApi.tx.fileSystem.bspVolunteer(fileMetadata.fileKey)],
+          signer: bspKey
+        });
+
+        // Skip blocks until the BSP can change its capacity
+        await userApi.block.skipUntilBspCanChangeCapacity(userApi.shConsts.DUMMY_BSP_ID);
+
+        // Wait for BSP to be available to send transactions
+        await userApi.wait.waitForAvailabilityToSendTx(bspKey.address.toString());
+
+        // Trigger non-file events (should NOT be indexed)
+        await userApi.block.seal({
+          calls: [bspApi.tx.providers.changeCapacity(4000000)],
+          signer: bspKey
+        });
+
+        await userApi.block.seal({
+          calls: [
+            userApi.tx.paymentStreams.createFixedRatePaymentStream(
+              bspApi.shConsts.DUMMY_BSP_ID,
+              bspKey.address,
+              200
+            )
+          ]
+        });
+
+        await userApi.block.seal();
+        await userApi.block.seal();
+        await userApi.block.seal();
+
+        // Verify file events are indexed
+        const files = await sql`SELECT * FROM file WHERE file_key = ${fileMetadata.fileKey}`;
+        assert.equal(files.length, 1, "Files should be indexed in fishing mode");
+
+        const bspFiles = await sql`
+            SELECT * FROM bsp_file 
+            WHERE file_id = ${files[0].id}
+          `;
+        assert(bspFiles.length > 0, "BSP file associations should be indexed in fishing mode");
+
+        // Verify non-file events are NOT indexed
+        const bsp = await sql`SELECT capacity FROM bsp WHERE id = ${bspApi.shConsts.DUMMY_BSP_ID}`;
+        assert.notEqual(
+          bsp[0].capacity,
+          4000000,
+          "Capacity changes should NOT be indexed in fishing mode"
+        );
+
+        const streams = await sql`SELECT COUNT(*) FROM paymentstream`;
+        assert.equal(streams[0].count, 0, "Payment streams should NOT be indexed in fishing mode");
+      });
+    }
+  );
+});

--- a/test/util/bspNet/consts.ts
+++ b/test/util/bspNet/consts.ts
@@ -41,6 +41,12 @@ export const NODE_INFOS = {
     p2pPort: 30666,
     nodeKey: '0x23b3b1c917dda506f152816aad4685eefa54fe57792165b31141ac893610b315',
   },
+  fisherman: {
+    containerName: "docker-sh-fisherman-1",
+    port: 9999,
+    p2pPort: 30666,
+    nodeKey: "0x23b3b1c917dda506f152816aad4685eefa54fe57792165b31141ac893610b315"
+  },
   toxiproxy: {
     containerName: 'toxiproxy',
     port: 8474,

--- a/test/util/bspNet/fileHelpers.ts
+++ b/test/util/bspNet/fileHelpers.ts
@@ -79,19 +79,7 @@ export const createBucketAndSendNewStorageRequest = async (
   owner?: KeyringPair | null,
   replicationTarget?: number | null
 ): Promise<FileMetadata> => {
-  let localValuePropId = valuePropId;
   let localOwner = owner;
-
-  if (!localValuePropId) {
-    const valueProps = await api.call.storageProvidersApi.queryValuePropositionsForMsp(
-      mspId ?? ShConsts.DUMMY_MSP_ID
-    );
-    localValuePropId = valueProps[0].id;
-
-    if (!localValuePropId) {
-      throw new Error("No value proposition found");
-    }
-  }
 
   if (!localOwner) {
     localOwner = shUser;
@@ -100,7 +88,7 @@ export const createBucketAndSendNewStorageRequest = async (
   const newBucketEventEvent = await createBucket(
     api,
     bucketName,
-    localValuePropId,
+    valuePropId,
     mspId ?? ShConsts.DUMMY_MSP_ID,
     localOwner
   );

--- a/test/util/bspNet/helpers.ts
+++ b/test/util/bspNet/helpers.ts
@@ -97,9 +97,11 @@ export const cleardownTest = async (cleardownOptions: {
   try {
     if (Array.isArray(cleardownOptions.api)) {
       for (const api of cleardownOptions.api) {
-        await api.disconnect();
+        if (api) {
+          await api.disconnect();
+        }
       }
-    } else {
+    } else if (cleardownOptions.api) {
       await cleardownOptions.api.disconnect();
     }
   } catch (e) {

--- a/test/util/bspNet/types.ts
+++ b/test/util/bspNet/types.ts
@@ -154,11 +154,25 @@ export type BspNetConfig = {
   indexer?: boolean;
 
   /**
-   * Optional parameter to set the indexer mode when indexer is enabled.
+   * Optional parameter to set the indexer mode for the user node when indexer is enabled.
    * 'full' - indexes all events (default)
    * 'lite' - indexes only essential events as defined in LITE_MODE_EVENTS.md
+   * 'fishing' - indexes only events relevant to fisherman monitoring (file tracking)
    */
-  indexerMode?: "full" | "lite";
+  userIndexerMode?: "full" | "lite" | "fishing";
+
+  /**
+   * If true, runs a dedicated fisherman node with indexer service.
+   */
+  fisherman?: boolean;
+
+  /**
+   * Optional parameter to set the indexer mode for the fisherman node when fisherman is enabled.
+   * 'full' - indexes all events (default)
+   * 'lite' - indexes only essential events
+   * 'fishing' - indexes only events relevant to fisherman monitoring (file tracking)
+   */
+  fishermanIndexerMode?: "full" | "lite" | "fishing";
 };
 
 /**
@@ -250,6 +264,12 @@ export type FullNetContext = {
    * @returns A promise that resolves to an enriched api instance for MSP operations.
    */
   createMsp2Api: () => ReturnType<typeof BspNetTestApi.create> | undefined;
+
+  /**
+   * Creates and returns a connected API instance for the fisherman node (if enabled).
+   * @returns A promise that resolves to an enriched api instance for fisherman operations, or undefined if not enabled.
+   */
+  createFishermanApi?: () => ReturnType<typeof BspNetTestApi.create> | undefined;
 
   /**
    * Creates and returns a connected API instance for a BSP node.
@@ -345,11 +365,25 @@ export type TestOptions = {
   /** If true, runs launched userNode has attached indexer service enabled. */
   indexer?: boolean;
   /**
-   * Optional parameter to set the indexer mode when indexer is enabled.
+   * Optional parameter to set the indexer mode for the user node when indexer is enabled.
    * 'full' - indexes all events (default)
    * 'lite' - indexes only essential events as defined in LITE_MODE_EVENTS.md
+   * 'fishing' - indexes only events relevant to fisherman monitoring (file tracking)
    */
-  indexerMode?: "full" | "lite";
+  userIndexerMode?: "full" | "lite" | "fishing";
+
+  /**
+   * If true, runs a dedicated fisherman node with indexer service.
+   */
+  fisherman?: boolean;
+
+  /**
+   * Optional parameter to set the indexer mode for the fisherman node when fisherman is enabled.
+   * 'full' - indexes all events (default)
+   * 'lite' - indexes only essential events
+   * 'fishing' - indexes only events relevant to fisherman monitoring (file tracking)
+   */
+  fishermanIndexerMode?: "full" | "lite" | "fishing";
 };
 
 /**


### PR DESCRIPTION
### TL;DR

Added a dedicated fisherman node with specialized indexer mode for monitoring the network.

### What changed?

- Added a new `sh-fisherman` service to the Docker compose template with appropriate configuration
- Added test suites to verify fisherman functionality:
  - `fisherman-default-mode.test.ts` - Tests basic fisherman node setup and indexer operation
  - `indexer-fishing.test.ts` - Comprehensive tests for the fishing mode functionality
  - `indexer-modes-comparison.test.ts` - Compares behavior across different indexer modes
- Extended the test utilities to support fisherman node configuration and API access
- Added new npm scripts for running fisherman-specific tests
