### PR TITLE
fix: 🐛 correctly implement config parsing + integration test fixes

### DIFF
--- a/bsp_config.toml
+++ b/bsp_config.toml
@@ -46,9 +46,9 @@ max_submission_attempts = 5
 extrinsic_retry_timeout = 10
 
 # RPC configuration
-[provider.rpc]
+[provider.rpc_config]
 # Remote file configuration
-[provider.rpc.remote_file]
+[provider.rpc_config.remote_file]
 # Maximum file size in bytes (default: 10GB)
 max_file_size = 10737418240
 # Connection timeout in seconds (default: 30)
@@ -61,13 +61,13 @@ follow_redirects = true
 max_redirects = 10
 # User agent string (default: "StorageHub-Client/1.0")
 user_agent = "StorageHub-Client/1.0"
-# Chunk size in bytes (default: 8192)
+# Chunk size in bytes. This is different from the FILE_CHUNK_SIZE constant in the runtime, as it only affects file upload/download. (default: 8KB)
 chunk_size = 8192
-# Number of FILE_CHUNK_SIZE chunks to buffer (default: 512)
+# Number of chunks to buffer (default: 512)
 chunks_buffer = 512
 
 # Optional indexer configuration
 [indexer]
 # Set to true to enable the indexer
 indexer = true
-database_url = "postgresql://postgres:postgres@docker-sh-postgres-1:5432/storage_hub"
+database_url = "postgresql://postgres:postgres@storage-hub-sh-postgres-1:5432/storage_hub"

--- a/client/rpc/src/remote_file/http.rs
+++ b/client/rpc/src/remote_file/http.rs
@@ -219,8 +219,7 @@ impl RemoteFileHandler for HttpFileHandler {
                 );
 
                 // Wrap the reader in a buffered reader with buffer size based on chunks_buffer
-                let buffer_size =
-                    self.config.chunks_buffer.max(1) * shc_common::types::FILE_CHUNK_SIZE as usize;
+                let buffer_size = self.config.chunks_buffer.max(1) * self.config.chunk_size;
                 let buffered_reader = tokio::io::BufReader::with_capacity(buffer_size, reader);
 
                 Ok(Box::new(buffered_reader) as Box<dyn AsyncRead + Send + Unpin>)

--- a/client/rpc/src/remote_file/local.rs
+++ b/client/rpc/src/remote_file/local.rs
@@ -267,8 +267,7 @@ impl RemoteFileHandler for LocalFileHandler {
         let file = File::open(&self.absolute_file_path).await?;
 
         // Wrap file in a buffered reader with buffer size based on chunks_buffer
-        let buffer_size =
-            self.config.chunks_buffer.max(1) * shc_common::types::FILE_CHUNK_SIZE as usize;
+        let buffer_size = self.config.chunks_buffer.max(1) * self.config.chunk_size;
         let buffered_reader = tokio::io::BufReader::with_capacity(buffer_size, file);
         Ok(Box::new(buffered_reader))
     }

--- a/client/rpc/src/remote_file/mod.rs
+++ b/client/rpc/src/remote_file/mod.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::io::AsyncRead;
 use url::Url;
@@ -58,16 +59,17 @@ pub trait RemoteFileHandler: Send + Sync {
     ) -> Result<(), RemoteFileError>;
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RemoteFileConfig {
     pub max_file_size: u64,
     pub connection_timeout: u64,
     pub read_timeout: u64,
     pub follow_redirects: bool,
-    pub max_redirects: u32,
+    pub max_redirects: u64,
     pub user_agent: String,
+    /// Chunk size in bytes. This is different from the FILE_CHUNK_SIZE constant in the runtime, as it only affects file upload/download. (default: 8KB)
     pub chunk_size: usize,
-    /// Number of FILE_CHUNK_SIZE chunks to buffer (minimum 1, default 512)
+    /// Number of chunks to buffer (minimum 1, default 512)
     pub chunks_buffer: usize,
 }
 
@@ -85,7 +87,7 @@ impl RemoteFileConfig {
             max_redirects: 10,
             user_agent: "StorageHub-Client/1.0".to_string(),
             chunk_size: 8192,   // 8KB default
-            chunks_buffer: 512, // 512 FILE_CHUNK_SIZE chunks default (512KB)
+            chunks_buffer: 512, // 512 chunks default (4MB)
         }
     }
 }

