### PR TITLE
fix: FileList response type

### DIFF
--- a/sdk/msp-client/src/index.ts
+++ b/sdk/msp-client/src/index.ts
@@ -4,7 +4,7 @@ export type {
   Capacity,
   DownloadOptions,
   DownloadResult,
-  FileEntry,
+  FileTree,
   FileInfo,
   FileListResponse,
   HealthStatus,

--- a/sdk/msp-client/src/types.ts
+++ b/sdk/msp-client/src/types.ts
@@ -108,18 +108,16 @@ export interface Bucket {
   fileCount: number;
 }
 
-export type FileEntryType = "file" | "folder" | string;
-
-export interface FileEntry {
+export type FileTree = {
   name: string;
-  type: FileEntryType;
-  sizeBytes?: number;
-  fileKey?: string;
-}
+} & (
+    | { type: "file"; sizeBytes: number; fileKey: string }
+    | { type: "folder"; children: FileTree[] }
+  );
 
 export interface FileListResponse {
   bucketId: string;
-  files: FileEntry[];
+  files: FileTree[];
 }
 
 export interface GetFilesOptions {


### PR DESCRIPTION
FileListResponse type didn't contain children field in its type definition