### PR TITLE
refactor: 🔥 Remove ongoing tasks from Blockchain Service state store

### DIFF
--- a/client/blockchain-service/src/handler.rs
+++ b/client/blockchain-service/src/handler.rs
@@ -40,16 +40,9 @@ use crate::{
     capacity_manager::{CapacityRequest, CapacityRequestQueue},
     commands::BlockchainServiceCommand,
     events::BlockchainServiceEventBusProvider,
-    state::{
-        BlockchainServiceStateStore, LastProcessedBlockNumberCf,
-        OngoingProcessConfirmStoringRequestCf, OngoingProcessMspRespondStorageRequestCf,
-        OngoingProcessStopStoringForInsolventUserRequestCf,
-    },
+    state::{BlockchainServiceStateStore, LastProcessedBlockNumberCf},
     transaction::SubmittedTransaction,
-    types::{
-        ManagedProvider, MinimalBlockInfo, NewBlockNotificationKind,
-        StopStoringForInsolventUserRequest,
-    },
+    types::{ManagedProvider, MinimalBlockInfo, NewBlockNotificationKind},
 };
 
 pub(crate) const LOG_TARGET: &str = "blockchain-service";
@@ -1271,68 +1264,6 @@ where
 
         // If this is the first block import notification, we might need to catch up.
         info!(target: LOG_TARGET, "🥱 Handling coming out of sync mode (synced to #{}: {})", block_number, block_hash);
-
-        // Check if there was an ongoing process confirm storing task.
-        let state_store_context = self.persistent_state.open_rw_context_with_overlay();
-
-        // Check if there was an ongoing process confirm storing task.
-        // Note: This would only exist if the node was running as a BSP.
-        let maybe_ongoing_process_confirm_storing_request = state_store_context
-            .access_value(&OngoingProcessConfirmStoringRequestCf::<Runtime> {
-                phantom: Default::default(),
-            })
-            .read();
-
-        // If there was an ongoing process confirm storing task, we need to re-queue the requests.
-        if let Some(process_confirm_storing_request) = maybe_ongoing_process_confirm_storing_request
-        {
-            for request in process_confirm_storing_request.confirm_storing_requests {
-                state_store_context
-                    .pending_confirm_storing_request_deque::<Runtime>()
-                    .push_back(request);
-            }
-        }
-
-        // Check if there was an ongoing process msp respond storage request task.
-        // Note: This would only exist if the node was running as an MSP.
-        let maybe_ongoing_process_msp_respond_storage_request = state_store_context
-            .access_value(&OngoingProcessMspRespondStorageRequestCf::<Runtime> {
-                phantom: Default::default(),
-            })
-            .read();
-
-        // If there was an ongoing process msp respond storage request task, we need to re-queue the requests.
-        if let Some(process_msp_respond_storage_request) =
-            maybe_ongoing_process_msp_respond_storage_request
-        {
-            for request in process_msp_respond_storage_request.respond_storing_requests {
-                state_store_context
-                    .pending_msp_respond_storage_request_deque()
-                    .push_back(request);
-            }
-        }
-
-        // Check if there was an ongoing process stop storing task.
-        let maybe_ongoing_process_stop_storing_for_insolvent_user_request = state_store_context
-            .access_value(
-                &OngoingProcessStopStoringForInsolventUserRequestCf::<Runtime> {
-                    phantom: Default::default(),
-                },
-            )
-            .read();
-
-        // If there was an ongoing process stop storing task, we need to re-queue the requests.
-        if let Some(process_stop_storing_for_insolvent_user_request) =
-            maybe_ongoing_process_stop_storing_for_insolvent_user_request
-        {
-            state_store_context
-                .pending_stop_storing_for_insolvent_user_request_deque::<Runtime>()
-                .push_back(StopStoringForInsolventUserRequest::new(
-                    process_stop_storing_for_insolvent_user_request.who,
-                ));
-        }
-
-        state_store_context.commit();
 
         // Initialise the Provider.
         match &self.maybe_managed_provider {

--- a/client/blockchain-service/src/handler_msp.rs
+++ b/client/blockchain-service/src/handler_msp.rs
@@ -12,7 +12,7 @@ use pallet_storage_providers_runtime_api::StorageProvidersApi;
 use shc_actors_framework::actor::Actor;
 use shc_common::traits::StorageEnableRuntime;
 use shc_common::{
-    typed_store::{CFDequeAPI, ProvidesTypedDbSingleAccess},
+    typed_store::CFDequeAPI,
     types::{
         BlockHash, BlockNumber, Fingerprint, ProviderId, StorageEnableEvents,
         StorageRequestMetadata,
@@ -31,10 +31,6 @@ use crate::{
         StartMovedBucketDownload,
     },
     handler::LOG_TARGET,
-    state::{
-        OngoingProcessFileDeletionRequestCf, OngoingProcessMspRespondStorageRequestCf,
-        OngoingProcessStopStoringForInsolventUserRequestCf,
-    },
     types::ManagedProvider,
     BlockchainService,
 };
@@ -320,26 +316,6 @@ where
                         error!(target: LOG_TARGET, "Forest root write task channel closed unexpectedly. Lock is released anyway!");
                     }
                 }