--- a/client/src/builder.rs
+++ b/client/src/builder.rs
@@ -20,7 +20,7 @@ use shc_common::{
 use shc_file_manager::{in_memory::InMemoryFileStorage, rocksdb::RocksDbFileStorage};
 use shc_file_transfer_service::{spawn_file_transfer_service, FileTransferService};
 use shc_forest_manager::traits::ForestStorageHandler;
-use shc_rpc::{remote_file::RemoteFileConfig, StorageHubClientRpcConfig};
+use shc_rpc::{RpcConfig, StorageHubClientRpcConfig};
 
 use crate::tasks::{
     bsp_charge_fees::BspChargeFeesConfig, bsp_move_bucket::BspMoveBucketConfig,
@@ -226,7 +226,7 @@ where
     pub fn create_rpc_config(
         &self,
         keystore: KeystorePtr,
-        remote_file_config: RemoteFileConfig,
+        config: RpcConfig,
     ) -> StorageHubClientRpcConfig<<(R, S) as ShNodeType>::FL, <(R, S) as ShNodeType>::FSH> {
         StorageHubClientRpcConfig::new(
             self.file_storage
@@ -236,7 +236,7 @@ where
                 .clone()
                 .expect("Forest Storage Handler not initialized. Use `setup_storage_layer` before calling `create_rpc_config`."),
             keystore,
-            remote_file_config,
+            config,
         )
     }
 
@@ -709,71 +709,4 @@ pub struct IndexerOptions {
     pub indexer: bool,
     /// Postgres database URL.
     pub database_url: Option<String>,
-}
-
-/// Remote file configuration options.
-#[derive(Clone, Debug, serde::Serialize, Deserialize)]
-pub struct RemoteFileOptions {
-    /// Maximum file size in bytes (default: 10GB)
-    pub max_file_size: u64,
-    /// Connection timeout in seconds (default: 30)
-    pub connection_timeout: u64,
-    /// Read timeout in seconds (default: 300)
-    pub read_timeout: u64,
-    /// Whether to follow redirects (default: true)
-    pub follow_redirects: bool,
-    /// Maximum number of redirects (default: 10)
-    pub max_redirects: u32,
-    /// User agent string (default: "StorageHub-Client/1.0")
-    pub user_agent: String,
-    /// Chunk size in bytes (default: 8192)
-    pub chunk_size: usize,
-    /// Number of FILE_CHUNK_SIZE chunks to buffer (default: 512)
-    pub chunks_buffer: usize,
-}
-
-impl Default for RemoteFileOptions {
-    fn default() -> Self {
-        let config = shc_rpc::remote_file::RemoteFileConfig::default();
-        Self {
-            max_file_size: config.max_file_size,
-            connection_timeout: config.connection_timeout,
-            read_timeout: config.read_timeout,
-            follow_redirects: config.follow_redirects,
-            max_redirects: config.max_redirects,
-            user_agent: config.user_agent,
-            chunk_size: config.chunk_size,
-            chunks_buffer: config.chunks_buffer,
-        }
-    }
-}
-
-impl From<RemoteFileOptions> for shc_rpc::remote_file::RemoteFileConfig {
-    fn from(options: RemoteFileOptions) -> Self {
-        Self {
-            max_file_size: options.max_file_size,
-            connection_timeout: options.connection_timeout,
-            read_timeout: options.read_timeout,
-            follow_redirects: options.follow_redirects,
-            max_redirects: options.max_redirects,
-            user_agent: options.user_agent,
-            chunk_size: options.chunk_size,
-            chunks_buffer: options.chunks_buffer,
-        }
-    }
-}
-
-/// RPC configuration options.
-#[derive(Clone, Debug, serde::Serialize, Deserialize)]
-pub struct RpcOptions {
-    /// Remote file configuration options
-    pub remote_file: RemoteFileOptions,
-}
-
-impl Default for RpcOptions {
-    fn default() -> Self {
-        Self {
-            remote_file: RemoteFileOptions::default(),
-        }
-    }
 }

--- a/docker/bspnet-base-template.yml
+++ b/docker/bspnet-base-template.yml
@@ -1,7 +1,7 @@
 services:
   sh-bsp:
     image: storage-hub:local
-    container_name: docker-sh-bsp-1
+    container_name: storage-hub-sh-bsp-1
     platform: linux/amd64
     ports:
       - "9666:9944"
@@ -29,7 +29,7 @@ services:
   sh-user:
     image: storage-hub:local
     platform: linux/amd64
-    container_name: docker-sh-user-1
+    container_name: storage-hub-sh-user-1
     ports:
       - "9888:9944"
       - "30444:30444"

--- a/docker/dev-keystores/msp-three/61757261c0647914b37034d861ddc3f0750ded6defec0823de5c782f3ca7c64ba29a4a2e
+++ b/docker/dev-keystores/msp-three/61757261c0647914b37034d861ddc3f0750ded6defec0823de5c782f3ca7c64ba29a4a2e
@@ -1,0 +1,1 @@
+//Sh-MSP-Three

--- a/docker/dev-keystores/msp-three/62637376c0647914b37034d861ddc3f0750ded6defec0823de5c782f3ca7c64ba29a4a2e
+++ b/docker/dev-keystores/msp-three/62637376c0647914b37034d861ddc3f0750ded6defec0823de5c782f3ca7c64ba29a4a2e
@@ -1,0 +1,1 @@
+"//Sh-MSP-Three"

--- a/docker/fullnet-base-template.yml
+++ b/docker/fullnet-base-template.yml
@@ -1,7 +1,7 @@
 services:
   sh-bsp:
     image: storage-hub:local
-    container_name: docker-sh-bsp-1
+    container_name: storage-hub-sh-bsp-1
     platform: linux/amd64
     ports:
       - "9666:9944"
@@ -28,7 +28,7 @@ services:
       ]
   sh-msp-1:
     image: storage-hub:local
-    container_name: docker-sh-msp-1
+    container_name: storage-hub-sh-msp-1
     platform: linux/amd64
     ports:
       - "9777:9944"
@@ -57,7 +57,7 @@ services:
       ]
   sh-msp-2:
     image: storage-hub:local
-    container_name: docker-sh-msp-2
+    container_name: storage-hub-sh-msp-2
     platform: linux/amd64
     ports:
       - "9778:9944"
@@ -87,7 +87,7 @@ services:
   sh-user:
     image: storage-hub:local
     platform: linux/amd64
-    container_name: docker-sh-user-1
+    container_name: storage-hub-sh-user-1
     ports:
       - "9888:9944"
       - "30444:30444"
@@ -114,7 +114,7 @@ services:
 
   sh-postgres:
     image: postgres:15
-    container_name: docker-sh-postgres-1
+    container_name: storage-hub-sh-postgres-1
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres

--- a/msp_config.toml
+++ b/msp_config.toml
@@ -37,9 +37,9 @@ max_tip = 100.0
 extrinsic_retry_timeout = 60
 
 # RPC configuration
