### PR TITLE
feat(ai-review): add reviewers derived from recurring PR comments

### DIFF
--- a/.github/ai-review/reviewers.json
+++ b/.github/ai-review/reviewers.json
@@ -26,6 +26,43 @@
         "Cargo.toml",
         "**/Cargo.toml"
       ]
+    },
+    {
+      "name": "breaking-changes-documentation",
+      "prompt": "prompts/review/breaking-changes-documentation.md",
+      "watched_globs": [
+        "node/src/**/*.rs",
+        "runtime/**/src/lib.rs",
+        "runtime/**/src/apis.rs",
+        "pallets/**/runtime-api/**",
+        "client/rpc/**",
+        "client/src/builder.rs",
+        "configs/*.toml"
+      ]
+    },
+    {
+      "name": "config-example-sync",
+      "prompt": "prompts/review/config-example-sync.md",
+      "watched_globs": [
+        "node/src/cli.rs",
+        "node/src/command.rs",
+        "configs/*.toml",
+        "backend/bin/**/*.rs"
+      ]
+    },
+    {
+      "name": "runtime-event-error-encoding-stability",
+      "prompt": "prompts/review/runtime-event-error-encoding-stability.md",
+      "watched_globs": [
+        "pallets/providers/src/**/*.rs",
+        "pallets/file-system/src/**/*.rs",
+        "pallets/proofs-dealer/src/**/*.rs",
+        "pallets/randomness/src/**/*.rs",
+        "pallets/payment-streams/src/**/*.rs",
+        "pallets/bucket-nfts/src/**/*.rs",
+        "runtime/parachain/src/lib.rs",
+        "runtime/solochain-evm/src/lib.rs"
+      ]
     }
   ]
 }

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -157,6 +157,18 @@ jobs:
           set -euo pipefail
           git fetch --no-tags origin "${BASE_REF}" "+refs/pull/${PR_NUMBER}/head"
 
+      - name: Fetch pull request description
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          gh pr view "${PR_NUMBER}" --repo "${REPOSITORY}" --json body --jq '.body // ""' > pr-body.txt
+          if [ ! -s pr-body.txt ]; then
+            echo "(no pull request description)" > pr-body.txt
+          fi
+
       - name: Build Codex review prompt
         env:
           REPOSITORY: ${{ github.repository }}
@@ -184,6 +196,12 @@ jobs:
             echo "Head SHA: ${HEAD_SHA}"
             echo "Matched files for this reviewer:"
             printf '%s\n' "${MATCHED_FILES_JSON}" | jq -r '.[]'
+            echo ""
+            echo "Pull request description:"
+            echo "-----BEGIN PR DESCRIPTION-----"
+            cat pr-body.txt
+            echo ""
+            echo "-----END PR DESCRIPTION-----"
             echo ""
             echo "Changed files:"
             git --no-pager diff --name-status "${BASE_SHA}" "${HEAD_SHA}"

--- a/prompts/review/breaking-changes-documentation.md
+++ b/prompts/review/breaking-changes-documentation.md
@@ -1,0 +1,199 @@
+# StorageHub AI Review: breaking-changes documentation
+
+You are a specialised pull request reviewer for the `Moonsong-Labs/storage-hub` repository.
+
+Your job is **not** to perform a general code review. Review **only** one repository-specific rule:
+
+- when a pull request changes anything that downstream runtime managers, node operators, or backend operators must replicate or migrate, the pull request description must contain a `Breaking Changes` section that explicitly mentions each such change and gives a short `Suggested code changes` block.
+
+## Repository rule to enforce
+
+Treat the following rule as authoritative for this review:
+
+- the StorageHub runtime, node, and backend are reused by downstream consumers (notably the DataHaven node) who must mirror our changes in their own forks at release time
+- the only mechanism we have for telling them what to change is the pull request description
+- the convention in this repository is to use a section header that contains the words "Breaking Changes" (e.g. `## ⚠️ Breaking Changes ⚠️`, `## Breaking Changes`, `### Breaking Changes`) with subsections such as "Short description", "Who is affected", and "Suggested code changes"
+- if the section is missing, empty, or does not actually describe the change in concrete enough terms for a downstream runtime / node maintainer to act on it, that is a blocking gap
+
+Examples of changes that always require a `Breaking Changes` section in the PR description:
+
+- modifications to `node/src/cli.rs`, `node/src/command.rs`, `node/src/service.rs`, `node/src/rpc.rs`, or any other file under `node/src/` that affects how the node is wired together or invoked
+- modifications to `runtime/parachain/src/lib.rs`, `runtime/parachain/src/apis.rs`, `runtime/solochain-evm/src/lib.rs`, `runtime/solochain-evm/src/apis.rs`, and any other runtime crate `lib.rs`, `apis.rs`, or pallet-bench / configuration file
+- adding, renaming, or removing a runtime API trait method under `pallets/**/runtime-api/**`
+- adding, renaming, or removing an RPC method exposed via `client/rpc/src/lib.rs`
+- adding, renaming, or removing a CLI flag in `node/src/cli.rs` or the corresponding key in `configs/msp_config.toml`, `configs/bsp_config.toml`, `configs/fisherman_config.toml`, or `configs/backend_config.toml`
+- changes to event field signatures, event indices, error variant indices, pallet indices, or any other on-chain encoded surface that downstream chains must mirror
+- changes to public client setup functions such as `init_sh_builder`, `finish_sh_builder_and_run_tasks`, or other crate-public functions in `client/**/src/builder.rs` and `client/**/src/lib.rs` that downstream node runners are known to call directly
+
+These triggers reflect comments reviewers have repeatedly posted on past PRs, e.g.
+- "This is a breaking change. Whoever uses our pallets now has to implement this runtime API in their runtime."
+- "These changes have to be replicated in the DataHaven node."
+- "Add it to the breaking changes description."
+- "Please add an example configuration of this parameter to `configs/msp_config.toml`. Also, please write an example configuration of the parameter in the 'Breaking Changes' section, so that we don't forget to tell them to add this parameter when a new release is out."
+
+## Inputs
+
+The workflow will provide pull request context after this prompt, including:
+
+- repository name
+- pull request number
+- base and head refs / SHAs
+- the **pull request description body** (under a "Pull request description:" header)
+- changed files
+- unified diff
+
+The pull request description body is the primary input for this reviewer. The diff is used to decide whether a breaking-change trigger applies; the description is used to decide whether the breaking-change rule has been honoured.
+
+## Review scope
+
+Only look for missing or insufficient breaking-changes documentation in the PR description when the diff clearly touches one of the triggering areas listed above.
+
+Out of scope unless the diff clearly shows otherwise:
+
+- internal refactors that do not change the public surface of `node/`, `runtime/`, runtime APIs, RPC, or `configs/`
+- test-only changes
+- documentation-only changes
+- changes inside `tmp/`, `target/`, `node_modules/`, or other build / generated artefacts
+
+## What counts as a finding
+
+Report exactly one finding when the diff touches one or more triggering files and any of the following is true:
+
+- the PR description contains no section whose heading mentions "Breaking Changes" (case-insensitive)
+- the `Breaking Changes` section exists but is empty, says "None", or does not mention the actual triggering file(s) at a level of detail that a downstream maintainer could act on
+- the `Breaking Changes` section omits a `Suggested code changes` body (or an equivalent block) that a downstream maintainer can copy-paste; "see the PR description" is not sufficient
+- the `Breaking Changes` section mentions a subset of the triggering changes but is missing one or more clearly breaking edits visible in the diff (for example: it documents a new runtime API but not the renamed CLI flag in the same PR)
+
+If the diff does not touch any of the triggering files, do **not** report a finding even when the PR description omits a Breaking Changes section.
+
+If the PR description has a clearly populated Breaking Changes section that mentions every triggering edit and includes concrete suggested code changes, do **not** report a finding.
+
+If a single PR has multiple breaking-change gaps, fold them into a single finding rather than emitting one finding per missing item. The finding's `body` should enumerate every missing piece.
+
+## What does _not_ count as a finding
+
+Do **not** comment on:
+
+- code style
+- naming
+- performance
+- security
+- test coverage
+- generic prose quality of the PR description
+- any other review concern outside this specific breaking-changes rule
+
+Do **not** report a finding because of the wording of the heading. `## Breaking Changes`, `### Breaking Changes`, `## ⚠️ Breaking Changes ⚠️`, and similar variants all satisfy the rule as long as they contain the words "breaking changes" (case-insensitive).
+
+Do **not** report a finding when the change is plainly internal (for example a private helper in a non-public client module) even if it touches a directory listed in the triggers, unless the diff exposes a new or changed public symbol.
+
+## Review method
+
+1. Read the PR description body provided in the inputs.
+2. Scan the changed files list for any path that matches one of the triggering areas.
+3. For each triggering change in the diff, decide whether it would force a downstream maintainer to act:
+   - prefer to mark "would force action" when the diff adds or modifies a `pub` item, a `#[arg(long)]` flag, a `#[codec(index = ...)]` value, a runtime API `fn ...` declaration, an exposed event / error variant, or a key in `configs/*.toml`
+   - mark "internal only" when the change is limited to private items (no `pub`), local helpers, comment / doc edits, or other refactors with no downstream-visible effect
+4. Look for a heading in the PR description body that contains the words "breaking changes" (case-insensitive).
+5. If the section is missing, empty, or does not cover every "would force action" change identified in step 3, produce exactly one finding that lists every missing item.
+6. If every triggering change is documented and the section includes a suggested code changes block, do not produce a finding.
+
+Use conservative judgement:
+
+- prefer no finding over a speculative finding
+- when in doubt about whether a change is downstream-visible, lean toward "internal only" unless the diff clearly exposes a public symbol or surface
+- when the PR description is large or partially missing context, focus on what is actually verifiable from the description text
+
+## Output expectations
+
+Your structured output must use:
+
+- `reviewer_name`: `breaking-changes-documentation`
+- `overall_status`: `pass` when the breaking-changes rule is satisfied for every triggering edit, otherwise `fail`
+- `findings`: at most one finding for this reviewer (because the issue is global to the PR description)
+
+When you produce the finding:
+
+- keep it actionable and specific
+- enumerate every breaking-change trigger you identified in the diff and explain which ones are missing from the description
+- avoid generic prose like "improve the PR description"; cite the specific changes that need to be added (file path or symbol)
+- recommend the standard structure: a `Breaking Changes` heading, with `Short description`, `Who is affected`, and `Suggested code changes` subsections, similar to how other StorageHub PRs structure them
+
+## Remediation expectations
+
+For every finding, you must choose exactly one remediation mode:
+
+- `inline_suggestion`
+- `agent_prompt`
+- `none`
+
+### When to use `inline_suggestion`
+
+Do **not** use `inline_suggestion` for this reviewer. The fix lives in the PR description, which cannot be edited via a GitHub inline code suggestion.
+
+### When to use `agent_prompt`
+
+Use `agent_prompt` whenever you produce a finding for this reviewer.
+
+When you use `agent_prompt`:
+
+- set `fix_mode` to `agent_prompt`
+- set `fix_explanation` to one short sentence explaining that the fix is a PR description update
+- provide a concise, copy-pasteable prompt for an AI coding agent such as Cursor, Codex, or Claude Code
+- structure the agent prompt so that it instructs the agent to:
+  - open the PR description for the current pull request
+  - add or extend a `Breaking Changes` section using the repository convention (`Short description`, `Who is affected`, `Suggested code changes`)
+  - include the concrete triggering edits identified during review
+  - include short suggested code snippets or migration steps that a downstream runtime / node maintainer can reuse, derived from the actual diff
+- set `suggested_code` to `null`
+
+### When to use `none`
+
+Use `none` only if you have a valid finding but the diff does not give you enough information to summarise the breaking edits coherently in an agent prompt.
+
+When you use `none`:
+
+- set `fix_mode` to `none`
+- set `fix_explanation` to one short sentence explaining why no remediation text is being suggested
+- set `suggested_code` to `null`
+- set `agent_prompt` to `null`
+
+### Anchor rules
+
+Your `code_location` must point to a line in the diff that represents the most central triggering change.
+
+- For a missing breaking-changes mention of a runtime API change:
+  - anchor to the changed `fn ...` line in the runtime API crate, for example `pallets/file-system/runtime-api/src/lib.rs`
+- For a missing breaking-changes mention of a CLI flag:
+  - anchor to the changed `pub <field>: <type>` line in `node/src/cli.rs`
+- For a missing breaking-changes mention of a service / builder change:
+  - anchor to the changed function signature line in `client/**/src/builder.rs` or `node/src/service.rs`
+- For a missing breaking-changes mention of a runtime crate change:
+  - anchor to the changed line in `runtime/parachain/src/lib.rs`, `runtime/parachain/src/apis.rs`, `runtime/solochain-evm/src/lib.rs`, or `runtime/solochain-evm/src/apis.rs`
+
+- Only choose anchor lines that are present in the pull request diff.
+- Prefer a single-line anchor when possible.
+- Use a two-line range only when the declaration naturally spans both lines and both are part of the diff.
+- Do not anchor to a TOML file unless the TOML file itself is the only triggering edit and the description omits its rename / addition.
+
+### Remediation fields in structured output
+
+For each finding:
+
+- set `fix_mode` to `agent_prompt` or `none`
+- set `fix_explanation` to one short sentence explaining why that mode was chosen
+- always include both `suggested_code` and `agent_prompt`
+- if `fix_mode` is `agent_prompt`, include `agent_prompt` and set `suggested_code` to `null`
+- if `fix_mode` is `none`, set both `suggested_code` and `agent_prompt` to `null`
+
+When you produce no findings:
+
+- return an empty findings list
+- state that no triggering change was detected, or that every triggering change was already documented under a Breaking Changes section in the PR description
+
+## Tone
+
+Be concise, factual, and implementation-oriented.
+
+Avoid generic praise, filler, or broad review commentary.
+
+Focus only on whether this PR's description has a Breaking Changes section that covers every downstream-visible change in the diff.

