### PR TITLE
fix: :bug: update call to init wasm to use object as parameter for the wasm blob

### DIFF
--- a/sdk/core/src/init.ts
+++ b/sdk/core/src/init.ts
@@ -63,7 +63,7 @@ export async function initWasm(): Promise<void> {
       throw new Error("Embedded WASM is missing or empty. Ensure build generated _wasm_embed.ts.");
     }
     const bytes = decodeBase64ToBytes(b64);
-    await wasmInit(bytes);
+    await wasmInit({ module_or_path: bytes });
     return;
   })();
 


### PR DESCRIPTION
Microfix as when the SDK was initializing the WASM we were getting a `deprecated` warning, since we are now expecting an object with `module_or_path` instead of directly the WASM blob bytes.