-[provider.rpc]
+[provider.rpc_config]
 # Remote file configuration
-[provider.rpc.remote_file]
+[provider.rpc_config.remote_file]
 # Maximum file size in bytes (default: 10GB)
 max_file_size = 10737418240
 # Connection timeout in seconds (default: 30)
@@ -52,13 +52,13 @@ follow_redirects = true
 max_redirects = 10
 # User agent string (default: "StorageHub-Client/1.0")
 user_agent = "StorageHub-Client/1.0"
-# Chunk size in bytes (default: 8192)
+# Chunk size in bytes. This is different from the FILE_CHUNK_SIZE constant in the runtime, as it only affects file upload/download. (default: 8KB)
 chunk_size = 8192
-# Number of FILE_CHUNK_SIZE chunks to buffer (default: 512)
+# Number of chunks to buffer (default: 512)
 chunks_buffer = 512
 
 # Optional indexer configuration
 [indexer]
 # Set to true to enable the indexer
 indexer = true
-database_url = "postgresql://postgres:postgres@docker-sh-postgres-1:5432/storage_hub"
+database_url = "postgresql://postgres:postgres@storage-hub-sh-postgres-1:5432/storage_hub"

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -10,6 +10,7 @@ use shc_client::builder::{
     BspUploadFileOptions, MspChargeFeesOptions, MspMoveBucketOptions,
 };
 use shc_indexer_service::IndexerMode;
+use shc_rpc::RpcConfig;
 
 /// Sub-commands supported by the collator.
 #[derive(Debug, clap::Subcommand)]
@@ -177,13 +178,44 @@ pub struct ProviderConfigurations {
     #[clap(long, default_value = "10")]
     pub max_blocks_behind_to_catch_up_root_changes: Option<u32>,
 
-    /// MSP charging fees period (in blocks).
-    /// Setting it to 600 with a block every 6 seconds will charge user every hour.
-    #[clap(long, required_if_eq_all([
-        ("provider", "true"),
-        ("provider_type", "msp"),
-    ]))]
-    pub msp_charging_period: Option<u32>,
+    // ============== Provider RPC options ==============
+    // ============== Remote file upload/download options ==============
+    /// Maximum file size in bytes (default: 10GB)
+    #[clap(
+        long,
+        value_name = "BYTES",
+        help_heading = "RPC - Remote File Options",
+        default_value = "10737418240"
+    )]
+    pub max_file_size: Option<u64>,
+
+    /// Connection timeout in seconds (default: 30)
+    #[clap(long, value_name = "SECONDS", default_value = "30")]
+    pub connection_timeout: Option<u64>,
+
+    /// Read timeout in seconds (default: 300)
+    #[clap(long, value_name = "SECONDS", default_value = "300")]
+    pub read_timeout: Option<u64>,
+
+    /// Whether to follow redirects (default: true)
+    #[clap(long, value_name = "BOOLEAN", default_value = "true")]
+    pub follow_redirects: Option<bool>,
+
+    /// Maximum number of redirects (default: 10)
+    #[clap(long, value_name = "COUNT", default_value = "10")]
+    pub max_redirects: Option<u64>,
+
+    /// User agent string (default: "StorageHub-Client/1.0")
+    #[clap(long, value_name = "STRING", default_value = "StorageHub-Client/1.0")]
+    pub user_agent: Option<String>,
+
+    /// Chunk size in bytes. This is different from the FILE_CHUNK_SIZE constant in the runtime, as it only affects file upload/download. (default: 8KB)
+    #[clap(long, value_name = "BYTES", default_value = "8192")]
+    pub chunk_size: Option<u64>,
+
+    /// Number of chunks to buffer (default: 512)
+    #[clap(long, value_name = "COUNT", default_value = "512")]
+    pub chunks_buffer: Option<u64>,
 
     // ============== MSP Charge Fees task options ==============
     /// Enable and configure MSP Charge Fees task.
@@ -201,6 +233,14 @@ pub struct ProviderConfigurations {
         ])
     )]
     pub msp_charge_fees_min_debt: Option<u64>,
+
+    /// MSP charging fees period (in blocks).
+    /// Setting it to 600 with a block every 6 seconds will charge user every hour.
+    #[clap(long, required_if_eq_all([
+        ("provider", "true"),
+        ("provider_type", "msp"),
+    ]))]
+    pub msp_charging_period: Option<u32>,
 
     // ============== MSP Move Bucket task options ==============
     /// Enable and configure MSP Move Bucket task.