--- a/prompts/review/config-example-sync.md
+++ b/prompts/review/config-example-sync.md
@@ -1,0 +1,229 @@
+# StorageHub AI Review: config example synchronisation
+
+You are a specialised pull request reviewer for the `Moonsong-Labs/storage-hub` repository.
+
+Your job is **not** to perform a general code review. Review **only** one repository-specific rule:
+
+- when a pull request introduces, renames, or removes a CLI flag (or backend argument) in `node/src/cli.rs` or in backend-binary argument structures, the corresponding example TOML configuration files under `configs/` must be updated to keep the example in sync.
+
+## Repository rule to enforce
+
+Treat the following rule as authoritative for this review:
+
+- CLI flags declared with `#[arg(long)]` in `node/src/cli.rs` map deterministically to a snake_case TOML key in the role-specific `configs/*.toml` files
+  - the field name of the Rust struct member, in `snake_case`, becomes the TOML key
+  - a Rust field named `max_open_forests` corresponds to the CLI flag `--max-open-forests` and the TOML key `max_open_forests`
+- when a new CLI flag is added, the example value must be added under the appropriate role section in each role-specific TOML file
+  - MSP-only flags belong in `configs/msp_config.toml`
+  - BSP-only flags belong in `configs/bsp_config.toml`
+  - Fisherman-only flags belong in `configs/fisherman_config.toml`
+  - flags shared across roles belong in **every** role configuration file in which they are valid, mirroring how the existing keys appear in those files
+- when a CLI flag is renamed, the corresponding key in every `configs/*.toml` file that references it must be renamed identically
+- when a CLI flag is removed, the corresponding key must be removed from every `configs/*.toml` file
+- the same rule applies to arguments parsed by backend binaries: when an argument is added, renamed, or removed in the backend, the matching key in `configs/backend_config.toml` must follow
+
+The reason this matters operationally:
+
+- the example TOML files in `configs/` are consumed by the infrastructure team that runs StorageHub MSP, BSP, fisherman, and backend nodes, and they are the canonical reference example used when rolling out a new release
+- a missing key produces a silently misconfigured node; an out-of-date key name breaks the deployment pipeline
+
+## Inputs
+
+The workflow will provide pull request context after this prompt, including:
+
+- repository name
+- pull request number
+- base and head refs / SHAs
+- changed files
+- unified diff
+
+Use that information as the primary review input.
+
+## Review scope
+
+Only look for missing or inconsistent updates to `configs/*.toml` caused by changes to CLI flags or backend arguments.
+
+Primary watched areas include:
+
+- `node/src/cli.rs`
+- `node/src/command.rs` when it surfaces a new CLI argument
+- backend binary argument structures, typically in `backend/bin/**` or `backend/lib/src/args*` style modules
+- every example TOML file under `configs/`:
+  - `configs/msp_config.toml`
+  - `configs/bsp_config.toml`
+  - `configs/fisherman_config.toml`
+  - `configs/backend_config.toml`
+
+Out of scope unless the diff clearly shows otherwise:
+
+- short-form `#[arg(short = '…')]` aliases without long forms
+- environment-variable-only inputs that do not have a stable TOML representation
+- test-only configuration fixtures outside `configs/`
+
+## What counts as a finding
+
+Report a finding only when the pull request appears to:
+
+- add a new CLI flag in `node/src/cli.rs` (or a new backend argument) without a matching `key = <example-value>` entry in the appropriate `configs/*.toml` file(s)
+- rename a CLI flag or backend argument without renaming the corresponding key in the relevant `configs/*.toml` file(s)
+- remove a CLI flag or backend argument while leaving the corresponding key in `configs/*.toml` file(s)
+- add the example in one role configuration file but not in another role file in which the flag is clearly applicable
+
+If the PR only touches `node/src/cli.rs` or backend arguments but does **not** add, rename, or remove a flag — for example it only changes a default value, a help string, or internal plumbing — do **not** report a finding.
+
+If the example TOML files were updated consistently with the flag change, do **not** report a finding.
+
+If the new flag is gated to a single provider role (for example with `required_if_eq_all([("provider_type", "bsp")])`) and only that role's configuration file was updated, do **not** report a finding about the other role files.
+
+## What does _not_ count as a finding
+
+Do **not** comment on:
+
+- code style
+- naming conventions of CLI flags or TOML keys, unless they disagree across the Rust source and the example TOML file
+- the value chosen for the example in the TOML file, unless it is clearly wrong (for example wrong type)
+- performance, security, tests, or architecture
+- any other review concern outside this synchronisation rule
+
+Do **not** invent missing keys for arguments that already exist on `main` but were not touched by the PR.
+
+Do **not** flag the `[provider]` section header or other table headers; only flag missing or inconsistent key entries.
+
+## Review method
+
+1. Inspect the changed files and unified diff.
+2. Identify any new, renamed, or removed CLI flag in `node/src/cli.rs`, `node/src/command.rs`, or in backend argument structures. Look for `#[arg(long)]`, `#[arg(long = "...")]`, and `pub <snake_case_field>: <type>` patterns.
+3. For each such change, determine which role configuration file(s) should contain the example: MSP, BSP, fisherman, or backend.
+4. Check the same diff for a corresponding addition, rename, or removal in those `configs/*.toml` file(s).
+5. Only if the example TOML files are missing the required update, produce a finding.
+
+Use conservative judgement:
+
+- prefer no finding over a speculative finding
+- if the flag's role applicability is ambiguous from the diff, explain the ambiguity clearly and keep `confidence_score` lower
+- do not require updates to TOML role files for which the flag is provably not applicable
+
+## Output expectations
+
+Your structured output must use:
+
+- `reviewer_name`: `config-example-sync`
+- `overall_status`: `pass` when every changed CLI flag or backend argument has a matching example update in every relevant `configs/*.toml` file, otherwise `fail`
+
+When you produce findings:
+
+- keep them actionable and specific
+- use the following anchor rules for `code_location`
+- explain which `configs/*.toml` file appears missing the synchronised example
+- name the expected TOML key (snake_case derived from the Rust field name)
+- if the flag is role-scoped, state which role files should be updated
+
+## Remediation expectations
+
+For every finding, you must choose exactly one remediation mode:
+
+- `inline_suggestion`
+- `agent_prompt`
+- `none`
+
+### When to use `inline_suggestion`
+
+Use `inline_suggestion` only when all of the following are true:
+
+- the missing example can be expressed as a one-line `key = value` addition or replacement
+- the change is anchored on a single line of a `configs/*.toml` file that is already part of the diff
+- you are confident the suggested value is a sensible example (matching the type and default value declared in the Rust source)
+
+When you use `inline_suggestion`:
+
+- set `fix_mode` to `inline_suggestion`
+- set `fix_explanation` to one short sentence explaining why an inline suggestion is appropriate
+- provide `suggested_code` with only the replacement TOML line(s)
+- do not include markdown fences in `suggested_code`
+- do not include explanatory prose inside `suggested_code`
+- set `agent_prompt` to `null`
+
+### When to use `agent_prompt`
+
+Use `agent_prompt` when the fix is not safe or practical as a GitHub inline suggestion, especially when:
+
+- multiple `configs/*.toml` files need to be updated together
+- the example value is not obvious from the Rust source and requires choosing a sensible default
+- the rename touches one CLI flag in `node/src/cli.rs` plus matching keys across several TOML files
+- the diff anchors on the Rust declaration but the missing fix belongs in a TOML file
+
+When you use `agent_prompt`:
+
+- set `fix_mode` to `agent_prompt`
+- set `fix_explanation` to one short sentence explaining why an agent prompt is more appropriate
+- provide a concise, copy-pasteable prompt for an AI coding agent such as Cursor, Codex, or Claude Code
+- make the prompt implementation-oriented
+- mention the exact Rust flag name and its new or renamed identifier
+- mention every `configs/*.toml` file the agent should update and the role each file represents
+- describe the example value the agent should write, including the units (bytes, seconds, blocks, etc.) when relevant
+- set `suggested_code` to `null`
+
+### When to use `none`
+
+Use `none` only if you have a valid finding but cannot responsibly suggest either:
+
+- a safe local inline replacement, or
+- a meaningful agent prompt
+
+This should be rare.
+
+When you use `none`:
+
+- set `fix_mode` to `none`
+- set `fix_explanation` to one short sentence explaining why no remediation text is being suggested
+- set `suggested_code` to `null`
+- set `agent_prompt` to `null`
+
+### Reviewer-specific bias for this prompt
+
+For `config-example-sync`, prefer `agent_prompt` by default, because the same flag often needs to be added to several TOML files at once.
+
+Use `inline_suggestion` only when exactly one TOML file already appears in the diff and the missing line is a clear local addition or rename.
+
+Use `none` only when the missing example value cannot be inferred responsibly from the diff.
+
+### Anchor rules
+
+Your `code_location` must point to the Rust declaration that introduced the configuration-sync work, not to the missing TOML key.
+
+- For a missing example in a `configs/*.toml` file when the Rust declaration is in the diff:
+  - anchor to the changed Rust field line in `node/src/cli.rs`, `node/src/command.rs`, or the backend argument struct
+  - prefer the `pub <field>: <type>` line; if the `#[arg(...)]` attribute is the only changed line, anchor there
+  - example anchor:
+    - `node/src/cli.rs` on the line `pub max_open_forests: Option<usize>,`
+
+- For a stale or partial update inside a `configs/*.toml` file when that file is part of the diff:
+  - anchor to the offending changed line in the TOML file (the renamed key, the leftover key for a removed flag, etc.)
+
+- Only choose anchor lines that are present in the pull request diff.
+- Prefer a single-line anchor when possible.
+- Use a two-line range only when the declaration naturally spans both lines and both are part of the diff.
+
+### Remediation fields in structured output
+
+For each finding:
+
+- set `fix_mode` to `inline_suggestion`, `agent_prompt`, or `none`
+- set `fix_explanation` to one short sentence explaining why that mode was chosen
+- always include both `suggested_code` and `agent_prompt`
+- if `fix_mode` is `inline_suggestion`, include `suggested_code` and set `agent_prompt` to `null`
+- if `fix_mode` is `agent_prompt`, include `agent_prompt` and set `suggested_code` to `null`
+- if `fix_mode` is `none`, set both `suggested_code` and `agent_prompt` to `null`
+
+When you produce no findings:
+
+- return an empty findings list
+- state that no missing `configs/*.toml` synchronisation work was detected
+
+## Tone
+
+Be concise, factual, and implementation-oriented.
+
+Avoid generic praise, filler, or broad review commentary.
+
+Focus only on whether this PR introduces or modifies CLI flags or backend arguments without keeping the example `configs/*.toml` files in sync.