-
-                let state_store_context = self.persistent_state.open_rw_context_with_overlay();
-                state_store_context
-                    .access_value(&OngoingProcessFileDeletionRequestCf::<Runtime> {
-                        phantom: Default::default(),
-                    })
-                    .delete();
-                state_store_context
-                    .access_value(&OngoingProcessMspRespondStorageRequestCf::<Runtime> {
-                        phantom: Default::default(),
-                    })
-                    .delete();
-                state_store_context
-                    .access_value(
-                        &OngoingProcessStopStoringForInsolventUserRequestCf::<Runtime> {
-                            phantom: Default::default(),
-                        },
-                    )
-                    .delete();
-                state_store_context.commit();
             }
         }
 
@@ -552,53 +528,12 @@ where
         let (tx, rx) = tokio::sync::oneshot::channel();
         *forest_root_write_lock = Some(rx);
 
-        // If this is a respond storage request, stop storing for insolvent user request, or
-        // file deletion request, we need to store it in the state store.
-        let data = data.into();
-        match &data {
-            ForestWriteLockTaskData::MspRespondStorageRequest(data) => {
-                let state_store_context = self.persistent_state.open_rw_context_with_overlay();
-                state_store_context
-                    .access_value(&OngoingProcessMspRespondStorageRequestCf::<Runtime> {
-                        phantom: Default::default(),
-                    })
-                    .write(data);
-                state_store_context.commit();
-            }
-            ForestWriteLockTaskData::FileDeletionRequest(data) => {
-                let state_store_context = self.persistent_state.open_rw_context_with_overlay();
-                state_store_context
-                    .access_value(&OngoingProcessFileDeletionRequestCf::<Runtime> {
-                        phantom: Default::default(),
-                    })
-                    .write(data);
-                state_store_context.commit();
-            }
-            ForestWriteLockTaskData::StopStoringForInsolventUserRequest(data) => {
-                let state_store_context = self.persistent_state.open_rw_context_with_overlay();
-                state_store_context
-                    .access_value(
-                        &OngoingProcessStopStoringForInsolventUserRequestCf::<Runtime> {
-                            phantom: Default::default(),
-                        },
-                    )
-                    .write(data);
-                state_store_context.commit();
-            }
-            ForestWriteLockTaskData::ConfirmStoringRequest(_) => {
-                unreachable!("MSPs do not confirm storing requests the way BSPs do.")
-            }
-            ForestWriteLockTaskData::SubmitProofRequest(_) => {
-                unreachable!("MSPs do not submit proofs.")
-            }
-        }
-
         // This is an [`Arc<Mutex<Option<T>>>`] (in this case [`oneshot::Sender<()>`]) instead of just
         // T so that we can keep using the current actors event bus (emit) which requires Clone on the
         // event. Clone is required because there is no constraint on the number of listeners that can
         // subscribe to the event (and each is guaranteed to receive all emitted events).
         let forest_root_write_tx = Arc::new(Mutex::new(Some(tx)));