@@ -314,6 +354,37 @@ pub struct ProviderConfigurations {
 
 impl ProviderConfigurations {
     pub fn provider_options(&self) -> ProviderOptions {
+        // Configure RPC options for Provider
+        let mut rpc_config = RpcConfig::default();
+        if let Some(max_file_size) = self.max_file_size {
+            rpc_config.remote_file.max_file_size = max_file_size;
+        }
+        if let Some(connection_timeout) = self.connection_timeout {
+            rpc_config.remote_file.connection_timeout = connection_timeout;
+        }
+        if let Some(read_timeout) = self.read_timeout {
+            rpc_config.remote_file.read_timeout = read_timeout;
+        }
+        if let Some(follow_redirects) = self.follow_redirects {
+            rpc_config.remote_file.follow_redirects = follow_redirects;
+        }
+        if let Some(max_redirects) = self.max_redirects {
+            rpc_config.remote_file.max_redirects = max_redirects;
+        }
+        if let Some(user_agent) = self.user_agent.clone() {
+            rpc_config.remote_file.user_agent = user_agent;
+        }
+        if let Some(chunk_size) = self.chunk_size {
+            if chunk_size > 0 {
+                rpc_config.remote_file.chunk_size = chunk_size as usize;
+            }
+        }
+        if let Some(chunks_buffer) = self.chunks_buffer {
+            if chunks_buffer > 0 {
+                rpc_config.remote_file.chunks_buffer = chunks_buffer as usize;
+            }
+        }
+
         // Get provider type to conditionally apply options
         let provider_type = self
             .provider_type
@@ -409,6 +480,7 @@ impl ProviderConfigurations {
             storage_path: self.storage_path.clone(),
             max_storage_capacity: self.max_storage_capacity,
             jump_capacity: self.jump_capacity,
+            rpc_config: Some(rpc_config),
             msp_charging_period: self.msp_charging_period,
             msp_charge_fees,
             msp_move_bucket,
@@ -418,7 +490,6 @@ impl ProviderConfigurations {
             bsp_submit_proof,
             blockchain_service,
             maintenance_mode: self.maintenance_mode,
-            rpc: None,
         }
     }
 }

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -22,6 +22,7 @@ use shc_client::builder::{
     BlockchainServiceOptions, BspChargeFeesOptions, BspMoveBucketOptions, BspSubmitProofOptions,
     BspUploadFileOptions, MspChargeFeesOptions, MspMoveBucketOptions,
 };
+use shc_rpc::RpcConfig;
 
 /// Configuration for the provider.
 #[derive(Debug, Clone, Deserialize)]
@@ -36,6 +37,9 @@ pub struct ProviderOptions {
     pub max_storage_capacity: Option<StorageDataUnit>,
     /// Jump capacity (bytes).
     pub jump_capacity: Option<StorageDataUnit>,
+    /// RPC configuration options.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rpc_config: Option<RpcConfig>,
     /// MSP charging fees frequency.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub msp_charging_period: Option<u32>,
@@ -62,9 +66,6 @@ pub struct ProviderOptions {
     pub blockchain_service: Option<BlockchainServiceOptions>,
     /// Whether the node is running in maintenance mode.
     pub maintenance_mode: bool,
-    /// RPC configuration options.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub rpc: Option<shc_client::builder::RpcOptions>,
 }
 
 fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -32,7 +32,7 @@ pub struct FullDeps<C, P, FL, FS> {
     pub client: Arc<C>,
     /// Transaction pool instance.
     pub pool: Arc<P>,
-    /// File Storage instance.
+    /// RPC configuration.
     pub maybe_storage_hub_client_config: Option<StorageHubClientRpcConfig<FL, FS>>,
     /// Manual seal command sink
     pub command_sink: Option<futures::channel::mpsc::Sender<EngineCommand<H256>>>,

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -227,6 +227,7 @@ where
 {
     match provider_options {
         Some(ProviderOptions {
+            rpc_config,
             provider_type,
             storage_path,
             max_storage_capacity,
@@ -239,7 +240,6 @@ where
             bsp_charge_fees,
             bsp_submit_proof,
             blockchain_service,
-            rpc,
             ..
         }) => {
             info!(
@@ -291,13 +291,10 @@ where
             }
 
             // Get the RPC configuration to use for this StorageHub node client.
-            let remote_file_config = rpc
-                .as_ref()
-                .map(|r| r.remote_file.clone().into())
-                .unwrap_or_default();
-            let rpc_config = storage_hub_builder.create_rpc_config(keystore, remote_file_config);
+            let storage_hub_client_rpc_config = storage_hub_builder
+                .create_rpc_config(keystore, rpc_config.clone().unwrap_or_default());
 
-            Some((storage_hub_builder, rpc_config))
+            Some((storage_hub_builder, storage_hub_client_rpc_config))
         }
         None => None,
     }

--- a/test/suites/integration/bsp/automatic-tipping.test.ts
+++ b/test/suites/integration/bsp/automatic-tipping.test.ts
@@ -24,14 +24,14 @@ describeBspNet(
         sealBlock: false
       });
 
-      await assertDockerLog("docker-sh-bsp-1", "attempt #1", 40000);
+      await assertDockerLog("storage-hub-sh-bsp-1", "attempt #1", 40000);
 
-      await assertDockerLog("docker-sh-bsp-1", "attempt #2", 40000);
+      await assertDockerLog("storage-hub-sh-bsp-1", "attempt #2", 40000);
 
-      await assertDockerLog("docker-sh-bsp-1", "attempt #3", 40000);
+      await assertDockerLog("storage-hub-sh-bsp-1", "attempt #3", 40000);
 
       await assertDockerLog(
-        "docker-sh-bsp-1",
+        "storage-hub-sh-bsp-1",
         "Failed to confirm file after 3 retries: Exhausted retry strategy",
         40000
       );

--- a/test/suites/integration/bsp/exclude-list.test.ts
+++ b/test/suites/integration/bsp/exclude-list.test.ts
@@ -22,7 +22,7 @@ describeBspNet("BSP Exclude list tests", ({ before, createUserApi, it, createBsp
 
     await bspApi.assert.log({
       searchString: "Key added to the exclude list",
-      containerName: "docker-sh-bsp-1"
+      containerName: "storage-hub-sh-bsp-1"
     });
 
     const { file_metadata: FileMetadata } = await userApi.rpc.storagehubclient.loadFileInStorage(
@@ -53,7 +53,7 @@ describeBspNet("BSP Exclude list tests", ({ before, createUserApi, it, createBsp
 
     await bspApi.assert.log({
       searchString: "Bucket is in the exclude list",
-      containerName: "docker-sh-bsp-1"
+      containerName: "storage-hub-sh-bsp-1"
     });
   });
 });

--- a/test/suites/integration/bsp/missing-chunks.test.ts
+++ b/test/suites/integration/bsp/missing-chunks.test.ts
@@ -37,7 +37,7 @@ describeBspNet(
       // Example of how to assert on a log message
       await bspApi.assert.log({
         searchString: "💤 Idle",
-        containerName: "docker-sh-bsp-1"
+        containerName: "storage-hub-sh-bsp-1"
       });
 
       // TODO Add an assert that shows this process timing out or being handled in a specific way

--- a/test/suites/integration/bsp/reorg-proof.test.ts
+++ b/test/suites/integration/bsp/reorg-proof.test.ts
@@ -399,7 +399,7 @@ describeBspNet(
 
       // Wait for confirmation line in docker logs.
       await bspApi.docker.waitForLog({
-        containerName: "docker-sh-bsp-1",
+        containerName: "storage-hub-sh-bsp-1",
         searchString: "New local Forest root matches the one in the block for BSP"
       });
       // Check that the file is included in the BSP's local Forest.

--- a/test/suites/integration/bsp/single-volunteer.test.ts
+++ b/test/suites/integration/bsp/single-volunteer.test.ts
@@ -185,7 +185,7 @@ describeBspNet("Single BSP Volunteering", ({ before, createBspApi, it, createUse
     await userApi.assert.eventPresent("fileSystem", "NewStorageRequest");
 
     await bspApi.docker.waitForLog({
-      containerName: "docker-sh-bsp-1",
+      containerName: "storage-hub-sh-bsp-1",
       searchString: "Skipping file key",
       timeout: 15000
     });

--- a/test/suites/integration/bsp/storage-capacity.test.ts
+++ b/test/suites/integration/bsp/storage-capacity.test.ts
@@ -104,7 +104,7 @@ describeBspNet("BSPNet: Change capacity tests.", ({ before, it, createUserApi })
 
     // Wait until the BSP detects that it has to increase its capacity to be able to volunteer.
     await userApi.docker.waitForLog({
-      containerName: "docker-sh-bsp-1",
+      containerName: "storage-hub-sh-bsp-1",
       searchString: "Insufficient storage capacity to volunteer for file key"
     });
 
@@ -282,7 +282,7 @@ describeBspNet("BSPNet: Change capacity tests.", ({ before, it, createUserApi })
 
     // Wait until the BSP first detects that it has to increase its capacity to be able to volunteer.
     await userApi.docker.waitForLog({
-      containerName: "docker-sh-bsp-1",
+      containerName: "storage-hub-sh-bsp-1",
       searchString: "Insufficient storage capacity to volunteer for file key"
     });
 
@@ -348,7 +348,7 @@ describeBspNet("BSPNet: Change capacity tests.", ({ before, it, createUserApi })
     await userApi.wait.bspCatchUpToChainTip(bspTwoApi);
 
     // Stop the other BSP so it doesn't volunteer for the files.
-    await userApi.docker.pauseContainer("docker-sh-bsp-1");
+    await userApi.docker.pauseContainer("storage-hub-sh-bsp-1");
 
     // Issue the first storage request. The new BSP should have enough capacity to volunteer for it.
     const source1 = "res/cloud.jpg";

--- a/test/suites/integration/msp/catch-up-storage.test.ts
+++ b/test/suites/integration/msp/catch-up-storage.test.ts
@@ -34,8 +34,8 @@ describeMspNet(
 
         // Stop the msp container so it will be behind when we restart the node.
         // TODO: clearLogs is not working, fix it.
-        // await clearLogs({ containerName: "docker-sh-msp-1" });
-        await userApi.docker.pauseContainer("docker-sh-msp-1");
+        // await clearLogs({ containerName: "storage-hub-sh-msp-1" });
+        await userApi.docker.pauseContainer("storage-hub-sh-msp-1");
 
         const newBucketEventEvent = await userApi.createBucket(bucketName);
         const newBucketEventDataBlob =
@@ -84,12 +84,12 @@ describeMspNet(
         await mspApi.disconnect();
 
         // Restarting the MSP container. This will start the Substrate node from scratch.
-        await userApi.docker.restartContainer({ containerName: "docker-sh-msp-1" });
+        await userApi.docker.restartContainer({ containerName: "storage-hub-sh-msp-1" });
 
         // TODO: Wait for the container logs of starting up
         await userApi.docker.waitForLog({
           searchString: "💤 Idle (3 peers)",
-          containerName: "docker-sh-msp-1",
+          containerName: "storage-hub-sh-msp-1",
           tail: 10
         });
 
@@ -108,7 +108,7 @@ describeMspNet(
 
         await userApi.docker.waitForLog({
           searchString: "🥱 Handling coming out of sync mode",
-          containerName: "docker-sh-msp-1"
+          containerName: "storage-hub-sh-msp-1"
         });
 
         await userApi.block.skip(4); // user retry every 5 blocks. The one we created before and this one
@@ -116,7 +116,7 @@ describeMspNet(
         await userApi.docker.waitForLog({
           searchString:
             'File upload complete. Peer PeerId("12D3KooWSUvz8QM5X4tfAaSLErAZjR2puojo16pULBHyqTMGKtNV") has the entire file',
-          containerName: "docker-sh-user-1"
+          containerName: "storage-hub-sh-user-1"
         });
 
         await waitFor({

--- a/test/suites/integration/msp/indexer-sanity.test.ts
+++ b/test/suites/integration/msp/indexer-sanity.test.ts
@@ -15,7 +15,7 @@ describeMspNet(
 
     it("postgres DB is ready", async () => {
       await userApi.docker.waitForLog({
-        containerName: "docker-sh-postgres-1",
+        containerName: "storage-hub-sh-postgres-1",
         searchString: "database system is ready to accept connections",
         timeout: 5000
       });

--- a/test/suites/integration/msp/move-bucket-low-capacity.test.ts
+++ b/test/suites/integration/msp/move-bucket-low-capacity.test.ts
@@ -47,7 +47,7 @@ describeMspNet(
 
     it("postgres DB is ready", async () => {
       await userApi.docker.waitForLog({
-        containerName: "docker-sh-postgres-1",
+        containerName: "storage-hub-sh-postgres-1",
         searchString: "database system is ready to accept connections",
         timeout: 5000
       });
@@ -94,10 +94,9 @@ describeMspNet(
 
     it("Add new MSP with low capacity", async () => {
       const { containerName, p2pPort, peerId, rpcPort } = await addMspContainer({
-        name: "sleepy",
+        name: "storage-hub-sh-msp-sleepy",
         additionalArgs: [
-          "--keystore-path=/tmp/msp-three",
-          "--node-key=0xe6a9007b119845010c43f68685f7c2065d8cbf596efc3ebc854dc44f05f6530a",
+          "--keystore-path=/keystore/msp-three",
           `--max-storage-capacity=${1024 * 1024}`,
           `--jump-capacity=${1024 * 1024}`,
           "--msp-charging-period=12"
@@ -105,7 +104,7 @@ describeMspNet(
       });
 
       await userApi.docker.waitForLog({
-        containerName: "sleepy",
+        containerName: "storage-hub-sh-msp-sleepy",
         searchString: "💤 Idle",
         timeout: 15000
       });
@@ -113,15 +112,13 @@ describeMspNet(
       msp3Api = await createApi(`ws://127.0.0.1:${rpcPort}`);
       await msp3Api.rpc.storagehubclient.insertBcsvKeys(mspThreeSeed);
 
-      //Give it some balance.
+      // Give it some balance.
       const amount = 10000n * 10n ** 12n;
       await userApi.block.seal({
         calls: [
           userApi.tx.sudo.sudo(userApi.tx.balances.forceSetBalance(mspThreeKey.address, amount))
         ]
       });
-
-      await userApi.block.seal();
 
       const mspIp = await getContainerIp(containerName);
       const multiAddressMsp = `/ip4/${mspIp}/tcp/${p2pPort}/p2p/${peerId}`;
@@ -144,7 +141,7 @@ describeMspNet(
     });
 
     it("User submits 3 storage requests in the same bucket for first MSP", async () => {
-      // Get value propositions form the MSP to use, and use the first one (can be any).
+      // Get value propositions from the MSP to use, and use the first one (can be any).
       const valueProps = await userApi.call.storageProvidersApi.queryValuePropositionsForMsp(
         userApi.shConsts.DUMMY_MSP_ID
       );
@@ -316,11 +313,31 @@ describeMspNet(
         allBucketFiles.push(fileKey);
       }
 
-      // Seal 5 more blocks to pass maxthreshold and ensure completed upload requests
-      for (let i = 0; i < 5; i++) {
-        await sleep(500);
-        const block = await userApi.block.seal();
-        await userApi.rpc.engine.finalizeBlock(block.blockReceipt.blockHash);
+      // Seal more blocks until the storage request is fulfilled.
+      let hasStorageRequests = true;
+      let iterations = 0;
+      const maxIterations = 60; // Max 60 iterations (30 seconds at 500ms per iteration)
+
+      while (hasStorageRequests && iterations < maxIterations) {
+        hasStorageRequests = false;
+        for (const fileKey of acceptedFileKeys) {
+          const storageRequest = await userApi.query.fileSystem.storageRequests(fileKey);
+          if (storageRequest && !storageRequest.isEmpty) {
+            hasStorageRequests = true;
+            break;
+          }
+        }
+
+        if (hasStorageRequests) {
+          await sleep(500);
+          const block = await userApi.block.seal();
+          await userApi.rpc.engine.finalizeBlock(block.blockReceipt.blockHash);
+          iterations++;
+        }
+      }
+
+      if (iterations >= maxIterations) {
+        throw new Error(`Storage requests not fulfilled after ${maxIterations} iterations`);
       }
     });
 

--- a/test/suites/integration/msp/move-bucket-reject.test.ts
+++ b/test/suites/integration/msp/move-bucket-reject.test.ts
@@ -47,7 +47,7 @@ describeMspNet(
 
     it("postgres DB is ready", async () => {
       await userApi.docker.waitForLog({
-        containerName: "docker-sh-postgres-1",
+        containerName: "storage-hub-sh-postgres-1",
         searchString: "database system is ready to accept connections",
         timeout: 5000
       });
@@ -332,7 +332,7 @@ describeMspNet(
     it("MSP 2 rejects move request when indexer postgres DB is down", async () => {
       // Pause the postgres container - this preserves the state
       const docker = new Docker();
-      const postgresContainer = docker.getContainer("docker-sh-postgres-1");
+      const postgresContainer = docker.getContainer("storage-hub-sh-postgres-1");
       await postgresContainer.pause();
 
       const valueProps = await userApi.call.storageProvidersApi.queryValuePropositionsForMsp(
@@ -380,7 +380,7 @@ describeMspNet(
       await postgresContainer.unpause();
 
       await userApi.docker.waitForLog({
-        containerName: "docker-sh-postgres-1",
+        containerName: "storage-hub-sh-postgres-1",
         searchString: "database system is ready to accept connections",
         timeout: 5000
       });

--- a/test/suites/integration/msp/move-bucket.test.ts
+++ b/test/suites/integration/msp/move-bucket.test.ts
@@ -44,7 +44,7 @@ describeMspNet(
 
     it("postgres DB is ready", async () => {
       await userApi.docker.waitForLog({
-        containerName: "docker-sh-postgres-1",
+        containerName: "storage-hub-sh-postgres-1",
         searchString: "database system is ready to accept connections",
         timeout: 5000
       });

--- a/test/suites/integration/user/send-file-to-provider.test.ts
+++ b/test/suites/integration/user/send-file-to-provider.test.ts
@@ -65,8 +65,9 @@ describeMspNet("User: Send file to provider", ({ before, createUserApi, it }) =>
 
   it("MSP first libp2p multiaddress is wrong and second should be correct. User will be able to connect and send file on the second attempt.", async () => {
     const { containerName, p2pPort, peerId } = await addMspContainer({
-      name: "lola1",
+      name: "storage-hub-sh-msp-three",
       additionalArgs: [
+        "--keystore-path=/keystore/msp-three",
         "--database=rocksdb",
         `--max-storage-capacity=${MAX_STORAGE_CAPACITY}`,
         `--jump-capacity=${CAPACITY[1024]}`,
@@ -74,7 +75,14 @@ describeMspNet("User: Send file to provider", ({ before, createUserApi, it }) =>
       ]
     });
 
-    //Give it some balance.
+    // Wait until the MSP is up and running.
+    await userApi.docker.waitForLog({
+      searchString: "Idle",
+      containerName: containerName,
+      timeout: 30000
+    });
+
+    // Give it some balance.
     const amount = 10000n * 10n ** 12n;
     await userApi.block.seal({
       calls: [
@@ -83,6 +91,7 @@ describeMspNet("User: Send file to provider", ({ before, createUserApi, it }) =>
     });
 
     const mspIp = await getContainerIp(containerName);
+    const badMultiAddress = `/ip4/51.75.30.194/tcp/30350/p2p/${peerId}`;
     const multiAddressMsp = `/ip4/${mspIp}/tcp/${p2pPort}/p2p/${peerId}`;
     await userApi.block.seal({
       calls: [
@@ -91,7 +100,7 @@ describeMspNet("User: Send file to provider", ({ before, createUserApi, it }) =>
             mspThreeKey.address,
             mspThreeKey.publicKey,
             userApi.shConsts.CAPACITY_512,
-            [`/ip4/51.75.30.194/tcp/30350/p2p/${peerId}`, multiAddressMsp],
+            [badMultiAddress, multiAddressMsp],
             100 * 1024 * 1024,
             "Terms of Service...",
             9999999,
@@ -150,16 +159,18 @@ describeMspNet("User: Send file to provider", ({ before, createUserApi, it }) =>
 
     await userApi.assert.eventPresent("fileSystem", "NewStorageRequest");
 
-    // Fail to connect to the first libp2p address because it is a phony one.
+    // It should have failed to connect to the first libp2p address because it is a phony one.
     await userApi.docker.waitForLog({
-      searchString: "Unable to upload final batch to peer",
-      containerName: userApi.shConsts.NODE_INFOS.user.containerName
+      searchString: `Unable to upload final batch to peer PeerId("${peerId}")`,
+      containerName: userApi.shConsts.NODE_INFOS.user.containerName,
+      timeout: 20000
     });
 
     // Second libp2p address is the right one so we should successfully send the file through this one.
     await userApi.docker.waitForLog({
-      searchString: "File upload complete.",
-      containerName: userApi.shConsts.NODE_INFOS.user.containerName
+      searchString: `File upload complete. Peer PeerId("${peerId}")`,
+      containerName: userApi.shConsts.NODE_INFOS.user.containerName,
+      timeout: 20000
     });
   });
 });

--- a/test/util/bspNet/block.ts
+++ b/test/util/bspNet/block.ts
@@ -76,7 +76,7 @@ export const extendFork = async (
 
     // TODO replace with something smarter eventually
     await waitForLog({
-      containerName: "docker-sh-user-1", // we can only produce blocks via the user node for now
+      containerName: "storage-hub-sh-user-1", // we can only produce blocks via the user node for now
       searchString: "💤 Idle",
       timeout: 5000
     });

--- a/test/util/bspNet/consts.ts
+++ b/test/util/bspNet/consts.ts
@@ -1,20 +1,20 @@
 export const NODE_INFOS = {
   user: {
-    containerName: "docker-sh-user-1",
+    containerName: "storage-hub-sh-user-1",
     port: 9888,
     p2pPort: 30444,
     AddressId: "5CombC1j5ZmdNMEpWYpeEWcKPPYcKsC1WgMPgzGLU72SLa4o",
     expectedPeerId: "12D3KooWMvbhtYjbhgjoDzbnf71SFznJAKBBkSGYEUtnpES1y9tM"
   },
   bsp: {
-    containerName: "docker-sh-bsp-1",
+    containerName: "storage-hub-sh-bsp-1",
     port: 9666,
     p2pPort: 30350,
     AddressId: "5FHSHEFWHVGDnyiw66DoRUpLyh5RouWkXo9GT1Sjk8qw7MAg",
     expectedPeerId: "12D3KooWNEZ8PGNydcdXTYy1SPHvkP9mbxdtTqGGFVrhorDzeTfU"
   },
   msp1: {
-    containerName: "docker-sh-msp-1",
+    containerName: "storage-hub-sh-msp-1",
     port: 9777,
     p2pPort: 30555,
     AddressId: "5E1rPv1M2mheg6pM57QqU7TZ6eCwbVpiYfyYkrugpBdEzDiU",
@@ -22,7 +22,7 @@ export const NODE_INFOS = {
     expectedPeerId: "12D3KooWSUvz8QM5X4tfAaSLErAZjR2puojo16pULBHyqTMGKtNV"
   },
   msp2: {
-    containerName: "docker-sh-msp-2",
+    containerName: "storage-hub-sh-msp-2",
     port: 9778,
     p2pPort: 30556,
     AddressId: "5CMDKyadzWu6MUwCzBB93u32Z1PPPsV8A1qAy4ydyVWuRzWR",
@@ -30,7 +30,7 @@ export const NODE_INFOS = {
     expectedPeerId: "12D3KooWAFJGBhD5NxgcGatAdzs1Zuh6XWqTzKr6S4BdQbTuZRzo"
   },
   collator: {
-    containerName: "docker-sh-collator-1",
+    containerName: "storage-hub-sh-collator-1",
     port: 9955,
     p2pPort: 30333,
     AddressId: "5C8NC6YuAivp3knYC58Taycx2scQoDcDd3MCEEgyw36Gh1R4"

--- a/test/util/bspNet/helpers.ts
+++ b/test/util/bspNet/helpers.ts
@@ -38,8 +38,8 @@ export const getContainerIp = async (containerName: string, verbose = false): Pr
   // TODO: Replace with dockerode
   execSync("docker ps -a", { stdio: "inherit" });
   try {
-    execSync("docker logs docker-sh-bsp-1", { stdio: "inherit" });
-    execSync("docker logs docker-sh-user-1", { stdio: "inherit" });
+    execSync("docker logs storage-hub-sh-bsp-1", { stdio: "inherit" });
+    execSync("docker logs storage-hub-sh-user-1", { stdio: "inherit" });
   } catch (e) {
     console.log(e);
   }

--- a/test/util/helpers.ts
+++ b/test/util/helpers.ts
@@ -98,7 +98,7 @@ export const cleanupEnvironment = async (verbose = false) => {
   );
 
   const postgresContainer = allContainers.find((container) =>
-    container.Names.some((name) => name.includes("docker-sh-postgres-1"))
+    container.Names.some((name) => name.includes("storage-hub-sh-postgres-1"))
   );
 
   const tmpDir = tmp.dirSync({ prefix: "bsp-logs-", unsafeCleanup: true });

--- a/test/util/netLaunch/index.ts
+++ b/test/util/netLaunch/index.ts
@@ -152,14 +152,14 @@ export class NetworkLauncher {
     if (this.config.indexer) {
       composeYaml.services["sh-user"].command.push("--indexer");
       composeYaml.services["sh-user"].command.push(
-        "--database-url=postgresql://postgres:postgres@docker-sh-postgres-1:5432/storage_hub"
+        "--database-url=postgresql://postgres:postgres@storage-hub-sh-postgres-1:5432/storage_hub"
       );
       if (this.type === "fullnet") {
         composeYaml.services["sh-msp-1"].command.push(
-          "--database-url=postgresql://postgres:postgres@docker-sh-postgres-1:5432/storage_hub"
+          "--database-url=postgresql://postgres:postgres@storage-hub-sh-postgres-1:5432/storage_hub"
         );
         composeYaml.services["sh-msp-2"].command.push(
-          "--database-url=postgresql://postgres:postgres@docker-sh-postgres-1:5432/storage_hub"
+          "--database-url=postgresql://postgres:postgres@storage-hub-sh-postgres-1:5432/storage_hub"
         );
       }
     }
@@ -182,7 +182,7 @@ export class NetworkLauncher {
     );
 
     let composeContents = {
-      name: "docker",
+      name: "storage-hub",
       services: remappedYamlContents
     };
 
@@ -720,7 +720,7 @@ export class NetworkLauncher {
 
     // Wait for network to be in sync
     await bspApi.docker.waitForLog({
-      containerName: "docker-sh-bsp-1",
+      containerName: "storage-hub-sh-bsp-1",
       searchString: "💤 Idle",
       timeout: 15000
     });
@@ -740,7 +740,7 @@ export class NetworkLauncher {
     await using userApi = await launchedNetwork.getApi("sh-user");
 
     await userApi.docker.waitForLog({
-      containerName: "docker-sh-user-1",
+      containerName: "storage-hub-sh-user-1",
       searchString: "💤 Idle",
       timeout: 15000
     });


### PR DESCRIPTION
This PR:
- Adds the `RpcConfig` struct which will hold all configurations related to RPCs (for now, only the configuration for remote files in `remote_file`).
  - This gets populated from the CLI or, if possible, from the configuration file for BSPs (`bsp_config.toml`) or MSPs (`msp_config.toml`) depending on which type of provider this is.
  - Default values have been provided that should work for most providers.
- Changes the `chunk` from the RPC remote file methods to have nothing to do with `FILE_CHUNK_SIZE`, since the former is related to the buffers used when fetching and uploading files to FTP or HTTP servers while the later is related to the size of the leafs of our file tries.
- Changes all docker containers from our integration tests to spawn under the `storage-hub` compose stack instead of having some spawining under the `docker` compose stack and others with no stack at all.
- Adds to the keystore the keys for a third MSP since it's used in more than one test (and we already had the constants for it).
- Fixes the `msp-move-bucket-low-capacity` test to ensure that no storage request is left open before issuing the move bucket request, preventing this test to error out if BSPs don't confirm storing all files quick enough.
- Fixes the `send-file-to-provider` test which wasn't asserting for the correct logs and as such was giving us false positives.