--- a/prompts/review/runtime-event-error-encoding-stability.md
+++ b/prompts/review/runtime-event-error-encoding-stability.md
@@ -1,0 +1,250 @@
+# StorageHub AI Review: runtime event/error encoding stability
+
+You are a specialised pull request reviewer for the `Moonsong-Labs/storage-hub` repository.
+
+Your job is **not** to perform a general code review. Review **only** one repository-specific rule:
+
+- pallet indices, event variant indices, error variant indices, and the field signatures of existing event / error variants must remain encoding-stable across runtime upgrades, because clients (notably the indexer, the SDK, and downstream chains) rely on the SCALE encoding being deterministic.
+
+## Repository rule to enforce
+
+Treat the following rule as authoritative for this review (it is the rule documented in the repository `CLAUDE.md`):
+
+- the affected pallets are: `Providers`, `FileSystem`, `ProofsDealer`, `Randomness`, `PaymentStreams`, `BucketNfts`
+- **pallet indices are immutable**: the `#[runtime::pallet_index(N)]` value declared in the runtime crates (`runtime/parachain/src/lib.rs`, `runtime/solochain-evm/src/lib.rs`, or equivalent) must never change once deployed
+- **event / error variant indices are pinned**: every event and error variant in those pallets uses an explicit `#[codec(index = N)]` attribute, and those indices must never change or be reused
+- **field signatures are stable**: the field set (types, count, and order) of any existing event or error variant must never change
+- **breaking changes require a new variant**: when you need to change an event or error variant, add a new variant with a `Vx` suffix (for example `NewStorageRequestV2`) using the next available index. Keep the old variant intact for backward compatibility.
+
+This rule exists because:
+
+- the on-chain runtime emits events that are SCALE-encoded with the variant index
+- the indexer, SDK, and any external client decodes those events at later block heights, sometimes well after the runtime that produced them has been upgraded
+- changing a variant index, dropping a variant, or modifying an existing variant's field layout silently breaks all decoders for historical blocks
+- reviewers in this repository have repeatedly flagged this exact concern, for example "This PR has breaking changes. The `StorageRequestMetadata` struct is used in an event, so the decoding of that event will change." and "Isn't this potentially breaking for the indexer? The encoding of the enum of events would be changed."
+
+## Inputs
+
+The workflow will provide pull request context after this prompt, including:
+
+- repository name
+- pull request number
+- base and head refs / SHAs
+- the pull request description body
+- changed files
+- unified diff
+
+Use the diff as the primary review input.
+
+## Review scope
+
+Only look for violations of the encoding-stability rule in the diff.
+
+Primary watched areas include:
+
+- `pallets/providers/src/**.rs`
+- `pallets/file-system/src/**.rs`
+- `pallets/proofs-dealer/src/**.rs`
+- `pallets/randomness/src/**.rs`
+- `pallets/payment-streams/src/**.rs`
+- `pallets/bucket-nfts/src/**.rs`
+- `runtime/parachain/src/lib.rs`
+- `runtime/solochain-evm/src/lib.rs`
+
+In every case the relevant declarations are:
+
+- `#[runtime::pallet_index(N)]` lines in the runtime crates
+- `#[codec(index = N)]` attributes on event and error variants in the listed pallets
+- the `Event<T>` and `Error<T>` enum bodies in those pallets
+
+Out of scope unless the diff clearly shows otherwise:
+
+- pallets not listed above
+- new pallets being added for the first time, provided their indices are explicit and stable; only flag if an existing pallet's variants have changed
+- test-only mocks, benchmarking modules, or anything gated to `#[cfg(test)]` / `#[cfg(feature = "runtime-benchmarks")]`
+- internal helper types that are not part of the event or error surface
+- comment-only edits that do not change a `#[codec(index = ...)]` value or a variant field layout
+
+## What counts as a finding
+
+Report a finding only when the diff appears to introduce or preserve at least one of the following violations:
+
+- a `#[runtime::pallet_index(N)]` value is changed for an already-deployed pallet in `runtime/parachain/src/lib.rs` or `runtime/solochain-evm/src/lib.rs`
+- a `#[codec(index = N)]` value on an existing event or error variant is changed, removed, or reused for a different variant
+- an existing event or error variant has its field set modified: a field added, a field removed, a field type changed, or fields reordered
+- an existing event or error variant is renamed without keeping the old variant available under its original index (a rename without a `Vx`-suffix duplicate is a breaking change)
+- a new event or error variant is introduced **without** an explicit `#[codec(index = N)]` attribute, leaving its encoding implicit and therefore fragile
+- a new variant reuses an index that already belongs to another variant within the same enum
+
+If the PR only adds a brand-new event or error variant with a fresh, explicit `#[codec(index = N)]` value that does not collide with any existing variant, and does not touch existing variants, do **not** report a finding.
+
+If the PR adds a `Vx`-suffixed replacement (e.g. `NewStorageRequestV2`) with a new index while leaving the old variant untouched, do **not** report a finding.
+
+If the diff in a watched pallet only touches non-Event / non-Error code paths (such as call handlers, storage items, or runtime API impls), do **not** report a finding, even when the file is in scope.
+
+## What does _not_ count as a finding
+
+Do **not** comment on:
+
+- code style
+- naming, except when a variant rename is itself the breaking change
+- performance
+- security
+- tests
+- architecture
+- formatting
+- unrelated bugs
+- any other review concern outside this encoding-stability rule
+
+Do **not** flag missing migrations, storage versioning, or weight changes; those are out of scope for this reviewer.
+
+Do **not** flag a `#[codec(index = ...)]` value on a brand-new variant that is the next free index, even if existing variants happen to be non-contiguous (gaps in the index space are fine).
+
+Do **not** infer that an event has changed merely because the surrounding code that emits it has changed; only flag the encoding rule when the enum declaration itself moves.
+
+## Review method
+
+1. Inspect the changed files and unified diff.
+2. Filter to hunks that touch one of the watched paths.
+3. For each watched hunk, determine whether it modifies an `Event<T>` enum body, an `Error<T>` enum body, or a `#[runtime::pallet_index(N)]` line.
+4. For each such modification, check:
+   - is a pallet index being changed for an existing pallet entry?
+   - is a `#[codec(index = N)]` value being changed, removed, or reused?
+   - is the field set of an existing variant being modified?
+   - is a new variant being added without an explicit `#[codec(index = N)]`?
+5. Only if at least one violation is present, produce a finding.
+
+Use conservative judgement:
+
+- prefer no finding over a speculative finding
+- when only a new variant is added with a fresh explicit index, no finding is appropriate
+- when the change is clearly limited to non-enum code (such as a `match` arm or a call signature), no finding is appropriate
+
+## Output expectations
+
+Your structured output must use:
+
+- `reviewer_name`: `runtime-event-error-encoding-stability`
+- `overall_status`: `pass` when no encoding-stability violations are detected, otherwise `fail`
+
+When you produce findings:
+
+- keep them actionable and specific
+- use the following anchor rules for `code_location`
+- explain exactly which variant or pallet index is affected, and why the change is encoding-breaking
+- name the preferred remediation direction, for example:
+  - revert the `#[codec(index = N)]` value to its previous number and add a new `Vx`-suffixed variant with the next free index
+  - add an explicit `#[codec(index = N)]` to the new variant using the next free index
+  - keep the existing variant intact and create a `NewStorageRequestV2` (or similar) alongside it for the new field shape
+
+## Remediation expectations
+
+For every finding, you must choose exactly one remediation mode:
+
+- `inline_suggestion`
+- `agent_prompt`
+- `none`
+
+### When to use `inline_suggestion`
+
+Use `inline_suggestion` only when all of the following are true:
+
+- the fix is a single-line change on the variant declaration line itself
+- the fix is unambiguous, for example reverting a `#[codec(index = N)]` to the original value, or adding an explicit `#[codec(index = N)]` to a brand-new variant whose intended index is obvious from surrounding context
+- the fix does not require introducing a new `Vx`-suffixed variant
+- the suggestion can be expressed as a direct replacement on the commented line
+
+When you use `inline_suggestion`:
+
+- set `fix_mode` to `inline_suggestion`
+- set `fix_explanation` to one short sentence explaining why an inline suggestion is appropriate
+- provide `suggested_code`
+- keep `suggested_code` to the replacement lines only
+- do not include markdown fences in `suggested_code`
+- do not include explanatory prose inside `suggested_code`
+- set `agent_prompt` to `null`
+
+### When to use `agent_prompt`
+
+Use `agent_prompt` when the fix is not safe or practical as a GitHub inline suggestion, especially when:
+
+- the fix requires introducing a new `Vx`-suffixed variant alongside the existing one
+- the fix requires reverting field-layout changes and emitting a new variant for the new shape
+- the fix spans multiple variants, multiple files, or multiple downstream call sites
+- restoring the original encoding implies updating both the pallet `Event<T>` / `Error<T>` enum and any helper or conversion code that depends on it
+
+When you use `agent_prompt`:
+
+- set `fix_mode` to `agent_prompt`
+- set `fix_explanation` to one short sentence explaining why an agent prompt is more appropriate
+- provide a concise, copy-pasteable prompt for an AI coding agent such as Cursor, Codex, or Claude Code
+- make the prompt implementation-oriented
+- mention the exact file path, pallet, and variant name involved
+- explain that the existing variant index and field shape must remain stable, and the new behaviour must move into a `Vx`-suffixed variant with a fresh index
+- if the violation is a missing explicit `#[codec(index = N)]`, instruct the agent to add it with the next free index inside that enum
+- set `suggested_code` to `null`
+
+### When to use `none`
+
+Use `none` only if you have a valid finding but cannot responsibly suggest either:
+
+- a safe local inline replacement, or
+- a meaningful agent prompt
+
+This should be rare.
+
+When you use `none`:
+
+- set `fix_mode` to `none`
+- set `fix_explanation` to one short sentence explaining why no remediation text is being suggested
+- set `suggested_code` to `null`
+- set `agent_prompt` to `null`
+
+### Reviewer-specific bias for this prompt
+
+For `runtime-event-error-encoding-stability`, prefer `agent_prompt` by default because most fixes involve introducing a `Vx`-suffixed variant rather than a one-line edit.
+
+Use `inline_suggestion` only when restoring a single changed `#[codec(index = N)]` value or attaching a missing explicit index to a brand-new variant.
+
+Use `none` only when the diff makes the correct fix genuinely ambiguous.
+
+### Anchor rules
+
+Your `code_location` must point to the offending declaration in the diff.
+
+- For a changed `#[codec(index = N)]` on an event / error variant:
+  - anchor to the `#[codec(index = N)]` line itself
+- For a changed variant field layout:
+  - anchor to the line of the renamed / re-typed field, or the variant name line if multiple fields changed
+- For a changed `#[runtime::pallet_index(N)]`:
+  - anchor to the `#[runtime::pallet_index(N)]` line in the runtime crate
+- For a new variant missing an explicit `#[codec(index = N)]`:
+  - anchor to the variant name line inside the enum body
+
+- Only choose anchor lines that are present in the pull request diff.
+- Prefer a single-line anchor when possible.
+- Use a two-line range only when the declaration naturally spans both lines and both are part of the diff.
+
+### Remediation fields in structured output
+
+For each finding:
+
+- set `fix_mode` to `inline_suggestion`, `agent_prompt`, or `none`
+- set `fix_explanation` to one short sentence explaining why that mode was chosen
+- always include both `suggested_code` and `agent_prompt`
+- if `fix_mode` is `inline_suggestion`, include `suggested_code` and set `agent_prompt` to `null`
+- if `fix_mode` is `agent_prompt`, include `agent_prompt` and set `suggested_code` to `null`
+- if `fix_mode` is `none`, set both `suggested_code` and `agent_prompt` to `null`
+
+When you produce no findings:
+
+- return an empty findings list
+- state that no encoding-stability violations were detected in the watched pallets or runtime crates
+
+## Tone
+
+Be concise, factual, and implementation-oriented.
+
+Avoid generic praise, filler, or broad review commentary.
+
+Focus only on whether this PR breaks SCALE encoding stability of the watched pallets' events, errors, or pallet indices.

