### PR TITLE
feat: handle fisherman incomplete storage request

### DIFF
--- a/client/fisherman-service/src/handler.rs
+++ b/client/fisherman-service/src/handler.rs
@@ -1,6 +1,6 @@
 use codec::Decode;
 use futures::stream::{self, StreamExt};
-use log::{debug, error, info, warn};
+use log::{debug, error, info, trace, warn};
 use pallet_file_system_runtime_api::FileSystemApi;
 use sc_client_api::{BlockImportNotification, BlockchainEvents, HeaderBackend};
 use shc_common::types::{FileOperation, OpaqueBlock, StorageEnableEvents};
@@ -107,41 +107,11 @@ impl<Runtime: StorageEnableRuntime> FishermanService<Runtime> {
                     self.emit(event);
                 }
                 StorageEnableEvents::FileSystem(
-                    pallet_file_system::Event::StorageRequestExpired { file_key },
+                    pallet_file_system::Event::IncompleteStorageRequest { file_key },
                 ) => {
                     info!(
                         target: LOG_TARGET,
-                        "🎣 Found StorageRequestExpired event for file key: {:?}",
-                        file_key
-                    );
-
-                    let event = crate::events::ProcessIncompleteStorageRequest {
-                        file_key: file_key.into(),
-                    };
-
-                    self.emit(event);
-                }
-                StorageEnableEvents::FileSystem(
-                    pallet_file_system::Event::StorageRequestRevoked { file_key },
-                ) => {
-                    info!(
-                        target: LOG_TARGET,
-                        "🎣 Found StorageRequestRevoked event for file key: {:?}",
-                        file_key
-                    );
-
-                    let event = crate::events::ProcessIncompleteStorageRequest {
-                        file_key: file_key.into(),
-                    };
-
-                    self.emit(event);
-                }
-                StorageEnableEvents::FileSystem(
-                    pallet_file_system::Event::StorageRequestRejected { file_key, .. },
-                ) => {
-                    info!(
-                        target: LOG_TARGET,
-                        "🎣 Found StorageRequestRejected event for file key: {:?}",
+                        "🎣 Found IncompleteStorageRequest event for file key: {:?}",
                         file_key
                     );
 
@@ -261,7 +231,7 @@ impl<Runtime: StorageEnableRuntime> FishermanService<Runtime> {
             })
             .collect();
 
-        info!(
+        trace!(
             target: LOG_TARGET,
             "🎣 Found {} file key changes for provider {:?} between blocks {} and {}",
             changes.len(),

--- a/client/indexer-service/src/handler.rs
+++ b/client/indexer-service/src/handler.rs
@@ -526,6 +526,7 @@ impl<Runtime: StorageEnableRuntime> IndexerService<Runtime> {
                 )
                 .await?;
             }
+            pallet_file_system::Event::IncompleteStorageRequest { .. } => {}
             pallet_file_system::Event::__Ignore(_, _) => {}
         }
         Ok(())

--- a/client/indexer-service/src/handler/fishing.rs
+++ b/client/indexer-service/src/handler/fishing.rs
@@ -69,7 +69,7 @@ where
                     new_msp_id,
                     value_prop_id,
                 } => {
-                    trace!(target: LOG_TARGET, "Indexing move bucket accepted event for bucket ID: {}, old MSP ID: {:?}, new MSP ID: {:?}, value prop ID: {:?}", 
+                    trace!(target: LOG_TARGET, "Indexing move bucket accepted event for bucket ID: {}, old MSP ID: {:?}, new MSP ID: {:?}, value prop ID: {:?}",
                         bucket_id, old_msp_id, new_msp_id, value_prop_id);
                     self.index_file_system_event(conn, fs_event).await?
                 }
@@ -82,7 +82,7 @@ where
                     old_root,
                     new_root,
                 } => {
-                    trace!(target: LOG_TARGET, "Indexing MSP file deletion completed event for user: {:?}, file key: {:?}, file size: {}, bucket ID: {:?}, MSP ID: {:?}, old root: {:?}, new root: {:?}", 
+                    trace!(target: LOG_TARGET, "Indexing MSP file deletion completed event for user: {:?}, file key: {:?}, file size: {}, bucket ID: {:?}, MSP ID: {:?}, old root: {:?}, new root: {:?}",
                         user, file_key, file_size, bucket_id, msp_id, old_root, new_root);
                     self.index_file_system_event(conn, fs_event).await?
                 }
@@ -94,7 +94,7 @@ where
                     old_root,
                     new_root,
                 } => {
-                    trace!(target: LOG_TARGET, "Indexing BSP file deletion completed event for user: {:?}, file key: {:?}, file size: {}, BSP ID: {:?}, old root: {:?}, new root: {:?}", 
+                    trace!(target: LOG_TARGET, "Indexing BSP file deletion completed event for user: {:?}, file key: {:?}, file size: {}, BSP ID: {:?}, old root: {:?}, new root: {:?}",
                         user, file_key, file_size, bsp_id, old_root, new_root);
                     self.index_file_system_event(conn, fs_event).await?
                 }
@@ -102,7 +102,7 @@ where
                     signed_delete_intention,
                     signature: _,
                 } => {
-                    trace!(target: LOG_TARGET, "Indexing file deletion requested event for file key: {:?}", 
+                    trace!(target: LOG_TARGET, "Indexing file deletion requested event for file key: {:?}",
                         signed_delete_intention.file_key);
                     self.index_file_system_event(conn, fs_event).await?
                 }
@@ -115,6 +115,7 @@ where
                 | pallet_file_system::Event::PriorityChallengeForFileDeletionQueued { .. }
                 | pallet_file_system::Event::FailedToQueuePriorityChallenge { .. }
                 | pallet_file_system::Event::FileDeletionRequest { .. }
+                | pallet_file_system::Event::IncompleteStorageRequest { .. }
                 | pallet_file_system::Event::ProofSubmittedForPendingFileDeletionRequest {
                     ..
                 }

--- a/client/indexer-service/src/handler/lite.rs
+++ b/client/indexer-service/src/handler/lite.rs
@@ -103,6 +103,7 @@ impl<Runtime: StorageEnableRuntime> IndexerService<Runtime> {
             pallet_file_system::Event::MspFileDeletionCompleted { .. } => true,
             pallet_file_system::Event::BspFileDeletionCompleted { .. } => true,
             pallet_file_system::Event::FileDeletedFromIncompleteStorageRequest { .. } => true,
+            pallet_file_system::Event::IncompleteStorageRequest { .. } => true,
             pallet_file_system::Event::__Ignore(_, _) => true,
         };
 

--- a/pallets/file-system/src/lib.rs
+++ b/pallets/file-system/src/lib.rs
@@ -785,6 +785,11 @@ pub mod pallet {
             file_key: MerkleHash<T>,
             provider_id: ProviderIdFor<T>,
         },
+        /// Notifies that a storage request was marked as incomplete.
+        ///
+        /// This is important for fisherman nodes to listen and react to, to delete
+        /// the file key from the BSPs and/or MSP storing that file from their forest.
+        IncompleteStorageRequest { file_key: MerkleHash<T> },
     }
 
     // Errors inform users that something went wrong.

