### PR TITLE
test: :bug: Ensure BSP volunteered in upload file integration test

### DIFF
--- a/test/suites/integration/backend/upload-download-file.test.ts
+++ b/test/suites/integration/backend/upload-download-file.test.ts
@@ -199,9 +199,12 @@ await describeMspNet(
 
       // Make sure the accept transaction from the MSP is in the tx pool
       await userApi.wait.mspResponseInTxPool(1);
+      await userApi.wait.bspVolunteerInTxPool(1);
 
-      // Seal the block containing the MSP's acceptance
+      // Seal the block containing the MSP's acceptance and the BSP's volunteer
       await userApi.block.seal();
+
+      await userApi.assert.eventPresent("fileSystem", "AcceptedBspVolunteer");
 
       // Check that there's a `MspAcceptedStorageRequest` event
       const mspAcceptedStorageRequestEvent = await userApi.assert.eventPresent(


### PR DESCRIPTION
Hit an [error](https://github.com/Moonsong-Labs/storage-hub/actions/runs/18046378830/job/51358587248?pr=499) where the BSP confirmation transaction was not found in the transaction pool. 

This change will ensure that at least the volunteer extrinsic happened in the previous block which normally makes this flow deterministic.