--- a/scripts/extract_pr_comments.ts
+++ b/scripts/extract_pr_comments.ts
@@ -1,0 +1,338 @@
+#!/usr/bin/env bun
+
+/// <reference types="bun" />
+
+/*
+ * Extract human review/issue comments from every PR in a GitHub repository.
+ *
+ * Output:
+ *   - One JSON file per PR with at least one human comment, written to
+ *     `<output-dir>/pr-<number>.json`.
+ *   - PRs with zero human comments produce no file.
+ *
+ * Comments authored by bots are filtered out so the dataset reflects what
+ * human reviewers actually said.
+ *
+ * Usage:
+ *   bun run ./extract_pr_comments.ts [--repo <owner/repo>] [--out <dir>] [--limit <N>] [--force]
+ *
+ * Defaults:
+ *   --repo   Moonsong-Labs/storage-hub
+ *   --out    tmp/ai-review/pr-comments
+ *   --limit  10000
+ *   --force  re-fetch even if the destination file already exists
+ *
+ * Requires the `gh` CLI to be authenticated.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+
+const REPO_ROOT = resolve(import.meta.dir, "..");
+const DEFAULT_OUT_DIR = resolve(REPO_ROOT, "tmp/ai-review/pr-comments");
+
+type Args = {
+  repo: string;
+  outDir: string;
+  limit: number;
+  force: boolean;
+};
+
+type GhPrListItem = {
+  number: number;
+  title: string;
+  state: string;
+  author: { login: string } | null;
+  createdAt: string;
+  mergedAt: string | null;
+  closedAt: string | null;
+};
+
+type ReviewComment = {
+  id: number;
+  user: { login: string; type: string } | null;
+  body: string;
+  path: string | null;
+  line: number | null;
+  original_line: number | null;
+  start_line: number | null;
+  original_start_line: number | null;
+  side: string | null;
+  pull_request_review_id: number | null;
+  created_at: string;
+  diff_hunk: string | null;
+};
+
+type IssueComment = {
+  id: number;
+  user: { login: string; type: string } | null;
+  body: string;
+  created_at: string;
+};
+
+type CommentExport = {
+  pr: GhPrListItem;
+  review_comments: Array<{
+    id: number;
+    author: string;
+    author_type: string;
+    body: string;
+    path: string | null;
+    line: number | null;
+    start_line: number | null;
+    side: string | null;
+    diff_hunk: string | null;
+    created_at: string;
+  }>;
+  issue_comments: Array<{
+    id: number;
+    author: string;
+    author_type: string;
+    body: string;
+    created_at: string;
+  }>;
+};
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    repo: "Moonsong-Labs/storage-hub",
+    outDir: DEFAULT_OUT_DIR,
+    limit: 10000,
+    force: false
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--repo" && argv[i + 1]) {
+      args.repo = argv[++i];
+    } else if (arg === "--out" && argv[i + 1]) {
+      args.outDir = argv[++i];
+    } else if (arg === "--limit" && argv[i + 1]) {
+      args.limit = Number(argv[++i]);
+    } else if (arg === "--force") {
+      args.force = true;
+    } else if (arg === "--help" || arg === "-h") {
+      console.log(
+        "Usage: extract_pr_comments.ts [--repo <owner/repo>] [--out <dir>] [--limit <N>] [--force]"
+      );
+      process.exit(0);
+    } else {
+      console.error(`Unknown argument: ${arg}`);
+      process.exit(1);
+    }
+  }
+  return args;
+}
+
+function ghJson<T>(args: string[]): T {
+  const result = spawnSync("gh", args, {
+    encoding: "utf8",
+    maxBuffer: 256 * 1024 * 1024
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `gh ${args.join(" ")} failed (${result.status}): ${result.stderr || result.stdout}`
+    );
+  }
+  return JSON.parse(result.stdout) as T;
+}
+
+function ghPaginate<T>(args: string[]): T[] {
+  // `--paginate` must come after the `api` subcommand for gh.
+  const expanded = args[0] === "api" ? ["api", "--paginate", ...args.slice(1)] : args;
+  const result = spawnSync("gh", expanded, {
+    encoding: "utf8",
+    maxBuffer: 256 * 1024 * 1024
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `gh ${args.join(" ")} failed (${result.status}): ${result.stderr || result.stdout}`
+    );
+  }
+  // gh --paginate returns concatenated JSON arrays; merge them.
+  const out = result.stdout.trim();
+  if (out.length === 0) return [];
+  const merged: T[] = [];
+  for (const chunk of splitJsonArrays(out)) {
+    const arr = JSON.parse(chunk) as T[];
+    merged.push(...arr);
+  }
+  return merged;
+}
+
+function splitJsonArrays(text: string): string[] {
+  // Split concatenated `[ ... ][ ... ]` blocks returned by gh --paginate.
+  const chunks: string[] = [];
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (inString) {
+      if (ch === "\\") {
+        escaped = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === "[") {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (ch === "]") {
+      depth--;
+      if (depth === 0 && start >= 0) {
+        chunks.push(text.slice(start, i + 1));
+        start = -1;
+      }
+    }
+  }
+  return chunks;
+}
+
+function isHumanAuthor(user: { login: string; type: string } | null): boolean {
+  if (!user) return false;
+  if (user.type === "Bot") return false;
+  // Known bot accounts that report as type "User" on GitHub.
+  const botLogins = new Set([
+    "github-actions[bot]",
+    "dependabot[bot]",
+    "renovate[bot]",
+    "coderabbitai[bot]",
+    "gemini-code-assist[bot]",
+    "copilot-pull-request-reviewer[bot]",
+    "Copilot"
+  ]);
+  if (botLogins.has(user.login)) return false;
+  if (user.login.endsWith("[bot]")) return false;
+  return true;
+}
+
+function ensureDir(path: string): void {
+  if (!existsSync(path)) mkdirSync(path, { recursive: true });
+}
+
+async function main(): Promise<number> {
+  const args = parseArgs(process.argv.slice(2));
+  ensureDir(args.outDir);
+
+  console.error(`Listing PRs from ${args.repo} (limit ${args.limit})...`);
+  const prs = ghJson<GhPrListItem[]>([
+    "pr",
+    "list",
+    "--repo",
+    args.repo,
+    "--state",
+    "all",
+    "--limit",
+    String(args.limit),
+    "--json",
+    "number,title,state,author,createdAt,mergedAt,closedAt"
+  ]);
+  console.error(`Found ${prs.length} PRs.`);
+
+  let withComments = 0;
+  let skipped = 0;
+  let processed = 0;
+
+  for (const pr of prs) {
+    processed++;
+    const outFile = `${args.outDir}/pr-${pr.number}.json`;
+    if (!args.force && existsSync(outFile)) {
+      skipped++;
+      if (processed % 50 === 0) {
+        console.error(`  [${processed}/${prs.length}] skipped existing pr-${pr.number}`);
+      }
+      continue;
+    }
+
+    let reviewComments: ReviewComment[] = [];
+    let issueComments: IssueComment[] = [];
+    try {
+      reviewComments = ghPaginate<ReviewComment>([
+        "api",
+        `/repos/${args.repo}/pulls/${pr.number}/comments?per_page=100`
+      ]);
+    } catch (err) {
+      console.error(`  pr ${pr.number}: review-comments fetch failed: ${err}`);
+    }
+    try {
+      issueComments = ghPaginate<IssueComment>([
+        "api",
+        `/repos/${args.repo}/issues/${pr.number}/comments?per_page=100`
+      ]);
+    } catch (err) {
+      console.error(`  pr ${pr.number}: issue-comments fetch failed: ${err}`);
+    }
+
+    const humanReview = reviewComments.filter((c) => isHumanAuthor(c.user));
+    const humanIssue = issueComments.filter((c) => isHumanAuthor(c.user));
+
+    if (humanReview.length === 0 && humanIssue.length === 0) {
+      // No human comments at all; still write a tiny stub so reruns skip it.
+      const empty: CommentExport = {
+        pr,
+        review_comments: [],
+        issue_comments: []
+      };
+      await Bun.write(outFile, JSON.stringify(empty));
+      if (processed % 25 === 0) {
+        console.error(`  [${processed}/${prs.length}] pr-${pr.number}: 0 comments`);
+      }
+      continue;
+    }
+
+    const exported: CommentExport = {
+      pr,
+      review_comments: humanReview.map((c) => ({
+        id: c.id,
+        author: c.user?.login ?? "",
+        author_type: c.user?.type ?? "",
+        body: c.body,
+        path: c.path ?? null,
+        line: c.line ?? c.original_line ?? null,
+        start_line: c.start_line ?? c.original_start_line ?? null,
+        side: c.side ?? null,
+        diff_hunk: c.diff_hunk ?? null,
+        created_at: c.created_at
+      })),
+      issue_comments: humanIssue.map((c) => ({
+        id: c.id,
+        author: c.user?.login ?? "",
+        author_type: c.user?.type ?? "",
+        body: c.body,
+        created_at: c.created_at
+      }))
+    };
+
+    await Bun.write(outFile, JSON.stringify(exported, null, 2));
+    withComments++;
+    if (withComments % 25 === 0) {
+      console.error(
+        `  [${processed}/${prs.length}] pr-${pr.number}: ${humanReview.length} review / ${humanIssue.length} issue (${withComments} PRs with comments)`
+      );
+    }
+  }
+
+  console.error(
+    `\nDone. Processed ${processed} PRs. ${withComments} had human comments, ${skipped} skipped (already on disk).`
+  );
+  return 0;
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err) => {
+    console.error(err);
+    process.exit(1);
+  }
+);

--- a/scripts/extract_recurring_comments.ts
+++ b/scripts/extract_recurring_comments.ts
@@ -1,0 +1,682 @@
+#!/usr/bin/env bun
+
+/// <reference types="bun" />
+
+/*
+ * Extract recurring rule-like review comments from the PR comment dataset
+ * produced by `extract_pr_comments.ts`.
+ *
+ * Pipeline:
+ *   1. Load every `pr-N.json` file and flatten review/issue comments.
+ *   2. Drop noise (very short bodies, pure acknowledgements, author replies,
+ *      bot-style answers, etc.) so the AI only sees plausible review rules.
+ *   3. Batch the surviving comments and ask the `claude` CLI to extract
+ *      candidate rules (title, description, paths-touched, keywords,
+ *      indices of the supporting comments inside the batch).
+ *   4. Merge candidates from all batches: rules whose keyword sets and
+ *      titles overlap strongly are collapsed into a single rule.
+ *   5. For every merged rule, run a deterministic TS search across the
+ *      entire comment corpus to find similar supporting examples by
+ *      keyword overlap.
+ *   6. Write a single Markdown report at `<out>` grouping rules by
+ *      frequency, with PR references and short body snippets so the
+ *      human reviewer can decide which patterns deserve a dedicated
+ *      AI Agent reviewer.
+ *
+ * Usage:
+ *   bun run ./extract_recurring_comments.ts
+ *     [--in <pr-comments-dir>]
+ *     [--out <markdown-path>]
+ *     [--model <claude-model-alias>]
+ *     [--batch-size <N>]
+ *     [--max-batches <N>]
+ *     [--max-budget-usd <usd>]
+ *     [--min-support <N>]
+ *     [--dry-run]
+ *
+ * Defaults:
+ *   --in              tmp/ai-review/pr-comments
+ *   --out             tmp/ai-review/recurring-comments.md
+ *   --model           haiku
+ *   --batch-size      30
+ *   --max-batches     -1 (process all batches)
+ *   --max-budget-usd  0.20 (per claude call)
+ *   --min-support     3   (minimum supporting comments to keep a rule)
+ *   --dry-run         when set, skip claude calls and just write a debug dump
+ *
+ * Requires the `claude` CLI to be on PATH and authenticated.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const REPO_ROOT = resolve(import.meta.dir, "..");
+const DEFAULT_IN_DIR = resolve(REPO_ROOT, "tmp/ai-review/pr-comments");
+const DEFAULT_OUT_PATH = resolve(REPO_ROOT, "tmp/ai-review/recurring-comments.md");
+
+type Args = {
+  inDir: string;
+  outPath: string;
+  model: string;
+  batchSize: number;
+  maxBatches: number;
+  maxBudgetUsd: number;
+  minSupport: number;
+  dryRun: boolean;
+};
+
+type PrFile = {
+  pr: {
+    number: number;
+    title: string;
+    state: string;
+    author: { login: string } | string | null;
+    createdAt: string;
+  };
+  review_comments: Array<{
+    id: number;
+    author: string;
+    author_type: string;
+    body: string;
+    path: string | null;
+    line: number | null;
+    start_line: number | null;
+    side: string | null;
+    diff_hunk: string | null;
+    created_at: string;
+  }>;
+  issue_comments: Array<{
+    id: number;
+    author: string;
+    author_type: string;
+    body: string;
+    created_at: string;
+  }>;
+};
+
+type Comment = {
+  pr: number;
+  pr_title: string;
+  author: string;
+  is_pr_author: boolean;
+  source: "review" | "issue";
+  path: string | null;
+  body: string;
+  created_at: string;
+};
+
+type RuleCandidate = {
+  title: string;
+  description: string;
+  paths_touched: string[];
+  keywords: string[];
+  example_indices: number[];
+};
+
+type MergedRule = {
+  title: string;
+  description: string;
+  paths_touched: string[];
+  keywords: string[];
+  seed_examples: Array<{
+    pr: number;
+    author: string;
+    path: string | null;
+    body: string;
+  }>;
+  supporting: Array<{
+    pr: number;
+    author: string;
+    path: string | null;
+    body: string;
+    score: number;
+  }>;
+  candidate_count: number;
+};
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    inDir: DEFAULT_IN_DIR,
+    outPath: DEFAULT_OUT_PATH,
+    model: "haiku",
+    batchSize: 30,
+    maxBatches: -1,
+    maxBudgetUsd: 0.2,
+    minSupport: 3,
+    dryRun: false
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--in" && argv[i + 1]) args.inDir = argv[++i];
+    else if (arg === "--out" && argv[i + 1]) args.outPath = argv[++i];
+    else if (arg === "--model" && argv[i + 1]) args.model = argv[++i];
+    else if (arg === "--batch-size" && argv[i + 1]) args.batchSize = Number(argv[++i]);
+    else if (arg === "--max-batches" && argv[i + 1]) args.maxBatches = Number(argv[++i]);
+    else if (arg === "--max-budget-usd" && argv[i + 1]) args.maxBudgetUsd = Number(argv[++i]);
+    else if (arg === "--min-support" && argv[i + 1]) args.minSupport = Number(argv[++i]);
+    else if (arg === "--dry-run") args.dryRun = true;
+    else if (arg === "--help" || arg === "-h") {
+      console.log(
+        "Usage: extract_recurring_comments.ts [--in <dir>] [--out <md>] [--model <alias>] [--batch-size <N>] [--max-batches <N>] [--max-budget-usd <usd>] [--min-support <N>] [--dry-run]"
+      );
+      process.exit(0);
+    } else {
+      console.error(`Unknown argument: ${arg}`);
+      process.exit(1);
+    }
+  }
+  return args;
+}
+
+function getAuthorLogin(author: PrFile["pr"]["author"]): string {
+  if (!author) return "";
+  if (typeof author === "string") return author;
+  return author.login ?? "";
+}
+
+// Trailing tokens allowed after a known acknowledgement word.
+// Includes whitespace, punctuation, common single-codepoint emoji, and
+// the multi-codepoint emoji used in this corpus (e.g. 👍🏻 with skin tone).
+const ACK_TAIL = /^(?:[\s.!👍✅🙏🫡]|👍🏻)*$/u;
+const ACK_PREFIXES = ["done", "fixed", "removed", "thanks", "thank you", "agreed", "lgtm", "ok"];
+
+function startsWithAckWord(body: string): boolean {
+  const lowered = body.trim().toLowerCase();
+  for (const prefix of ACK_PREFIXES) {
+    if (lowered === prefix) return true;
+    if (
+      lowered.startsWith(`${prefix} `) ||
+      lowered.startsWith(`${prefix}.`) ||
+      lowered.startsWith(`${prefix}!`)
+    ) {
+      const remainder = lowered.slice(prefix.length);
+      if (ACK_TAIL.test(remainder)) return true;
+    }
+  }
+  return false;
+}
+
+function isAcknowledgement(body: string): boolean {
+  const trimmed = body.trim();
+  if (trimmed.length === 0) return true;
+  if (trimmed.length < 12) return true;
+  // Pure emoji-only acknowledgements ("👍", "✅", "🫡").
+  if (/^[\s.!👍✅🙏🫡]+$/u.test(trimmed) || /^👍🏻\s*$/u.test(trimmed)) return true;
+  return startsWithAckWord(trimmed);
+}
+
+function loadComments(inDir: string): Comment[] {
+  if (!existsSync(inDir)) {
+    throw new Error(`Input directory does not exist: ${inDir}`);
+  }
+  const files = readdirSync(inDir).filter((f) => f.startsWith("pr-") && f.endsWith(".json"));
+  files.sort((a, b) => Number(a.replace(/\D/g, "")) - Number(b.replace(/\D/g, "")));
+
+  const comments: Comment[] = [];
+  for (const name of files) {
+    const path = `${inDir}/${name}`;
+    const text = readFileSync(path, "utf8");
+    const parsed: PrFile = JSON.parse(text);
+    const prAuthor = getAuthorLogin(parsed.pr.author);
+    for (const c of parsed.review_comments ?? []) {
+      comments.push({
+        pr: parsed.pr.number,
+        pr_title: parsed.pr.title,
+        author: c.author,
+        is_pr_author: c.author === prAuthor,
+        source: "review",
+        path: c.path,
+        body: c.body,
+        created_at: c.created_at
+      });
+    }
+    for (const c of parsed.issue_comments ?? []) {
+      comments.push({
+        pr: parsed.pr.number,
+        pr_title: parsed.pr.title,
+        author: c.author,
+        is_pr_author: c.author === prAuthor,
+        source: "issue",
+        path: null,
+        body: c.body,
+        created_at: c.created_at
+      });
+    }
+  }
+  return comments;
+}
+
+function filterForRuleMining(comments: Comment[]): Comment[] {
+  return comments.filter((c) => {
+    // Skip PR-author replies; they almost always answer feedback rather than express rules.
+    if (c.is_pr_author) return false;
+    // Skip tiny / acknowledgement-only bodies.
+    if (isAcknowledgement(c.body)) return false;
+    // Drop comments that are only quoted code suggestions.
+    const meaningful = c.body
+      .split("\n")
+      .filter((line) => !line.trim().startsWith(">") && !line.trim().startsWith("```"))
+      .join("\n")
+      .trim();
+    if (meaningful.length < 40) return false;
+    return true;
+  });
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}
+
+function compactBody(body: string, maxLen = 700): string {
+  const trimmed = body.replace(/\r/g, "").replace(/\s+\n/g, "\n").trim();
+  if (trimmed.length <= maxLen) return trimmed;
+  return `${trimmed.slice(0, maxLen)}\n…[truncated]`;
+}
+
+const CLAUDE_SCHEMA = {
+  type: "object",
+  properties: {
+    rules: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          title: { type: "string", minLength: 4 },
+          description: { type: "string", minLength: 10 },
+          paths_touched: {
+            type: "array",
+            items: { type: "string" }
+          },
+          keywords: {
+            type: "array",
+            items: { type: "string" },
+            minItems: 2
+          },
+          example_indices: {
+            type: "array",
+            items: { type: "integer", minimum: 0 },
+            minItems: 1
+          }
+        },
+        required: ["title", "description", "paths_touched", "keywords", "example_indices"],
+        additionalProperties: false
+      }
+    }
+  },
+  required: ["rules"],
+  additionalProperties: false
+};
+
+const BATCH_PROMPT = `You analyse human pull-request review comments from the Moonsong-Labs/storage-hub repository.
+
+Your job is to extract candidate REPETITIVE, RULE-LIKE review patterns that could be checked automatically by an AI Agent.
+
+A good candidate rule:
+- expresses a repository convention or follow-up step that reviewers tend to flag again and again;
+- is anchored on a specific file pattern, code construct, or downstream artefact (not generic praise);
+- can be verified by reading the pull-request diff (and, where relevant, the PR description).
+
+Bad candidates:
+- one-off design discussions or feature questions specific to a single PR;
+- subjective taste comments without a concrete rule;
+- pure acknowledgements or answers ("Done", "Nice catch", "Agreed").
+
+For each comment array entry I send you, the array index is the comment's identifier. Use those indices in \`example_indices\` to point to the comments that justify the rule.
+
+Guidelines:
+- prefer 0-6 rules per batch; if no clear rule emerges, return an empty list;
+- each rule needs at least one supporting example_index;
+- keywords must be short (1-3 words) and discriminating phrases that another script can grep for inside comment bodies (e.g. "breaking change", "workspace dependency", "merge imports", "info log", "config example").
+
+You MUST reply with structured JSON matching the provided schema (no markdown).`;
+
+type ClaudeRunResult = {
+  ok: boolean;
+  rules: RuleCandidate[];
+  raw: string;
+  cost_usd: number;
+};
+
+function runClaudeBatch(comments: Comment[], args: Args): ClaudeRunResult {
+  const inputPayload = comments.map((c, idx) => ({
+    index: idx,
+    pr: c.pr,
+    author: c.author,
+    path: c.path,
+    body: compactBody(c.body)
+  }));
+
+  const promptBody = [
+    BATCH_PROMPT,
+    "",
+    "Comment batch (JSON array):",
+    JSON.stringify(inputPayload, null, 2)
+  ].join("\n");
+
+  if (args.dryRun) {
+    return { ok: true, rules: [], raw: "(dry-run)", cost_usd: 0 };
+  }
+
+  const result = spawnSync(
+    "claude",
+    [
+      "-p",
+      "--bare",
+      "--no-session-persistence",
+      "--output-format",
+      "json",
+      "--model",
+      args.model,
+      "--max-budget-usd",
+      String(args.maxBudgetUsd),
+      "--json-schema",
+      JSON.stringify(CLAUDE_SCHEMA)
+    ],
+    {
+      input: promptBody,
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+      timeout: 5 * 60 * 1000
+    }
+  );
+
+  if (result.status !== 0) {
+    let costFromError = 0;
+    try {
+      const parsed = JSON.parse(result.stdout) as { total_cost_usd?: number };
+      costFromError = parsed.total_cost_usd ?? 0;
+    } catch {
+      /* ignore */
+    }
+    return {
+      ok: false,
+      rules: [],
+      raw: `claude exit ${result.status}: ${result.stderr || result.stdout}`.slice(0, 600),
+      cost_usd: costFromError
+    };
+  }
+
+  let envelope: {
+    is_error?: boolean;
+    structured_output?: { rules?: RuleCandidate[] };
+    result?: string;
+    total_cost_usd?: number;
+  };
+  try {
+    envelope = JSON.parse(result.stdout);
+  } catch (err) {
+    return {
+      ok: false,
+      rules: [],
+      raw: `failed to parse claude envelope: ${err}\n${result.stdout.slice(0, 800)}`,
+      cost_usd: 0
+    };
+  }
+
+  if (envelope.is_error) {
+    return {
+      ok: false,
+      rules: [],
+      raw: `claude reported is_error=true: ${envelope.result?.slice(0, 800) ?? ""}`,
+      cost_usd: envelope.total_cost_usd ?? 0
+    };
+  }
+
+  const rules = envelope.structured_output?.rules ?? [];
+  return {
+    ok: true,
+    rules,
+    raw: envelope.result ?? "",
+    cost_usd: envelope.total_cost_usd ?? 0
+  };
+}
+
+function normaliseKeyword(k: string): string {
+  return k.toLowerCase().trim();
+}
+
+function rulesOverlap(a: MergedRule, b: { keywords: string[]; title: string }): boolean {
+  const aKw = new Set(a.keywords.map(normaliseKeyword));
+  const bKw = new Set(b.keywords.map(normaliseKeyword));
+  let shared = 0;
+  for (const kw of bKw) {
+    if (aKw.has(kw)) shared++;
+  }
+  if (shared >= 2) return true;
+  // Title proximity fallback.
+  const aTitleTokens = new Set(a.title.toLowerCase().split(/\W+/).filter(Boolean));
+  const bTitleTokens = b.title.toLowerCase().split(/\W+/).filter(Boolean);
+  let titleShared = 0;
+  for (const t of bTitleTokens) {
+    if (aTitleTokens.has(t)) titleShared++;
+  }
+  return titleShared >= Math.min(2, bTitleTokens.length);
+}
+
+function mergeCandidateIntoRules(
+  candidate: RuleCandidate,
+  batch: Comment[],
+  merged: MergedRule[]
+): void {
+  const seedExamples = candidate.example_indices
+    .filter((idx) => idx >= 0 && idx < batch.length)
+    .map((idx) => {
+      const c = batch[idx];
+      return { pr: c.pr, author: c.author, path: c.path, body: compactBody(c.body, 400) };
+    });
+
+  const existing = merged.find((r) => rulesOverlap(r, candidate));
+  if (existing) {
+    existing.candidate_count += 1;
+    const seenKw = new Set(existing.keywords.map(normaliseKeyword));
+    for (const kw of candidate.keywords) {
+      if (!seenKw.has(normaliseKeyword(kw))) existing.keywords.push(kw);
+    }
+    const seenPath = new Set(existing.paths_touched);
+    for (const p of candidate.paths_touched ?? []) {
+      if (!seenPath.has(p)) existing.paths_touched.push(p);
+    }
+    for (const example of seedExamples) {
+      if (existing.seed_examples.length < 8) existing.seed_examples.push(example);
+    }
+    return;
+  }
+
+  merged.push({
+    title: candidate.title.trim(),
+    description: candidate.description.trim(),
+    paths_touched: [...(candidate.paths_touched ?? [])],
+    keywords: [...candidate.keywords],
+    seed_examples: seedExamples,
+    supporting: [],
+    candidate_count: 1
+  });
+}
+
+function buildSupportingEvidence(rule: MergedRule, allComments: Comment[]): void {
+  const lowerKw = rule.keywords.map(normaliseKeyword).filter((kw) => kw.length >= 3);
+  if (lowerKw.length === 0) return;
+  const scored: Array<{ comment: Comment; score: number }> = [];
+  for (const c of allComments) {
+    if (c.is_pr_author) continue;
+    const body = c.body.toLowerCase();
+    let score = 0;
+    for (const kw of lowerKw) {
+      if (body.includes(kw)) score++;
+    }
+    if (score >= 2) scored.push({ comment: c, score });
+  }
+  scored.sort((a, b) => b.score - a.score);
+  const dedupedByPr = new Map<number, { comment: Comment; score: number }>();
+  for (const item of scored) {
+    const existing = dedupedByPr.get(item.comment.pr);
+    if (!existing || existing.score < item.score) {
+      dedupedByPr.set(item.comment.pr, item);
+    }
+  }
+  const ordered = [...dedupedByPr.values()].sort((a, b) => b.score - a.score).slice(0, 20);
+  rule.supporting = ordered.map((item) => ({
+    pr: item.comment.pr,
+    author: item.comment.author,
+    path: item.comment.path,
+    body: compactBody(item.comment.body, 400),
+    score: item.score
+  }));
+}
+
+function renderReport(
+  rules: MergedRule[],
+  args: Args,
+  stats: {
+    total_comments: number;
+    filtered_comments: number;
+    batches: number;
+    successful_batches: number;
+    failed_batches: number;
+    total_cost_usd: number;
+  }
+): string {
+  const ordered = [...rules]
+    .map((rule) => ({ rule, support: rule.supporting.length }))
+    .sort((a, b) => b.support - a.support)
+    .filter((entry) => entry.support >= args.minSupport);
+
+  const header = [
+    "# Recurring PR review comments",
+    "",
+    `Generated by \`scripts/extract_recurring_comments.ts\` on ${new Date().toISOString()}.`,
+    "",
+    "## Pipeline stats",
+    "",
+    `- input directory: \`${args.inDir}\``,
+    `- claude model: \`${args.model}\``,
+    `- batch size: ${args.batchSize}`,
+    `- batches processed: ${stats.successful_batches}/${stats.batches} (${stats.failed_batches} failed)`,
+    `- comments loaded: ${stats.total_comments}`,
+    `- comments analysed (after noise filter): ${stats.filtered_comments}`,
+    `- candidate rules retained (≥ ${args.minSupport} supporting PRs): ${ordered.length}`,
+    `- approximate claude cost: $${stats.total_cost_usd.toFixed(4)}`,
+    "",
+    "Rules are sorted by the number of distinct PRs whose comments match the rule's keywords. Use this report to decide which patterns deserve a dedicated AI Agent reviewer.",
+    ""
+  ];
+
+  if (ordered.length === 0) {
+    header.push("> No rule met the minimum support threshold.");
+    return header.join("\n");
+  }
+
+  const sections: string[] = [...header];
+  for (let i = 0; i < ordered.length; i++) {
+    const { rule, support } = ordered[i];
+    sections.push(`## ${i + 1}. ${rule.title} (${support} supporting PRs)`);
+    sections.push("");
+    sections.push(rule.description);
+    sections.push("");
+    if (rule.paths_touched.length > 0) {
+      sections.push("Touched paths reviewers mentioned:");
+      sections.push("");
+      for (const p of rule.paths_touched.slice(0, 20)) {
+        sections.push(`- \`${p}\``);
+      }
+      sections.push("");
+    }
+    sections.push("Keywords used for cross-PR search:");
+    sections.push("");
+    sections.push(rule.keywords.map((k) => `\`${k}\``).join(", "));
+    sections.push("");
+    sections.push(`Candidate count from claude batches: ${rule.candidate_count}`);
+    sections.push("");
+    sections.push("### Seed examples (cited by claude)");
+    sections.push("");
+    for (const ex of rule.seed_examples.slice(0, 5)) {
+      sections.push(`- PR #${ex.pr} (${ex.author})${ex.path ? ` — \`${ex.path}\`` : ""}:`);
+      sections.push("");
+      sections.push(`  > ${ex.body.replace(/\n/g, "\n  > ")}`);
+      sections.push("");
+    }
+    sections.push("### Supporting evidence (TS-side keyword search)");
+    sections.push("");
+    for (const sup of rule.supporting.slice(0, 12)) {
+      sections.push(
+        `- PR #${sup.pr} (${sup.author}, score ${sup.score})${sup.path ? ` — \`${sup.path}\`` : ""}:`
+      );
+      sections.push("");
+      sections.push(`  > ${sup.body.replace(/\n/g, "\n  > ")}`);
+      sections.push("");
+    }
+  }
+  return sections.join("\n");
+}
+
+async function main(): Promise<number> {
+  const args = parseArgs(process.argv.slice(2));
+
+  console.error(`Loading PR comments from ${args.inDir}...`);
+  const allComments = loadComments(args.inDir);
+  console.error(`Loaded ${allComments.length} raw comments.`);
+
+  const filtered = filterForRuleMining(allComments);
+  console.error(`Retained ${filtered.length} comments after noise filtering.`);
+
+  const batches = chunk(filtered, args.batchSize);
+  const limit = args.maxBatches > 0 ? Math.min(args.maxBatches, batches.length) : batches.length;
+  console.error(`Will process ${limit} batch(es) of up to ${args.batchSize} comments each.`);
+
+  const merged: MergedRule[] = [];
+  let totalCost = 0;
+  let successful = 0;
+  let failed = 0;
+
+  for (let b = 0; b < limit; b++) {
+    const batch = batches[b];
+    const progress = `[${b + 1}/${limit}]`;
+    console.error(`${progress} batch with ${batch.length} comments (first PR #${batch[0]?.pr})...`);
+    const result = runClaudeBatch(batch, args);
+    totalCost += result.cost_usd;
+    if (!result.ok) {
+      failed++;
+      console.error(`${progress} batch failed: ${result.raw.slice(0, 300)}`);
+      continue;
+    }
+    successful++;
+    console.error(
+      `${progress} extracted ${result.rules.length} candidate rule(s), cost so far $${totalCost.toFixed(4)}`
+    );
+    for (const candidate of result.rules) {
+      mergeCandidateIntoRules(candidate, batch, merged);
+    }
+  }
+
+  console.error(`Building cross-PR supporting evidence for ${merged.length} merged rules...`);
+  for (const rule of merged) {
+    buildSupportingEvidence(rule, allComments);
+  }
+
+  const report = renderReport(merged, args, {
+    total_comments: allComments.length,
+    filtered_comments: filtered.length,
+    batches: limit,
+    successful_batches: successful,
+    failed_batches: failed,
+    total_cost_usd: totalCost
+  });
+
+  await Bun.write(args.outPath, report);
+  console.error(`\nWrote report to ${args.outPath}`);
+  console.error(`Total claude cost: $${totalCost.toFixed(4)}`);
+  return 0;
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err) => {
+    console.error(err);
+    process.exit(1);
+  }
+);

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "select:ai-review-prompts": "bun run ./select_ai_review_prompts.ts",
     "find:file-deletions": "bun run ./find_file_deletions.ts",
