### PR TITLE
NPM_TOKEN for SDK CI

### DIFF
--- a/.github/workflows/e2e-dappwright.yml
+++ b/.github/workflows/e2e-dappwright.yml
@@ -20,6 +20,14 @@ jobs:
       - name: Setup pnpm & cache
         uses: ./.github/workflow-templates/setup-pnpm
 
+      - name: Configure npm registry auth
+        uses: actions/setup-node@v4
+        with:
+          registry-url: https://registry.npmjs.org/
+          always-auth: true
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Install Rust toolchain (for wasm)
         uses: actions-rust-lang/setup-rust-toolchain@v1.8
         with:


### PR DESCRIPTION
Use NPM token to login and avoid rate limit in SDK CI jobs