-        match data {
+        match data.into() {
             ForestWriteLockTaskData::MspRespondStorageRequest(data) => {
                 self.emit(ProcessMspRespondStoringRequest {
                     data,

--- a/client/blockchain-service/src/state.rs
+++ b/client/blockchain-service/src/state.rs
@@ -1,5 +1,3 @@
-// TODO: Consider removing the use of the typed store in BlockchainService.
-
 use log::info;
 use rocksdb::{ColumnFamilyDescriptor, Options, DB};
 use std::path::PathBuf;
@@ -14,15 +12,9 @@ use shc_common::{
     types::BlockNumber,
 };
 
-use crate::{
-    events::{
-        ProcessConfirmStoringRequestData, ProcessFileDeletionRequestData,
-        ProcessMspRespondStoringRequestData, ProcessStopStoringForInsolventUserRequestData,
-    },
-    types::{
-        ConfirmStoringRequest, FileDeletionRequest, RespondStorageRequest,
-        StopStoringForInsolventUserRequest,
-    },
+use crate::types::{
+    ConfirmStoringRequest, FileDeletionRequest, RespondStorageRequest,
+    StopStoringForInsolventUserRequest,
 };
 
 /// Last processed block number.
@@ -41,44 +33,6 @@ impl<Runtime: StorageEnableRuntime> SingleScaleEncodedValueCf
 pub struct LastProcessedBlockNumberName;
 impl LastProcessedBlockNumberName {
     pub const NAME: &'static str = "last_processed_block_number";
-}
-
-/// Current ongoing task which requires a forest write lock.
-pub struct OngoingProcessConfirmStoringRequestCf<Runtime: StorageEnableRuntime> {
-    pub(crate) phantom: std::marker::PhantomData<Runtime>,
-}
-impl<Runtime: StorageEnableRuntime> SingleScaleEncodedValueCf
-    for OngoingProcessConfirmStoringRequestCf<Runtime>
-{
-    type Value = ProcessConfirmStoringRequestData<Runtime>;
-
-    const SINGLE_SCALE_ENCODED_VALUE_NAME: &'static str =
-        OngoingProcessConfirmStoringRequestName::NAME;
-}
-
-/// Non-generic name holder for the `OngoingProcessConfirmStoringRequest` column family
-pub struct OngoingProcessConfirmStoringRequestName;
-impl OngoingProcessConfirmStoringRequestName {
-    pub const NAME: &'static str = "ongoing_process_confirm_storing_request";
-}
-
-/// Current ongoing task which requires a forest write lock.
-pub struct OngoingProcessStopStoringForInsolventUserRequestCf<Runtime: StorageEnableRuntime> {
-    pub(crate) phantom: std::marker::PhantomData<Runtime>,
-}
-impl<Runtime: StorageEnableRuntime> SingleScaleEncodedValueCf
-    for OngoingProcessStopStoringForInsolventUserRequestCf<Runtime>
-{
-    type Value = ProcessStopStoringForInsolventUserRequestData<Runtime>;
-
-    const SINGLE_SCALE_ENCODED_VALUE_NAME: &'static str =
-        OngoingProcessStopStoringForInsolventUserRequestName::NAME;
-}
-
-/// Non-generic name holder for the `OngoingProcessStopStoringForInsolventUserRequest` column family
-pub struct OngoingProcessStopStoringForInsolventUserRequestName;
-impl OngoingProcessStopStoringForInsolventUserRequestName {
-    pub const NAME: &'static str = "ongoing_process_stop_storing_for_insolvent_user_request";
 }
 
 /// Pending confirm storing requests.
@@ -165,24 +119,6 @@ impl SingleScaleEncodedValueCf for PendingConfirmStoringRequestRightIndexCf {
 pub struct PendingConfirmStoringRequestRightIndexName;
 impl PendingConfirmStoringRequestRightIndexName {
     pub const NAME: &'static str = "pending_confirm_storing_request_right_index";
-}
-
-pub struct OngoingProcessMspRespondStorageRequestCf<Runtime: StorageEnableRuntime> {
-    pub(crate) phantom: std::marker::PhantomData<Runtime>,
-}
-impl<Runtime: StorageEnableRuntime> SingleScaleEncodedValueCf
-    for OngoingProcessMspRespondStorageRequestCf<Runtime>
-{
-    type Value = ProcessMspRespondStoringRequestData<Runtime>;
-
-    const SINGLE_SCALE_ENCODED_VALUE_NAME: &'static str =
-        OngoingProcessMspRespondStorageRequestName::NAME;
-}
-
-/// Non-generic name holder for the `OngoingProcessMspRespondStorageRequest` column family
-pub struct OngoingProcessMspRespondStorageRequestName;
-impl OngoingProcessMspRespondStorageRequestName {
-    pub const NAME: &'static str = "ongoing_process_msp_respond_storage_request";
 }
 
 /// Pending respond storage requests.
@@ -274,25 +210,6 @@ impl PendingStopStoringForInsolventUserRequestRightIndexName {
     pub const NAME: &'static str = "pending_stop_storing_for_insolvent_user_request_right_index";
 }
 
-/// Current ongoing task which requires a forest write lock.
-pub struct OngoingProcessFileDeletionRequestCf<Runtime: StorageEnableRuntime> {
-    pub(crate) phantom: std::marker::PhantomData<Runtime>,
-}
-impl<Runtime: StorageEnableRuntime> SingleScaleEncodedValueCf
-    for OngoingProcessFileDeletionRequestCf<Runtime>
-{
-    type Value = ProcessFileDeletionRequestData<Runtime>;
-
-    const SINGLE_SCALE_ENCODED_VALUE_NAME: &'static str =
-        OngoingProcessFileDeletionRequestName::NAME;
-}
-
-/// Non-generic name holder for the `OngoingProcessFileDeletionRequest` column family
-pub struct OngoingProcessFileDeletionRequestName;
-impl OngoingProcessFileDeletionRequestName {
-    pub const NAME: &'static str = "ongoing_process_file_deletion_request";
-}
-
 /// Pending file deletion requests.
 pub struct FileDeletionRequestCf<Runtime: StorageEnableRuntime> {
     pub(crate) phantom: std::marker::PhantomData<Runtime>,
@@ -348,21 +265,17 @@ impl FileDeletionRequestRightIndexName {
     pub const NAME: &'static str = "pending_file_deletion_request_right_index";
 }
 
-const ALL_COLUMN_FAMILIES: [&str; 17] = [
+const ALL_COLUMN_FAMILIES: [&str; 13] = [
     LastProcessedBlockNumberName::NAME,
-    OngoingProcessConfirmStoringRequestName::NAME,
     PendingConfirmStoringRequestLeftIndexName::NAME,
     PendingConfirmStoringRequestRightIndexName::NAME,
     PendingConfirmStoringRequestName::NAME,
-    OngoingProcessMspRespondStorageRequestName::NAME,
     PendingMspRespondStorageRequestLeftIndexName::NAME,
     PendingMspRespondStorageRequestRightIndexName::NAME,
     PendingMspRespondStorageRequestName::NAME,
-    OngoingProcessStopStoringForInsolventUserRequestName::NAME,
     PendingStopStoringForInsolventUserRequestLeftIndexName::NAME,
     PendingStopStoringForInsolventUserRequestRightIndexName::NAME,
     PendingStopStoringForInsolventUserRequestName::NAME,
-    OngoingProcessFileDeletionRequestName::NAME,
     FileDeletionRequestLeftIndexName::NAME,
     FileDeletionRequestRightIndexName::NAME,
     FileDeletionRequestName::NAME,


### PR DESCRIPTION
We were keeping track of some ongoing tasks in the state store of the Blockchain Service, to be able to re-spawn them if the node crashes and re-starts. This generates more edge cases than the ones it solves, so I'm removing it.