-    "remove:files-from-forest-storage": "bun run ./remove_files_from_forest_storage.ts"
+    "remove:files-from-forest-storage": "bun run ./remove_files_from_forest_storage.ts",
+    "extract:pr-comments": "bun run ./extract_pr_comments.ts",
+    "extract:recurring-comments": "bun run ./extract_recurring_comments.ts"
   },
   "dependencies": {
     "@polkadot/api": "^16.4.7",


### PR DESCRIPTION
## Summary

Mines recurring rule-like review comments from past pull requests, then turns the three most frequent patterns into new specialised AI Agent reviewers wired into the existing AI Review CI.

The full data-pipeline (PR fetch → AI-driven rule extraction → cross-PR keyword search → Markdown report) is committed as reproducible TypeScript scripts so future contributors can re-run it and propose more reviewers.

## What Changed

### New analysis scripts

- `scripts/extract_pr_comments.ts` — walks every PR in the repository (open and closed) via the `gh` CLI and dumps each PR's human review/issue comments to `tmp/ai-review/pr-comments/pr-<N>.json`. Bot accounts are filtered out so the dataset reflects real reviewer feedback.
- `scripts/extract_recurring_comments.ts` — loads every per-PR JSON, drops noise (PR-author replies, pure acknowledgements, sub-40-char bodies), batches the surviving comments and asks the `claude` CLI to extract candidate rules with `--json-schema`, then runs a TS-side keyword search to back each rule with supporting examples from other PRs. Emits a single Markdown report at `tmp/ai-review/recurring-comments.md`.
- `scripts/package.json` — adds the two `extract:*` scripts to the workspace.

On the 142 PRs / 617 comments currently in this repo the pipeline cost about \$0.63 in claude usage and surfaced 8 candidate rules. The top three are the foundation of this PR.

### Three new AI Agent reviewers

| Reviewer | Repository rule | Top supporting PRs in the corpus |
|---|---|---|
| `breaking-changes-documentation` | Changes that touch `node/`, `runtime/`, runtime-api crates, public client builder symbols, or `configs/*.toml` must be enumerated under a populated `Breaking Changes` section of the PR description. | #594, #595, #617, #663, #690 (\"Please put them in the Breaking Changes suggestions.\", \"Add it to the breaking changes description\", \"replicated in DataHaven\") |
| `config-example-sync` | New / renamed / removed CLI flags in `node/src/cli.rs`, `node/src/command.rs`, or backend argument structs must keep `configs/msp_config.toml`, `configs/bsp_config.toml`, `configs/fisherman_config.toml`, and `configs/backend_config.toml` in sync. | #595 (\"Please add an example configuration of this parameter to `configs/msp_config.toml`\"). |
| `runtime-event-error-encoding-stability` | The pallet indices and `#[codec(index = N)]` / variant field shapes documented in `CLAUDE.md` are SCALE-encoding invariants; breaking changes must move into a `Vx`-suffixed new variant. | #599, #600 (\"The `StorageRequestMetadata` struct is used in an event, so the decoding of that event will change.\") |

Each reviewer mimics the structure of `prompts/review/types-bundle-sync.md` — single repository rule, narrow review scope, conservative judgement, explicit remediation modes (`inline_suggestion` / `agent_prompt` / `none`) and anchor rules pointing to the actual diff line that triggered the finding.

### Workflow change

The existing `.github/workflows/ai-review.yml` only fed each Codex reviewer the diff. The new `breaking-changes-documentation` reviewer needs the PR description body too, so the workflow now adds a `Fetch pull request description` step that uses `gh pr view ... --jq .body > pr-body.txt` (with the existing `GITHUB_TOKEN`), and the prompt builder injects the body between `-----BEGIN PR DESCRIPTION-----` and `-----END PR DESCRIPTION-----`. This is backwards-compatible with the existing reviewers, which simply ignore the new section.

## Methodology summary

1. Fetched all 142 PRs and saved 617 human comments (`extract_pr_comments.ts`).
2. Read several PRs by hand to understand the dominant patterns.
3. Ran `extract_recurring_comments.ts` (claude haiku, 11 batches of 30 comments each) to surface rule candidates and cross-PR support.
4. Cross-checked the top candidates against this repo's CLAUDE.md, the existing reviewer set, and Gemini 2.5 Pro before committing.

The full data-pipeline output lives under `tmp/ai-review/` (git-ignored) and is reproducible with `bun run --cwd scripts extract:pr-comments && bun run --cwd scripts extract:recurring-comments`.

## Test plan

- [ ] AI Review CI runs the three new reviewers when the relevant files are touched.
- [ ] `breaking-changes-documentation` triggers on a PR that edits `node/src/cli.rs` without a `Breaking Changes` section.
- [ ] `config-example-sync` triggers when a new `#[arg(long)]` flag is added without the matching `configs/*.toml` example.
- [ ] `runtime-event-error-encoding-stability` triggers when an existing `#[codec(index = N)]` is changed in one of the watched pallets.
- [ ] Existing reviewers (`no-panic-in-runtime`, `types-bundle-sync`, `use-workspace-deps`) still pass on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)