--- a/pallets/file-system/src/utils.rs
+++ b/pallets/file-system/src/utils.rs
@@ -1033,6 +1033,8 @@ where
                         &file_key,
                         incomplete_storage_request_metadata,
                     );
+
+                    Self::deposit_event(Event::IncompleteStorageRequest { file_key });
                 }
 
                 // We cleanup the storage request
@@ -1370,6 +1372,7 @@ where
             IncompleteStorageRequests::<T>::remove(&file_key);
         } else {
             IncompleteStorageRequests::<T>::insert(&file_key, incomplete_storage_request_metadata);
+            Self::deposit_event(Event::IncompleteStorageRequest { file_key });
         }
 
         Ok(())
@@ -2106,6 +2109,8 @@ where
             let incomplete_storage_request_metadata: IncompleteStorageRequestMetadata<T> =
                 (&storage_request_metadata, &file_key).into();
             <IncompleteStorageRequests<T>>::insert(&file_key, incomplete_storage_request_metadata);
+
+            Self::deposit_event(Event::IncompleteStorageRequest { file_key });
         }
 
         // We cleanup the storage request
@@ -3078,6 +3083,8 @@ mod hooks {
                                 &file_key,
                                 incomplete_storage_request_metadata,
                             );
+
+                            Self::deposit_event(Event::IncompleteStorageRequest { file_key });
                         }
                         // Clean up all storage request related data
                         Self::cleanup_storage_request(&file_key, &storage_request_metadata);

--- a/test/util/fisherman/fishermanHelpers.ts
+++ b/test/util/fisherman/fishermanHelpers.ts
@@ -37,6 +37,42 @@ export async function waitForDeleteFileExtrinsic(
 }
 
 /**
+ * Helper function to wait for delete_file_for_incomplete_storage_request extrinsic in transaction pool
+ * @param api - The API instance to use
+ * @param expectedCount - Number of expected delete_file_for_incomplete_storage_request extrinsics (default: 1)
+ * @param timeout - Timeout in milliseconds (default: 10000)
+ * @returns Promise<boolean> - True if expected number of extrinsics found, false if timeout
+ */
+export async function waitForDeleteFileForIncompleteStorageRequestExtrinsic(
+  api: EnrichedBspApi,
+  expectedCount = 1,
+  timeout = 10000
+): Promise<boolean> {
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeout) {
+    try {
+      const pendingTxs = await api.rpc.author.pendingExtrinsics();
+      const deleteFileTxs = pendingTxs.filter(
+        (tx) =>
+          tx.method.method === "deleteFileForIncompleteStorageRequest" &&
+          tx.method.section === "fileSystem"
+      );
+
+      if (deleteFileTxs.length >= expectedCount) {
+        return true;
+      }
+    } catch (error) {
+      console.warn("Error checking pending extrinsics:", error);
+    }
+
+    await sleep(500);
+  }
+
+  return false;
+}
+
+/**
  * Helper function to wait for fisherman to process an event
  * @param api - The API instance to use
  * @param searchPattern - The log pattern to search for


### PR DESCRIPTION
Notable changes:

- monitor block now checks for `IncompleteStorageRequest` event 
- add revoking and expired storage request integration tests 
- do not return err result if peer id and file key already registered