### PR TITLE
refactor: remove big dependencies from `configure_file_transfer_network`

### DIFF
--- a/client/file-transfer-service/src/lib.rs
+++ b/client/file-transfer-service/src/lib.rs
@@ -5,11 +5,10 @@ use sc_network::{
     config::FullNetworkConfiguration, request_responses::IncomingRequest,
     request_responses::ProtocolConfig, service::traits::NetworkService, ProtocolName,
 };
-use sc_service::Configuration;
 use shc_actors_framework::actor::{ActorHandle, ActorSpawner, TaskSpawner};
 use shc_common::{
     traits::StorageEnableRuntime,
-    types::{BlockHash, OpaqueBlock, ParachainClient, BATCH_CHUNK_FILE_TRANSFER_MAX_SIZE},
+    types::{BlockHash, OpaqueBlock, BATCH_CHUNK_FILE_TRANSFER_MAX_SIZE},
 };
 
 pub use self::handler::FileTransferService;
@@ -56,20 +55,21 @@ pub fn configure_file_transfer_network<
     Network: sc_network::NetworkBackend<OpaqueBlock, BlockHash>,
     Runtime: StorageEnableRuntime,
 >(
-    client: Arc<ParachainClient<Runtime::RuntimeApi>>,
-    parachain_config: &Configuration,
+    genesis_hash: Runtime::Hash,
+    fork_id: Option<&str>,
     net_config: &mut FullNetworkConfiguration<OpaqueBlock, BlockHash, Network>,
 ) -> (ProtocolName, async_channel::Receiver<IncomingRequest>) {
-    let genesis_hash = client
-        .block_hash(0u32.into())
-        .ok()
-        .flatten()
-        .expect("Genesis block exists; qed");
-
     let (tx, request_receiver) = async_channel::bounded(MAX_FILE_TRANSFER_REQUESTS_QUEUE);
 
-    let mut protocol_config =
-        generate_protocol_config(genesis_hash, parachain_config.chain_spec.fork_id());
+    let mut protocol_config = ProtocolConfig {
+        name: generate_protocol_name(genesis_hash, fork_id).into(),
+        fallback_names: Vec::new(),
+        max_request_size: MAX_REQUEST_PACKET_SIZE_BYTES,
+        max_response_size: MAX_RESPONSE_PACKET_SIZE_BYTES,
+        request_timeout: Duration::from_secs(15),
+        inbound_queue: None,
+    };
+
     protocol_config.inbound_queue = Some(tx);
 
     let request_response_config = Network::request_response_config(
@@ -119,6 +119,17 @@ fn generate_protocol_name<Hash: AsRef<[u8]>>(genesis_hash: Hash, fork_id: Option
             array_bytes::bytes2hex("", genesis_hash)
         )
     }
+}
+
+/// Fetch the genesis hash.
+///
+/// Will panic if there is no genesis block found.
+pub fn fetch_genesis_hash(client: Arc<impl BlockBackend<OpaqueBlock> + 'static>) -> BlockHash {
+    client
+        .block_hash(0u32.into())
+        .ok()
+        .flatten()
+        .expect("Genesis block exists; qed")
 }
 
 /// Generates a [`ProtocolConfig`] for the provider requests protocol, refusing incoming

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -65,7 +65,7 @@ use shc_client::{
         RocksDbStorageLayer, ShNodeType, ShRole, ShStorageLayer, UserRole,
     },
 };
-use shc_file_transfer_service::configure_file_transfer_network;
+use shc_file_transfer_service::{configure_file_transfer_network, fetch_genesis_hash};
 use sp_api::ProvideRuntimeApi;
 use sp_keystore::{Keystore, KeystorePtr};
 use substrate_prometheus_endpoint::Registry;
@@ -540,8 +540,8 @@ where
     let mut file_transfer_request_protocol = None;
     if provider_options.is_some() || fisherman_options.is_some() {
         file_transfer_request_protocol = Some(configure_file_transfer_network::<_, Runtime>(
-            client.clone(),
-            &config,
+            fetch_genesis_hash(client.clone()),
+            config.chain_spec.fork_id(),
             &mut net_config,
         ));
     }
@@ -934,8 +934,8 @@ where
     let mut file_transfer_request_protocol = None;
     if provider_options.is_some() || fisherman_options.is_some() {
         file_transfer_request_protocol = Some(configure_file_transfer_network::<_, Runtime>(
-            client.clone(),
-            &config,
+            fetch_genesis_hash(client.clone()),
+            config.chain_spec.fork_id(),
             &mut net_config,
         ));
     }
@@ -1111,8 +1111,8 @@ where
     let mut file_transfer_request_protocol = None;
     if provider_options.is_some() {
         file_transfer_request_protocol = Some(configure_file_transfer_network::<_, Runtime>(
-            client.clone(),
-            &parachain_config,
+            fetch_genesis_hash(client.clone()),
+            parachain_config.chain_spec.fork_id(),
             &mut net_config,
         ));
     }
@@ -1359,8 +1359,8 @@ where
     let mut file_transfer_request_protocol = None;
     if provider_options.is_some() {
         file_transfer_request_protocol = Some(configure_file_transfer_network::<_, Runtime>(
-            client.clone(),
-            &parachain_config,
+            fetch_genesis_hash(client.clone()),
+            parachain_config.chain_spec.fork_id(),
             &mut net_config,
         ));
     }


### PR DESCRIPTION
Simplifying input parameters to `configure_file_transfer_network` function for better ergonomic calling by library users.