### PR TITLE
style: :art: improve structure of the backend upload handler

### DIFF
--- a/backend/lib/src/api/handlers/files.rs
+++ b/backend/lib/src/api/handlers/files.rs
@@ -2,8 +2,6 @@
 //!
 //! TODO: move the rest of the endpoints as they are implemented
 
-#[cfg(not(feature = "mocks"))]
-use std::collections::HashSet;
 use std::io::Cursor;
 
 use axum::{
@@ -24,17 +22,10 @@ use tokio::fs::File;
 use tokio_util::io::ReaderStream;
 
 use shc_common::types::FileMetadata;
-#[cfg(not(feature = "mocks"))]
-use shc_common::types::{
-    ChunkId, StorageProofsMerkleTrieLayout, BATCH_CHUNK_FILE_TRANSFER_MAX_SIZE, FILE_CHUNK_SIZE,
-};
-#[cfg(not(feature = "mocks"))]
-use shc_file_manager::{in_memory::InMemoryFileDataTrie, traits::FileDataTrie};
-use shp_types::Hashing;
 
 use crate::{
     api::validation::extract_bearer_token, constants::mocks::MOCK_ADDRESS, error::Error,
-    models::files::FileUploadResponse, services::Services,
+    services::Services,
 };
 
 pub async fn get_file_info(
@@ -156,7 +147,6 @@ pub async fn download_by_key(
 /// and returns a mock success response without actual file processing.
 ///
 /// TODO: Further optimize this to avoid having to load the entire file into memory.
-#[cfg_attr(feature = "mocks", allow(unused_variables))]
 pub async fn upload_file(
     State(services): State<Services>,
     TypedHeader(auth): TypedHeader<Authorization<Bearer>>,
@@ -221,184 +211,11 @@ pub async fn upload_file(
         Error::BadRequest("Missing 'file_metadata' field in multipart data".to_string())
     })?;
 
-    // Validate that the bucket ID received in the URL matches the bucket ID in the file metadata.
-    let expected_bucket_id = hex::encode(file_metadata.bucket_id());
-    if bucket_id.trim_start_matches("0x") != expected_bucket_id {
-        return Err(Error::BadRequest(
-            "Bucket ID in URL does not match file metadata".to_string(),
-        ));
-    }
-
-    // Generate the file key from the obtained file metadata and ensure it matches the file key received in the URL.
-    let expected_file_key = hex::encode(file_metadata.file_key::<Hashing>());
-    if file_key.trim_start_matches("0x") != expected_file_key {
-        return Err(Error::BadRequest(
-            "File key in URL does not match file metadata".to_string(),
-        ));
-    }
-
-    process_upload_after_validation(
-        file_data_stream,
-        file_metadata,
-        &bucket_id,
-        &file_key,
-        &services,
-    )
-    .await
-}
-
-#[cfg(feature = "mocks")]
-async fn process_upload_after_validation(
-    file_data_stream: Field,
-    file_metadata: FileMetadata,
-    bucket_id: &str,
-    file_key: &str,
-    _services: &Services,
-) -> Result<impl IntoResponse, Error> {
-    // Consume the file field to ensure it is correct
-
-    let _file_bytes = file_data_stream
-        .bytes()
-        .await
-        .map_err(|e| Error::BadRequest(format!("Failed to read file: {}", e)))?;
-
-    // Return a mock success response
-    let bytes_location = file_metadata.location().clone();
-    let location = str::from_utf8(&bytes_location)
-        .unwrap_or(file_key)
-        .to_string();
-    let response = FileUploadResponse {
-        status: "upload_successful".to_string(),
-        file_key: file_key.to_string(),
-        bucket_id: bucket_id.to_string(),
-        fingerprint: hex::encode(file_metadata.fingerprint().as_ref()),
-        location,
-    };
-
-    Ok((StatusCode::CREATED, Json(response)))
-}
-
-#[cfg(not(feature = "mocks"))]
-async fn process_upload_after_validation(
-    mut file_data_stream: Field,
-    file_metadata: FileMetadata,
-    bucket_id: &str,
-    file_key: &str,
-    services: &Services,
-) -> Result<impl IntoResponse, Error> {
-    // Initialize the trie that will hold the chunked file data.
-    let mut trie = InMemoryFileDataTrie::<StorageProofsMerkleTrieLayout>::new();
-
-    // Prepare the overflow buffer that will hold any data that doesn't exactly fit in a chunk.
-    let mut overflow_buffer = Vec::new();
-
-    // Initialize the chunk index.
-    let mut chunk_index = 0;
-
-    // Start streaming the file data into the trie, chunking it into FILE_CHUNK_SIZE chunks in the process.
-    while let Some(bytes_read) = file_data_stream
-        .chunk()
-        .await
-        .map_err(|e| Error::BadRequest(e.to_string()))?
-    {
-        // Load the bytes read from the file into the overflow buffer.
-        overflow_buffer.extend_from_slice(&bytes_read);
-
-        // While the overflow buffer is larger than FILE_CHUNK_SIZE, process a chunk.
-        while overflow_buffer.len() >= FILE_CHUNK_SIZE as usize {
-            let chunk = overflow_buffer[..FILE_CHUNK_SIZE as usize].to_vec();
-
-            // Insert the chunk into the trie.
-            trie.write_chunk(&ChunkId::new(chunk_index as u64), &chunk)
-                .map_err(|e| Error::BadRequest(e.to_string()))?;
-
-            // Increment the chunk index.
-            chunk_index += 1;
-
-            // Remove the chunk from the overflow buffer.
-            overflow_buffer.drain(..FILE_CHUNK_SIZE as usize);
-        }
-    }
-
-    // Check the overflow buffer to see if the file didn't fit exactly in an integer number of chunks.
-    if !overflow_buffer.is_empty() {
-        // Insert the chunk into the trie.
-        trie.write_chunk(&ChunkId::new(chunk_index as u64), &overflow_buffer)
-            .map_err(|e| Error::BadRequest(e.to_string()))?;
-
-        // Increment the chunk index to get the total amount of chunks.
-        chunk_index += 1;
-    }
-
-    // Validate that the file fingerprint matches the trie root.
-    let computed_root = trie.get_root();
-    if computed_root.as_ref() != file_metadata.fingerprint().as_ref() {
-        return Err(Error::BadRequest(format!(
-            "File fingerprint mismatch. Expected: {}, Computed: {}",
-            hex::encode(file_metadata.fingerprint().as_ref()),
-            hex::encode(computed_root)
-        )));
-    }
-
-    // Validate that the received amount of chunks matches the amount of chunks corresponding to the file size in the metadata.
-    let total_chunks = file_metadata.chunks_count();
-    if chunk_index != total_chunks {
-        return Err(Error::BadRequest(format!(
-            "Received amount of chunks {} does not match the amount of chunks {} corresponding to the file size in the metadata",
-            chunk_index, total_chunks
-        )));
-    }
-
-    // At this point, the trie contains the entire file data and we can start generating the proofs for the chunk batches
-    // and sending them to the MSP.
-
-    // Get how many chunks fit in a batch of BATCH_CHUNK_FILE_TRANSFER_MAX_SIZE, rounding down.
-    const CHUNKS_PER_BATCH: u64 = BATCH_CHUNK_FILE_TRANSFER_MAX_SIZE as u64 / FILE_CHUNK_SIZE;
-
-    // Initialize the index of the initial chunk to process in this batch.
-    let mut batch_start_chunk_index = 0;
-
-    // Start processing batches, until all chunks have been processed.
-    while batch_start_chunk_index < total_chunks {
-        // Get the chunks to send in this batch, capping at the total amount of chunks of the file.
-        let chunks = (batch_start_chunk_index
-            ..(batch_start_chunk_index + CHUNKS_PER_BATCH).min(total_chunks))
-            .map(|chunk_index| ChunkId::new(chunk_index as u64))
-            .collect::<HashSet<_>>();
-        let chunks_in_batch = chunks.len() as u64;
-
-        // Generate the proof for the batch.
-        let file_proof = trie
-            .generate_proof(&chunks)
-            .map_err(|e| Error::BadRequest(e.to_string()))?;
-
-        // Convert the generated proof to a FileKeyProof and send it to the MSP.
-        let file_key_proof = file_proof
-            .to_file_key_proof(file_metadata.clone())
-            .map_err(|e| Error::BadRequest(format!("Failed to convert proof: {:?}", e)))?;
-
-        services
-            .msp
-            .upload_to_msp(&chunks, &file_key_proof)
-            .await
-            .map_err(|e| Error::BadRequest(e.to_string()))?;
-
-        // Update the initial chunk index for the next batch.
-        batch_start_chunk_index += chunks_in_batch;
-    }
-
-    // If the complete file was uploaded to the MSP successfully, we can return the response.
-    let bytes_location = file_metadata.location().clone();
-    let location = str::from_utf8(&bytes_location)
-        .unwrap_or(file_key)
-        .to_string();
-    let response = FileUploadResponse {
-        status: "upload_successful".to_string(),
-        file_key: file_key.to_string(),
-        bucket_id: bucket_id.to_string(),
-        fingerprint: format!("0x{}", hex::encode(trie.get_root())),
-        location,
-    };
+    // Process and upload the file using the MSP service
+    let response = services
+        .msp
+        .process_and_upload_file(&bucket_id, &file_key, file_data_stream, file_metadata)
+        .await?;
 
     Ok((StatusCode::CREATED, Json(response)))
 }

--- a/backend/lib/src/data/rpc/mock_connection.rs
+++ b/backend/lib/src/data/rpc/mock_connection.rs
@@ -204,6 +204,7 @@ impl RpcConnection for MockConnection {
         let response: Value = match method {
             "storagehubclient_saveFileToDisk" => self.mock_save_file_to_disk(params).await,
             "storagehubclient_isFileKeyExpected" => serde_json::json!(true),
+            "storagehubclient_receiveBackendFileChunks" => serde_json::json!([]),
             _ => {
                 let responses = self.responses.read().await;
                 responses

--- a/backend/lib/src/services/msp.rs
+++ b/backend/lib/src/services/msp.rs
@@ -4,11 +4,16 @@
 
 use std::{collections::HashSet, sync::Arc};
 
+use axum_extra::extract::multipart::Field;
 use chrono::Utc;
 use codec::Encode;
 use sc_network::PeerId;
 use serde::{Deserialize, Serialize};
-use shc_common::types::{ChunkId, FileKeyProof};
+use shc_common::types::{
+    ChunkId, FileKeyProof, FileMetadata, StorageProofsMerkleTrieLayout,
+    BATCH_CHUNK_FILE_TRANSFER_MAX_SIZE, FILE_CHUNK_SIZE,
+};
+use shc_file_manager::{in_memory::InMemoryFileDataTrie, traits::FileDataTrie};
 use shc_rpc::SaveFileToDisk;
 use sp_core::{Blake2Hasher, H256};
 use tracing::{debug, info, warn};
@@ -25,7 +30,7 @@ use crate::{
     error::Error,
     models::{
         buckets::{Bucket, FileTree},
-        files::{DistributeResponse, FileInfo},
+        files::{DistributeResponse, FileInfo, FileUploadResponse},
         msp_info::{Capacity, InfoResponse, MspHealthResponse, StatsResponse, ValueProp},
         payment::PaymentStream,
     },
@@ -329,6 +334,143 @@ impl MspService {
                 })
             }
         }
+    }
+
+    /// Process a streamed file upload: validate metadata, chunk into trie, batch proofs, and send to MSP.
+    pub async fn process_and_upload_file(
+        &self,
+        bucket_id: &str,
+        file_key: &str,
+        mut file_data_stream: Field,
+        file_metadata: FileMetadata,
+    ) -> Result<FileUploadResponse, Error> {
+        // Validate bucket id and file key against metadata
+        let expected_bucket_id = hex::encode(file_metadata.bucket_id());
+        if bucket_id.trim_start_matches("0x") != expected_bucket_id {
+            return Err(Error::BadRequest(
+                "Bucket ID in URL does not match file metadata".to_string(),
+            ));
+        }
+
+        let expected_file_key = hex::encode(file_metadata.file_key::<Blake2Hasher>());
+        if file_key.trim_start_matches("0x") != expected_file_key {
+            return Err(Error::BadRequest(
+                "File key in URL does not match file metadata".to_string(),
+            ));
+        }
+
+        // Initialize the trie that will hold the chunked file data.
+        let mut trie = InMemoryFileDataTrie::<StorageProofsMerkleTrieLayout>::new();
+
+        // Prepare the overflow buffer that will hold any data that doesn't exactly fit in a chunk.
+        let mut overflow_buffer = Vec::new();
+
+        // Initialize the chunk index.
+        let mut chunk_index = 0;
+
+        // Start streaming the file data into the trie, chunking it into FILE_CHUNK_SIZE chunks in the process.
+        while let Some(bytes_read) = file_data_stream
+            .chunk()
+            .await
+            .map_err(|e| Error::BadRequest(e.to_string()))?
+        {
+            // Load the bytes read from the file into the overflow buffer.
+            overflow_buffer.extend_from_slice(&bytes_read);
+
+            // While the overflow buffer is larger than FILE_CHUNK_SIZE, process a chunk.
+            while overflow_buffer.len() >= FILE_CHUNK_SIZE as usize {
+                let chunk = overflow_buffer[..FILE_CHUNK_SIZE as usize].to_vec();
+
+                // Insert the chunk into the trie.
+                trie.write_chunk(&ChunkId::new(chunk_index as u64), &chunk)
+                    .map_err(|e| Error::BadRequest(e.to_string()))?;
+
+                // Increment the chunk index.
+                chunk_index += 1;
+
+                // Remove the chunk from the overflow buffer.
+                overflow_buffer.drain(..FILE_CHUNK_SIZE as usize);
+            }
+        }
+
+        // Check the overflow buffer to see if the file didn't fit exactly in an integer number of chunks.
+        if !overflow_buffer.is_empty() {
+            // Insert the chunk into the trie.
+            trie.write_chunk(&ChunkId::new(chunk_index as u64), &overflow_buffer)
+                .map_err(|e| Error::BadRequest(e.to_string()))?;
+
+            // Increment the chunk index to get the total amount of chunks.
+            chunk_index += 1;
+        }
+
+        // Validate that the file fingerprint matches the trie root.
+        let computed_root = trie.get_root();
+        if computed_root.as_ref() != file_metadata.fingerprint().as_ref() {
+            return Err(Error::BadRequest(format!(
+                "File fingerprint mismatch. Expected: {}, Computed: {}",
+                hex::encode(file_metadata.fingerprint().as_ref()),
+                hex::encode(computed_root)
+            )));
+        }
+
+        // Validate that the received amount of chunks matches the amount of chunks corresponding to the file size in the metadata.
+        let total_chunks = file_metadata.chunks_count();
+        if chunk_index != total_chunks {
+            return Err(Error::BadRequest(format!(
+            "Received amount of chunks {} does not match the amount of chunks {} corresponding to the file size in the metadata",
+            chunk_index, total_chunks
+        )));
+        }
+
+        // At this point, the trie contains the entire file data and we can start generating the proofs for the chunk batches
+        // and sending them to the MSP.
+
+        // Get how many chunks fit in a batch of BATCH_CHUNK_FILE_TRANSFER_MAX_SIZE, rounding down.
+        const CHUNKS_PER_BATCH: u64 = BATCH_CHUNK_FILE_TRANSFER_MAX_SIZE as u64 / FILE_CHUNK_SIZE;
+
+        // Initialize the index of the initial chunk to process in this batch.
+        let mut batch_start_chunk_index = 0;
+
+        // Start processing batches, until all chunks have been processed.
+        while batch_start_chunk_index < total_chunks {
+            // Get the chunks to send in this batch, capping at the total amount of chunks of the file.
+            let chunks = (batch_start_chunk_index
+                ..(batch_start_chunk_index + CHUNKS_PER_BATCH).min(total_chunks))
+                .map(|chunk_index| ChunkId::new(chunk_index as u64))
+                .collect::<HashSet<_>>();
+            let chunks_in_batch = chunks.len() as u64;
+
+            // Generate the proof for the batch.
+            let file_proof = trie
+                .generate_proof(&chunks)
+                .map_err(|e| Error::BadRequest(e.to_string()))?;
+
+            // Convert the generated proof to a FileKeyProof and send it to the MSP.
+            let file_key_proof = file_proof
+                .to_file_key_proof(file_metadata.clone())
+                .map_err(|e| Error::BadRequest(format!("Failed to convert proof: {:?}", e)))?;
+
+            // Send the proof with the chunks to the MSP.
+            self.upload_to_msp(&chunks, &file_key_proof)
+                .await
+                .map_err(|e| Error::BadRequest(e.to_string()))?;
+
+            // Update the initial chunk index for the next batch.
+            batch_start_chunk_index += chunks_in_batch;
+        }
+
+        // If the complete file was uploaded to the MSP successfully, we can return the response.
+        let bytes_location = file_metadata.location().clone();
+        let location = str::from_utf8(&bytes_location)
+            .unwrap_or(file_key)
+            .to_string();
+        Ok(FileUploadResponse {
+            status: "upload_successful".to_string(),
+            file_key: file_key.to_string(),
+            bucket_id: bucket_id.to_string(),
+            fingerprint: format!("0x{}", hex::encode(trie.get_root())),
+            location,
+        })
     }
 
     /// Upload a batch of file chunks with their FileKeyProof to the MSP via its RPC.


### PR DESCRIPTION
This PR:
- Removes the `mocks` flag from the upload handler. Now, like other endpoints, only mocks the RPC calls.
- Extracts the functionality and moves it to the MSP service, to avoid having the endpoint handler too cluttered.