### PR TITLE
feat(script): ✨ Add periodic sealing to solochain EVM setup demo script

### DIFF
--- a/test/scripts/solochainEvmBootstrapInitialised.ts
+++ b/test/scripts/solochainEvmBootstrapInitialised.ts
@@ -1,6 +1,30 @@
+import type { ApiPromise } from "@polkadot/api";
 import type { BspNetConfig } from "../util";
 import { BspNetTestApi, ShConsts, sleep } from "../util";
+import { cleanupEnvironment } from "../util/helpers";
 import { NetworkLauncher } from "../util/netLaunch";
+
+let currentApi: ApiPromise | undefined;
+
+let isTearingDown = false;
+const tearDownNetwork = async () => {
+  if (isTearingDown) return;
+  isTearingDown = true;
+  try {
+    console.log("\n🛑 Interrupt received. Tearing down network containers...");
+    try {
+      await currentApi?.disconnect();
+    } catch (e) {
+      console.error("Error disconnecting API:", e);
+    }
+    await cleanupEnvironment();
+  } finally {
+    process.exit(0);
+  }
+};
+
+process.on("SIGINT", () => void tearDownNetwork());
+process.on("SIGTERM", () => void tearDownNetwork());
 
 const bspNetConfig: BspNetConfig = {
   noisy: process.env.NOISY === "1",
@@ -22,8 +46,9 @@ async function bootStrapNetwork() {
     `ws://127.0.0.1:${ShConsts.NODE_INFOS.user.port}`,
     "solochain"
   );
+  currentApi = api as unknown as ApiPromise;
 
-  console.log("⛏️  Auto-sealing blocks every 6s. Press Ctrl+C to stop.");
+  console.log("⛏️  Auto-sealing blocks every 6s. Press Ctrl+C to stop (will tear down network).");
   // Keep sealing blocks every 6 seconds until the process is interrupted
   // eslint-disable-next-line no-constant-condition
   while (true) {

--- a/test/scripts/solochainEvmBootstrapInitialised.ts
+++ b/test/scripts/solochainEvmBootstrapInitialised.ts
@@ -1,4 +1,5 @@
 import type { BspNetConfig } from "../util";
+import { BspNetTestApi, ShConsts, sleep } from "../util";
 import { NetworkLauncher } from "../util/netLaunch";
 
 const bspNetConfig: BspNetConfig = {
@@ -16,6 +17,23 @@ async function bootStrapNetwork() {
   });
 
   console.log("✅ Solochain EVM Bootstrap success");
+
+  await using api = await BspNetTestApi.create(
+    `ws://127.0.0.1:${ShConsts.NODE_INFOS.user.port}`,
+    "solochain"
+  );
+
+  console.log("⛏️  Auto-sealing blocks every 6s. Press Ctrl+C to stop.");
+  // Keep sealing blocks every 6 seconds until the process is interrupted
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      await api.block.seal();
+    } catch (e) {
+      console.error("Auto-seal error:", e);
+    }
+    await sleep(6000);
+  }
 }
 
 await bootStrapNetwork().catch((e) => {


### PR DESCRIPTION
- Adds 6 second periodic manual sealing of blocks to `solochainEvmBootstrapInitialised.ts` script.
- Adds teardown of the network when killing script.
- Fixes race condition in testing setup replacing `sleep` for `waitFor` to wait for postgres container readiness.